### PR TITLE
chore: prepare 0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the Stoffel crates are tracked here.
 
-## [0.1.1]
+## [0.1.1] - 2026-07-03
 
 ### PR #67 - runner release and install updates
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,7 +831,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -860,7 +860,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -880,7 +880,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -901,9 +901,26 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.7",
+ "num-traits",
  "zeroize",
 ]
 
@@ -938,12 +955,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-ff-macros"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -955,7 +982,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -968,7 +995,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.7",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1030,7 +1070,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
 ]
 
 [[package]]
@@ -1039,11 +1079,24 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.7",
+ "serde_with",
 ]
 
 [[package]]
@@ -1051,6 +1104,17 @@ name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,6 +1146,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1568,13 +1642,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -2071,7 +2156,7 @@ dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2085,7 +2170,7 @@ dependencies = [
  "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2372,13 +2457,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash",
  "libm",
- "rand 0.9.4",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -2657,11 +2742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2671,8 +2754,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3819,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c863e9ab5e7bf9c99ba75e1050f1e4d624ae87ed3532d6238ffbdc7b585dbbe6"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4146,9 +4232,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4462,21 +4548,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -4486,16 +4573,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4562,6 +4649,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4636,6 +4740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4658,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -4887,18 +5000,19 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -4927,9 +5041,9 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -5043,27 +5157,6 @@ dependencies = [
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5571,7 +5664,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stoffel-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "stoffellang",
  "thiserror 2.0.18",
@@ -5579,7 +5672,7 @@ dependencies = [
 
 [[package]]
 name = "stoffel-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -5649,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "stoffel-rust-sdk"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aes",
  "ark-bls12-381",
@@ -5684,7 +5777,7 @@ dependencies = [
 
 [[package]]
 name = "stoffel-vm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -5744,7 +5837,7 @@ dependencies = [
 
 [[package]]
 name = "stoffel-vm-runner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5779,9 +5872,9 @@ dependencies = [
 
 [[package]]
 name = "stoffel-vm-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-integer",
  "num-traits",
  "parking_lot 0.12.5",
@@ -5808,7 +5901,7 @@ dependencies = [
  "chacha20poly1305",
  "futures",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.7",
  "num-integer",
  "num-traits",
  "rand 0.7.3",
@@ -5830,7 +5923,7 @@ dependencies = [
 
 [[package]]
 name = "stoffellang"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "colored",
@@ -6902,15 +6995,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6957,28 +7041,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -7000,12 +7067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7022,12 +7083,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7048,22 +7103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7084,12 +7127,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7106,12 +7143,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7132,12 +7163,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7154,12 +7179,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/crates/stoffel-bindgen/Cargo.toml
+++ b/crates/stoffel-bindgen/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "stoffel-bindgen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Build-time Rust binding generation for Stoffel programs"
-license = "MIT"
-repository = "https://github.com/Stoffel-Labs/StoffelVM"
+license = "Apache-2.0"
+repository = "https://github.com/Stoffel-Labs/stoffel"
 homepage = "https://stoffelmpc.com"
 keywords = ["mpc", "bindings", "codegen", "compiler", "rust"]
 categories = ["development-tools::build-utils", "compilers"]
 publish = true
 
 [dependencies]
-stoffellang = { version = "0.1.0", path = "../stoffel-lang" }
+stoffellang = { version = "0.1.1", path = "../stoffel-lang" }
 thiserror = "2"

--- a/crates/stoffel-cli/Cargo.toml
+++ b/crates/stoffel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stoffel-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Cargo-like command line tool for Stoffel projects"
 license = "Apache-2.0"

--- a/crates/stoffel-lang/Cargo.toml
+++ b/crates/stoffel-lang/Cargo.toml
@@ -2,7 +2,7 @@
 name = "stoffellang"
 description = "Compiler for Stoffel programs targeting the Stoffel VM bytecode format"
 authors = ["Gabriel Arrouye"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Stoffel-Labs/stoffel"
@@ -14,7 +14,7 @@ categories = ["compilers", "cryptography", "parser-implementations"]
 name = "stoffellang"
 
 [dependencies]
-stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
+stoffel-vm-types = { version = "0.1.1", path = "../stoffel-vm-types" }
 colored = "3.0.0"
 edit-distance = "2.1.0"
 clap = { version = "4.5.4", features = ["derive"] }

--- a/crates/stoffel-rust-sdk/Cargo.toml
+++ b/crates/stoffel-rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stoffel-rust-sdk"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Rust SDK for building Stoffel MPC applications"
 license = "Apache-2.0"
@@ -34,12 +34,12 @@ tracing = { version = "0.1", features = ["attributes"] }
 tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
-stoffellang = { version = "0.1.0", path = "../stoffel-lang" }
+stoffellang = { version = "0.1.1", path = "../stoffel-lang" }
 stoffel-mpc-coordinator-shared = "0.1.0"
 stoffel-mpc-coordinator-off-chain = "0.1.0"
-stoffel-vm = { version = "0.1.0", path = "../stoffel-vm" }
-stoffel-vm-runner = { version = "0.1.0", path = "../stoffel-vm-runner" }
-stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
+stoffel-vm = { version = "0.1.1", path = "../stoffel-vm" }
+stoffel-vm-runner = { version = "0.1.1", path = "../stoffel-vm-runner" }
+stoffel-vm-types = { version = "0.1.1", path = "../stoffel-vm-types" }
 stoffelmpc-mpc = { package = "stoffelcrypto", version = "0.1.0" }
 
 [dev-dependencies]

--- a/crates/stoffel-vm-runner/Cargo.toml
+++ b/crates/stoffel-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stoffel-vm-runner"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Local runner and CLI binary for executing Stoffel VM programs"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ name = "stoffel-run"
 path = "src/bin/stoffel-run.rs"
 
 [dependencies]
-stoffel-vm = { version = "0.1.0", path = "../stoffel-vm" }
-stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
+stoffel-vm = { version = "0.1.1", path = "../stoffel-vm" }
+stoffel-vm-types = { version = "0.1.1", path = "../stoffel-vm-types" }
 stoffel-mpc-coordinator-shared = "0.1.0"
 stoffel-mpc-coordinator-off-chain = "0.1.0"
 stoffelmpc-mpc = { package = "stoffelcrypto", version = "0.1.0" }
@@ -45,6 +45,6 @@ uuid = { version = "1.17.0", features = ["v4"] }
 x509-parser = "0.18.1"
 
 [dev-dependencies]
-stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
-stoffellang = { version = "0.1.0", path = "../stoffel-lang" }
+stoffel-vm-types = { version = "0.1.1", path = "../stoffel-vm-types" }
+stoffellang = { version = "0.1.1", path = "../stoffel-lang" }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }

--- a/crates/stoffel-vm-types/Cargo.toml
+++ b/crates/stoffel-vm-types/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "stoffel-vm-types"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Shared bytecode, instruction, and runtime value types for the Stoffel virtual machine"
 license = "Apache-2.0"
-repository = "https://github.com/Stoffel-Labs/StoffelVM"
+repository = "https://github.com/Stoffel-Labs/stoffel"
 homepage = "https://stoffelmpc.com"
 keywords = ["mpc", "bytecode", "vm", "compiler", "runtime"]
 categories = ["compilers", "cryptography", "data-structures"]

--- a/crates/stoffel-vm/Cargo.toml
+++ b/crates/stoffel-vm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stoffel-vm"
 authors = ["Gabriel Arrouye"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Register-based virtual machine runtime and MPC execution engine for Stoffel programs"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ crate-type = ["rlib", "cdylib"]
 libc = "0.2"
 stoffelmpc-mpc = { package = "stoffelcrypto", version = "0.1.0" }
 stoffelnet = "0.1.0"
-stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
+stoffel-vm-types = { version = "0.1.1", path = "../stoffel-vm-types" }
 alloy = "1.7.3"
 alloy-primitives = "1.5.7"
 x509-parser = "0.18.1"
@@ -76,7 +76,7 @@ nat = []
 criterion = { version = "0.6.0", features = ["html_reports"] }
 k256 = { version = "0.13", features = ["ecdsa"] }
 p256 = { version = "0.13", features = ["ecdsa"] }
-stoffellang = { version = "0.1.0", path = "../stoffel-lang" }
+stoffellang = { version = "0.1.1", path = "../stoffel-lang" }
 tempfile = "3"
 turmoil = "0.7"
 


### PR DESCRIPTION
## Summary

Prepare the workspace for the 0.1.1 release after the latest main merge.

## 0.1.1 changelog

- Runner release/install path: add standalone `stoffel-run` release support and runner-only install options.
- Runtime/SDK runner lookup: resolve `stoffel-run` from `PATH` instead of assuming Cargo's bin directory.
- Compiler/VM optimization work: improve resolved bytecode handling, operand validation, constant/label/function metadata resolution, and MPC optimization for batching, scheduling, inlining, loop vectorization, and public-gate folding.
- MPC correctness/runtime fixes: cover AES/CTR/CBC regressions, preserve secret multiplication, fix optimizer budget leakage, flatten nested `Share.batch_mul` operands, and improve AVSS/client-store runtime behavior.
- Examples/API cleanup: update MPC examples to use `add_constant` semantics and refresh bytecode/runtime metadata for the 0.1.1 crate set.

## Release metadata

- Bumps publishable workspace crates and dependent workspace requirements to `0.1.1`:
  - `stoffel-vm-types`
  - `stoffellang`
  - `stoffel-vm`
  - `stoffel-vm-runner`
  - `stoffel-rust-sdk`
  - `stoffel-bindgen`
- Bumps `stoffel-cli` to `0.1.1` while keeping it `publish = false`.
- Dates the `CHANGELOG.md` 0.1.1 entry.
- Aligns stale crate metadata with the monorepo repository URL and Apache-2.0 license where needed.

## Validation

- `cargo fmt --check`
- `cargo check -p stoffel-vm-types -p stoffellang -p stoffel-vm -p stoffel-vm-runner -p stoffel-rust-sdk -p stoffel-bindgen -p stoffel-cli --locked`
- `cargo clippy -p stoffel-vm-types -p stoffellang -p stoffel-vm -p stoffel-vm-runner -p stoffel-rust-sdk -p stoffel-bindgen -p stoffel-cli --all-targets --locked -- -D warnings`
- `cargo test -p stoffel-vm-types --locked -- --test-threads=1`
- `cargo test -p stoffellang --locked -- --test-threads=1`
- `cargo test -p stoffel-bindgen --locked -- --test-threads=1`
- `cargo package -p stoffel-vm-types --allow-dirty --locked`
- `cargo publish -p stoffel-vm-types --locked --dry-run --allow-dirty`

Note: full workspace tests were limited locally by Docker disk/runtime constraints; the focused release gates above passed. Downstream crate packaging is expected to resolve after publishing `stoffel-vm-types 0.1.1` first.
