### PR TITLE
fix not-enough-preproc error with coord

### DIFF
--- a/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
@@ -228,6 +228,7 @@ where
 
                 let mut encoded_results = Vec::with_capacity(pairs.len());
                 let mut node = self.clone_node().await;
+                node.params.n_triples = node.params.n_triples.max(max_pairs_per_session);
                 for (chunk_index, chunk) in pairs.chunks(max_pairs_per_session).enumerate() {
                     let mut left_shares = Vec::with_capacity(chunk.len());
                     let mut right_shares = Vec::with_capacity(chunk.len());


### PR DESCRIPTION
fix the error that there is not enough preprocessing material anymore that was encountered when running with a coordinator as opposed to without one.