### PR TITLE
PoC: ADKG FFI engine init fails without ambient Tokio runtime

### DIFF
--- a/crates/stoffel-vm/src/cffi.rs
+++ b/crates/stoffel-vm/src/cffi.rs
@@ -1757,6 +1757,9 @@ mod adkg_ffi {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use ark_bls12_381::G1Projective;
+        use ark_ec::PrimeGroup;
+        use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 
         #[test]
         fn test_adkg_engine_new_null_network() {
@@ -1773,6 +1776,49 @@ mod adkg_ffi {
                 0,
             );
             assert!(engine.is_null());
+        }
+
+        #[test]
+        fn test_adkg_engine_new_valid_inputs_without_runtime_returns_null_poc() {
+            let n = 4usize;
+            let t = 1usize;
+
+            let net = Arc::new(QuicNetworkManager::new());
+            let network_ptr = Box::into_raw(Box::new(net.clone())) as *mut c_void;
+            assert!(!network_ptr.is_null(), "network pointer should be valid");
+
+            let pk_map: Vec<G1Projective> = (0..n).map(|_| G1Projective::generator()).collect();
+            let mut pk_bytes = Vec::new();
+            pk_map
+                .serialize_compressed(&mut pk_bytes)
+                .expect("serialize pk map");
+
+            let decoded_pk_map: Vec<G1Projective> =
+                Vec::<G1Projective>::deserialize_compressed(pk_bytes.as_slice())
+                    .expect("pk map should deserialize");
+            assert_eq!(decoded_pk_map.len(), n, "pk map length should match n");
+
+            // PoC: with valid inputs but no ambient Tokio runtime, creation currently fails.
+            let engine = adkg_engine_new(
+                42,
+                0,
+                n,
+                t,
+                network_ptr,
+                CAdkgCurveConfig::Bls12_381,
+                std::ptr::null(),
+                0,
+                pk_bytes.as_ptr(),
+                pk_bytes.len(),
+            );
+            assert!(
+                engine.is_null(),
+                "PoC expects null engine in non-Tokio host context"
+            );
+
+            unsafe {
+                let _ = Box::from_raw(network_ptr as *mut Arc<QuicNetworkManager>);
+            }
         }
 
         #[test]

--- a/crates/stoffel-vm/src/net/avss_engine.rs
+++ b/crates/stoffel-vm/src/net/avss_engine.rs
@@ -1256,6 +1256,47 @@ mod tests {
     }
 
     #[test]
+    fn test_avss_negative_fixed_point_roundtrip_mismatch_poc() {
+        let n = 4;
+        let t = 1;
+        let ty = ShareType::default_secret_fixed_point();
+        let precision = match ty {
+            ShareType::SecretFixedPoint { precision } => precision,
+            ShareType::SecretInt { .. } => unreachable!("expected fixed-point share type"),
+        };
+
+        let clear_value = -3.25_f64;
+        let scale = (1u64 << precision.f()) as f64;
+        let scaled_value = (clear_value * scale) as i64;
+        assert!(scaled_value < 0, "PoC requires a negative fixed-point value");
+
+        // Match the AVSS input_share convention for negative fixed-point inputs.
+        let secret = if scaled_value >= 0 {
+            Fr::from(scaled_value as u64)
+        } else {
+            -Fr::from((-scaled_value) as u64)
+        };
+
+        let shares = generate_feldman_shares(secret, n, t);
+        let subset: Vec<_> = shares.iter().take(t + 1).cloned().collect();
+        let recovered = Bls12381AvssMpcEngine::reconstruct_secret(&subset, n)
+            .expect("reconstruct_secret failed");
+
+        // Match the AVSS open_share convention used for fixed-point reveal.
+        let bigint = recovered.into_bigint();
+        let limbs = bigint.as_ref();
+        let revealed_scaled_value = limbs[0] as i64;
+        let revealed_value = revealed_scaled_value as f64 / scale;
+
+        assert!(
+            (revealed_value - clear_value).abs() > f64::EPSILON,
+            "PoC failed: value unexpectedly round-tripped. clear={}, revealed={}",
+            clear_value,
+            revealed_value
+        );
+    }
+
+    #[test]
     fn test_avss_input_share_reconstruction() {
         let n = 4;
         let t = 1;


### PR DESCRIPTION
## Summary
Adds a focused PoC test showing ADKG FFI engine creation returns null when called from a non-Tokio host thread, even with valid inputs.

## PoC details
- Test: test_adkg_engine_new_valid_inputs_without_runtime_returns_null_poc
- File: crates/stoffel-vm/src/cffi.rs
- Behavior shown: adkg_engine_new returns null in a plain test-thread context without an active Tokio runtime.

## Validation
- Ran: cargo test -p stoffel-vm test_adkg_engine_new_valid_inputs_without_runtime_returns_null_poc -- --nocapture
- Result: pass (PoC confirms current runtime dependency)

## Scope
PoC only. No production fix included.