### PR TITLE
Fix MPC scheduling, preprocessing planning, and AVSS integration

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -50,12 +50,12 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Check tag matches stoffel-cli version
+      - name: Check tag matches stoffel version
         run: |
           crate_version="$(cargo metadata --no-deps --format-version 1 \
-            | python3 -c "import sys,json; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='stoffel-cli'))")"
+            | python3 -c "import sys,json; m=json.load(sys.stdin); print(next(p['version'] for p in m['packages'] if p['name']=='stoffel'))")"
           if [ "$crate_version" != "${{ steps.ref.outputs.version }}" ]; then
-            echo "Tag ${{ steps.ref.outputs.tag }} does not match stoffel-cli version $crate_version"; exit 1
+            echo "Tag ${{ steps.ref.outputs.tag }} does not match stoffel version $crate_version"; exit 1
           fi
 
       - name: Check tag commit is contained in main
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build stoffel CLI and runner
         run: |
-          cargo build --release -p stoffel-cli --bin stoffel --locked --target ${{ matrix.target }}
+          cargo build --release -p stoffel --bin stoffel --locked --target ${{ matrix.target }}
           cargo build --release -p stoffel-vm-runner --bin stoffel-run --locked --target ${{ matrix.target }}
 
       - name: Package binaries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,5 +46,5 @@ All notable changes to the Stoffel crates are tracked here.
 
 ### Notes
 
-- `stoffel-bindgen` is currently marked `publish = false`; `stoffel-cli` is released as a GitHub binary artifact rather than a crates.io package.
-- Publish order for the initial crate release is `stoffel-vm-types`, `stoffellang`, `stoffel-vm`, `stoffel-vm-runner`, `stoffel-rust-sdk`, then downstream binary artifacts such as `stoffel-cli`.
+- `stoffel-bindgen` is currently marked `publish = false`; the `stoffel` CLI crate is published for `cargo install stoffel` and also released as a GitHub binary artifact.
+- Publish order for the initial crate release is `stoffel-vm-types`, `stoffellang`, `stoffel-vm`, `stoffel-vm-runner`, `stoffel-rust-sdk`, then downstream binary artifacts such as the `stoffel` CLI.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,13 +115,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum",
+ "phf 0.14.0",
 ]
 
 [[package]]
@@ -442,9 +442,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -831,7 +831,7 @@ dependencies = [
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "zeroize",
@@ -860,7 +860,7 @@ dependencies = [
  "ark-serialize 0.3.0",
  "ark-std 0.3.0",
  "derivative",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.3.3",
@@ -880,7 +880,7 @@ dependencies = [
  "derivative",
  "digest 0.10.7",
  "itertools 0.10.5",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
  "rustc_version 0.4.1",
@@ -901,9 +901,26 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "itertools 0.13.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ff"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7a806ac6c8307b929df4645776290a50ee2aac754ad09d8bdf73391309e43af"
+dependencies = [
+ "ark-ff-asm 0.6.0",
+ "ark-ff-macros 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "educe",
+ "num-bigint 0.4.8",
+ "num-traits",
  "zeroize",
 ]
 
@@ -938,12 +955,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-asm"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "ark-ff-macros"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db2fd794a08ccb318058009eefdf15bcaaaaf6f8161eb3345f907222bac38b20"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "quote",
  "syn 1.0.109",
@@ -955,7 +982,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abe79b0e4288889c4574159ab790824d0033b9fdcb2a112a3182fac2e514565"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -968,7 +995,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-ff-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0691ed21ef00ef89c1e9bda832eba493dda3ec2f8d892fb25b705f73f06bb8"
+dependencies = [
+ "num-bigint 0.4.8",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -1030,7 +1070,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-std 0.4.0",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
 ]
 
 [[package]]
@@ -1039,11 +1079,24 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.5.0",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74dd304fd536fb95d0a328e72be759209cc496a9da094c5bc56e5fea4f9e86b"
+dependencies = [
+ "ark-serialize-derive 0.6.0",
+ "ark-std 0.6.0",
+ "digest 0.10.7",
+ "num-bigint 0.4.8",
+ "serde_with",
 ]
 
 [[package]]
@@ -1051,6 +1104,17 @@ name = "ark-serialize-derive"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,6 +1146,16 @@ name = "ark-std"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
+dependencies = [
+ "num-traits",
+ "rand 0.8.6",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
@@ -1498,18 +1572,18 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -1528,9 +1602,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1568,13 +1642,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chacha20poly1305"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -1842,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1852,27 +1937,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -2071,7 +2156,7 @@ dependencies = [
  "asn1-rs 0.6.2",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2085,7 +2170,7 @@ dependencies = [
  "asn1-rs 0.7.2",
  "displaydoc",
  "nom",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-traits",
  "rusticata-macros",
 ]
@@ -2209,7 +2294,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415b6ec780d34dcf624666747194393603d0373b7141eef01d12ee58881507d9"
 dependencies = [
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2372,13 +2457,13 @@ dependencies = [
 
 [[package]]
 name = "fastbloom"
-version = "0.14.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
 dependencies = [
- "getrandom 0.3.4",
+ "foldhash",
  "libm",
- "rand 0.9.4",
+ "portable-atomic",
  "siphasher",
 ]
 
@@ -2657,11 +2742,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2671,8 +2754,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3390,11 +3476,11 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
@@ -3742,9 +3828,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"
@@ -3819,9 +3905,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -4146,9 +4232,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -4161,7 +4247,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
 ]
 
 [[package]]
@@ -4170,7 +4265,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -4181,7 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4192,6 +4287,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -4462,21 +4566,22 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "fastbloom",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier 0.6.2",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -4486,16 +4591,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4562,6 +4667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4620,6 +4736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_distr"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4636,6 +4758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4658,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.2"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b266a82f4aa99bb5c25e28d11cc44ace63d91adbcbcee4d323e2ae3d49ef37"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -4772,9 +4903,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4784,9 +4915,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4887,18 +5018,19 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
+checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
  "ark-ff 0.4.2",
  "ark-ff 0.5.0",
+ "ark-ff 0.6.0",
  "bytes",
  "fastrlp 0.3.1",
  "fastrlp 0.4.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parity-scale-codec",
@@ -4921,15 +5053,15 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -5047,27 +5179,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
-dependencies = [
- "core-foundation",
- "core-foundation-sys",
- "jni 0.21.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "rustls-platform-verifier-android",
- "rustls-webpki",
- "security-framework",
- "security-framework-sys",
- "webpki-root-certs 1.0.8",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "rustls-platform-verifier"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
@@ -5107,9 +5218,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -5397,9 +5508,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -5779,7 +5890,7 @@ dependencies = [
 name = "stoffel-vm-types"
 version = "0.1.0"
 dependencies = [
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "parking_lot 0.12.5",
@@ -5806,7 +5917,7 @@ dependencies = [
  "chacha20poly1305",
  "futures",
  "itertools 0.14.0",
- "num-bigint 0.4.6",
+ "num-bigint 0.4.8",
  "num-integer",
  "num-traits",
  "rand 0.7.3",
@@ -5890,27 +6001,6 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "subtle"
@@ -6075,9 +6165,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -6173,9 +6263,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6900,15 +6990,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -6955,28 +7036,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -6998,12 +7062,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7020,12 +7078,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7046,22 +7098,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7082,12 +7122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7104,12 +7138,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7130,12 +7158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7152,12 +7174,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -7278,18 +7294,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ dependencies = [
  "either",
  "k256",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -214,7 +214,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -392,7 +392,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -567,7 +567,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256",
- "rand 0.8.6",
+ "rand 0.8.7",
  "thiserror 2.0.18",
 ]
 
@@ -629,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1138,7 +1138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1148,7 +1148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1158,7 +1158,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1602,9 +1602,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2549,7 +2549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3058,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -3068,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3554,7 +3554,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot 0.12.5",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -3849,9 +3849,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3911,7 +3911,7 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
 ]
 
@@ -4079,7 +4079,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.18",
 ]
 
@@ -4266,7 +4266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -4529,7 +4529,7 @@ dependencies = [
  "bit-vec 0.8.0",
  "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift 0.4.0",
  "regex-syntax",
@@ -4645,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4657,9 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4748,7 +4748,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
 ]
 
 [[package]]
@@ -5036,8 +5036,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types",
  "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.7",
+ "rand 0.9.5",
  "rlp",
  "ruint-macro",
  "serde_core",
@@ -5111,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -5316,7 +5316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -5328,7 +5328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -5628,9 +5628,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5648,15 +5648,15 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "sha1",
 ]
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"
@@ -5716,7 +5716,7 @@ dependencies = [
  "hpke",
  "jsonrpsee",
  "p256",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "serde",
  "stoffel-mpc-coordinator-shared",
@@ -5740,7 +5740,7 @@ dependencies = [
  "hyper-util",
  "jsonrpsee",
  "p256",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "ring",
  "rustls",
@@ -5827,7 +5827,7 @@ dependencies = [
  "p256",
  "parking_lot 0.12.5",
  "quinn",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "redb",
  "rustc-hash",
@@ -5869,6 +5869,7 @@ dependencies = [
  "bincode",
  "futures",
  "hex",
+ "jsonrpsee",
  "libc",
  "rustls",
  "serde",
@@ -5983,7 +5984,7 @@ dependencies = [
  "byteorder",
  "dashmap 7.0.0-rc2",
  "quinn",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rcgen",
  "rustls",
  "serde",
@@ -6365,7 +6366,7 @@ dependencies = [
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6409,7 +6410,7 @@ dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6418,7 +6419,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -6564,9 +6565,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0710d4dfbeae4f9c390baa784c49858a7468fa433f3fe5d0ec5ebef651cf59f9"
+checksum = "06649c6f63d86604ba0c8950d5a1829fc9a17afd70fc6629f481d75b6a624c78"
 dependencies = [
  "glob",
  "serde",
@@ -6585,7 +6586,7 @@ checksum = "0061c28f1469e94771bb8aa626ce6b29265c2fb5034115046a170b0cba2e33d2"
 dependencies = [
  "bytes",
  "indexmap 2.14.0",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_distr",
  "scoped-tls",
  "tokio",
@@ -6683,9 +6684,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "ea5fab0d6c3c01ae70085a09cb03d4c7a1d6314e2b3e075392783396d724ca0a"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7186,9 +7187,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -7388,6 +7389,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5570,15 +5570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stoffel-bindgen"
-version = "0.1.0"
-dependencies = [
- "stoffellang",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "stoffel-cli"
+name = "stoffel"
 version = "0.1.0"
 dependencies = [
  "anyhow",
@@ -5593,10 +5585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "stoffel-bindgen"
+version = "0.1.0"
+dependencies = [
+ "stoffellang",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "stoffel-mpc-coordinator-off-chain"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c7858f0e6da81da3f26edc1d078cd3d69f8578bbaae01cfa737c6f8bdd1eab"
+source = "git+https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git?branch=dev#abac1fb778730d42ecd775d993123f05482685db"
 dependencies = [
  "ark-bls12-381",
  "ark-ff 0.5.0",
@@ -5617,8 +5616,7 @@ dependencies = [
 [[package]]
 name = "stoffel-mpc-coordinator-shared"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b32fe903439fde4c12bbb662341edd8265815d6b4978b92131985ebd5efb71d"
+source = "git+https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git?branch=dev#abac1fb778730d42ecd775d993123f05482685db"
 dependencies = [
  "ark-bls12-381",
  "ark-ec",

--- a/Dockerfile.benchmark
+++ b/Dockerfile.benchmark
@@ -41,7 +41,9 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=stoffel-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=stoffel-benchmark-target-${PROFILE_BUILD}-${ENABLE_NAT},target=/build/target,sharing=locked \
     if [ "$PROFILE_BUILD" = "true" ]; then \
-        export CARGO_PROFILE_RELEASE_DEBUG=1; \
+        export CARGO_PROFILE_RELEASE_DEBUG=2; \
+        export CARGO_PROFILE_RELEASE_STRIP=none; \
+        export RUSTFLAGS="-C force-frame-pointers=yes"; \
     fi; \
     cargo chef cook --release --recipe-path recipe.json
 
@@ -59,7 +61,9 @@ RUN --mount=type=ssh \
     --mount=type=cache,id=stoffel-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=stoffel-benchmark-target-${PROFILE_BUILD}-${ENABLE_NAT},target=/build/target,sharing=locked \
     if [ "$PROFILE_BUILD" = "true" ]; then \
-        export CARGO_PROFILE_RELEASE_DEBUG=1; \
+        export CARGO_PROFILE_RELEASE_DEBUG=2; \
+        export CARGO_PROFILE_RELEASE_STRIP=none; \
+        export RUSTFLAGS="-C force-frame-pointers=yes"; \
     fi; \
     if [ "$ENABLE_NAT" = "true" ]; then \
         cargo build --release --package stoffel-vm-runner --bin stoffel-run --features nat; \
@@ -76,7 +80,9 @@ RUN --mount=type=cache,id=stoffel-cargo-registry,target=/usr/local/cargo/registr
     --mount=type=cache,id=stoffel-cargo-git,target=/usr/local/cargo/git,sharing=locked \
     --mount=type=cache,id=stoffel-benchmark-target-${PROFILE_BUILD}-${ENABLE_NAT},target=/build/target,sharing=locked \
     if [ "$PROFILE_BUILD" = "true" ]; then \
-        export CARGO_PROFILE_RELEASE_DEBUG=1; \
+        export CARGO_PROFILE_RELEASE_DEBUG=2; \
+        export CARGO_PROFILE_RELEASE_STRIP=none; \
+        export RUSTFLAGS="-C force-frame-pointers=yes"; \
     fi; \
     cargo build --release --package stoffellang && \
     mkdir -p /build/programs && \
@@ -89,7 +95,14 @@ RUN --mount=type=cache,id=stoffel-cargo-registry,target=/usr/local/cargo/registr
       --mpc-backend honeybadger \
       --mpc-curve bls12-381 \
       --output /build/programs/mpc_aes128_circuit.stflb \
-      /build/crates/stoffel-lang/examples/mpc_aes128_circuit/main.stfl
+      /build/crates/stoffel-lang/examples/mpc_aes128_circuit/main.stfl && \
+    /build/target/release/stoffellang \
+      --binary \
+      --opt-level 3 \
+      --mpc-backend avss \
+      --mpc-curve secp256k1 \
+      --output /build/programs/threshold_ecdsa_secp256k1.stflb \
+      /build/crates/stoffel-lang/examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl
 
 FROM debian:bookworm-slim AS runtime
 

--- a/crates/stoffel-cli/Cargo.toml
+++ b/crates/stoffel-cli/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "stoffel-cli"
+name = "stoffel"
 version = "0.1.0"
 edition = "2021"
 description = "Cargo-like command line tool for Stoffel projects"
 license = "Apache-2.0"
 repository = "https://github.com/Stoffel-Labs/stoffel"
-publish = false
+publish = true
 
 [[bin]]
 name = "stoffel"
@@ -15,7 +15,7 @@ path = "src/main.rs"
 anyhow = "1"
 clap = { version = "4.5.4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
-stoffel-rust-sdk = { path = "../stoffel-rust-sdk" }
+stoffel-rust-sdk = { version = "0.1.0", path = "../stoffel-rust-sdk" }
 tokio = { version = "1.47.1", features = ["macros", "rt-multi-thread"] }
 toml = "0.8"
 

--- a/crates/stoffel-lang/examples/mpc_aes128_cbc/run.sh
+++ b/crates/stoffel-lang/examples/mpc_aes128_cbc/run.sh
@@ -47,4 +47,4 @@ STOFFEL="${STOFFEL_BIN:-$REPO_ROOT/target/release/stoffel}"
 
 # shellcheck disable=SC2086
 STOFFEL_RUN_BIN="$RUNNER" "$STOFFEL" run "$(dirname "$0")" \
-  --local --runner "$RUNNER" --timeout-secs 1100 $ARGS
+  --release --local --runner "$RUNNER" --timeout-secs 1100 $ARGS

--- a/crates/stoffel-lang/examples/mpc_aes128_ctr/run.sh
+++ b/crates/stoffel-lang/examples/mpc_aes128_ctr/run.sh
@@ -46,4 +46,4 @@ STOFFEL="${STOFFEL_BIN:-$REPO_ROOT/target/release/stoffel}"
 
 # shellcheck disable=SC2086
 STOFFEL_RUN_BIN="$RUNNER" "$STOFFEL" run "$(dirname "$0")" \
-  --local --runner "$RUNNER" --timeout-secs 1100 $ARGS
+  --release --local --runner "$RUNNER" --timeout-secs 1100 $ARGS

--- a/crates/stoffel-lang/examples/mpc_aes128_modes/README.md
+++ b/crates/stoffel-lang/examples/mpc_aes128_modes/README.md
@@ -29,7 +29,7 @@ rounds beyond the underlying AES block calls.
 ## Running it
 
 ```bash
-cargo build --release -p stoffel-vm-runner --bin stoffel-run -p stoffel-cli --bin stoffel
+cargo build --release -p stoffel-vm-runner --bin stoffel-run -p stoffel --bin stoffel
 ./run.sh
 ```
 

--- a/crates/stoffel-lang/examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl
+++ b/crates/stoffel-lang/examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl
@@ -1,14 +1,19 @@
 # Threshold ECDSA signature over secp256k1.
 #
-# This keeps the protocol in Stoffel source and uses VM primitives for field
-# inversion and extracting x(R) mod q.
+# The two nonlinear preprocessing products are issued as one batch.  If
+#   delta = gamma * nonce
+#   blinded_key = gamma * secret_key
+# then opening delta reveals neither secret, while
+#   delta^-1 * (gamma*e + blinded_key*r) = nonce^-1 * (e + secret_key*r).
+# The nonce's AVSS commitment is already nonce*G, so no open-in-the-exponent
+# round is needed.
 #
 # Result layout: r(32-byte big-endian) || s(32-byte big-endian) ||
 # SEC1 compressed pk(33).
 
 def main() -> bytes:
   var client_count = ClientStore.get_number_clients()
-  var secret_key: secret int64 = Share.random()
+  var secret_key: secret int64 = Share.random_field()
   var public_key = secret_key.get_commitment(0)
 
   var message = Bytes.from_string("stoffel-avss-threshold-ecdsa-demo-message-v1")
@@ -18,24 +23,25 @@ def main() -> bytes:
     var message_share = ClientStore.take_share(0, 0)
     message_field = message_share.open_field()
 
-  var gamma: secret int64 = Share.random()
-  var nonce: secret int64 = Share.random()
-  var delta_share = gamma.mul(nonce)
-  var delta = delta_share.open_field()
-  var delta_inverse = Crypto.field_inv(delta, "secp256k1")
-  var nonce_inverse = gamma.mul_field(delta_inverse)
+  var gamma: secret int64 = Share.random_field()
+  var nonce: secret int64 = Share.random_field()
+  var products = Share.batch_mul(
+    [gamma, gamma],
+    [nonce, secret_key],
+  )
+  var delta_inverse = Field.inverse(products[0].open_field())
 
-  var nonce_point = nonce.open_exp("secp256k1")
+  var nonce_point = nonce.get_commitment(0)
   var r = Crypto.point_x_to_field(nonce_point, "secp256k1")
 
-  var secret_over_nonce = secret_key.mul(nonce_inverse)
-  var message_over_nonce = nonce_inverse.mul_field(message_field)
-  var scaled_secret = secret_over_nonce.mul_field(r)
-  var response_share = message_over_nonce.add(scaled_secret)
+  var masked_numerator = gamma.mul_field(message_field).add(
+    products[1].mul_field(r),
+  )
+  var response_share = masked_numerator.mul_field(delta_inverse)
   var response = response_share.open_field()
 
   if client_count > 0 and Mpc.has_capability("client-output"):
-    var r_share = Share.from_clear(1).mul_field(r)
+    var r_share = secret_key.mul_scalar(0).add_field(r)
     var output_shares: list[Share] = [r_share, response_share]
     MpcOutput.send_to_client(0, output_shares)
 

--- a/crates/stoffel-lang/examples/validate_examples.sh
+++ b/crates/stoffel-lang/examples/validate_examples.sh
@@ -223,7 +223,7 @@ if [ "$RUN_LOCAL_MPC" -eq 1 ]; then
   CLI="${WORKSPACE_DIR}/target/debug/stoffel"
   if [ ! -x "$CLI" ]; then
     echo "Building stoffel CLI..."
-    cargo build --quiet --manifest-path "${WORKSPACE_DIR}/Cargo.toml" -p stoffel-cli
+    cargo build --quiet --manifest-path "${WORKSPACE_DIR}/Cargo.toml" -p stoffel
   fi
   CAP="${STOFFEL_LOCAL_MPC_TIMEOUT:-120}"
   lm_pass=0

--- a/crates/stoffel-lang/src/codegen.rs
+++ b/crates/stoffel-lang/src/codegen.rs
@@ -3511,6 +3511,14 @@ pub fn generate_bytecode_with_opt_level(
     node: &AstNode,
     opt_level: u8,
 ) -> CompilerResult<CompiledProgram> {
+    generate_bytecode_with_opt_level_and_backend(node, opt_level, MpcBackend::default())
+}
+
+pub fn generate_bytecode_with_opt_level_and_backend(
+    node: &AstNode,
+    opt_level: u8,
+    mpc_backend: MpcBackend,
+) -> CompilerResult<CompiledProgram> {
     let mut generator = CodeGenerator::new();
     generator.opt_level = opt_level;
     collect_reassigned_vars(node, &mut generator.reassigned_vars);
@@ -3520,7 +3528,8 @@ pub fn generate_bytecode_with_opt_level(
     // whole AST (call-multiplicity- and list-length-aware) and stamp it into the
     // client-IO manifest, replacing the placeholder set during finalisation.
     program.client_io_manifest.preprocessing_demand =
-        crate::preprocessing_planner::plan_preprocessing_demand(node);
+        crate::preprocessing_planner::plan_preprocessing_demand_for_backend(node, mpc_backend);
+    program.client_io_manifest.mpc_backend = mpc_backend;
     if std::env::var("STOFFEL_DEBUG_DEMAND").is_ok() {
         eprintln!(
             "[stoffel-lang] preprocessing demand: {:?}",

--- a/crates/stoffel-lang/src/codegen.rs
+++ b/crates/stoffel-lang/src/codegen.rs
@@ -2376,10 +2376,19 @@ impl CodeGenerator {
                     };
 
                 // 2. Map source-level builtin aliases to actual VM function names.
-                let function_name = crate::builtin_registry::builtin_registry()
-                    .vm_symbol_for_call(&raw_function_name)
-                    .map(str::to_string)
-                    .unwrap_or(raw_function_name);
+                let function_name = match raw_function_name.as_str() {
+                    // Semantic IR keeps these canonical while the MPC scheduler
+                    // runs, preventing collisions with user functions named
+                    // `mul`/`open`. Singular receiver calls still use the VM's
+                    // established dynamic method-dispatch ABI; native batches
+                    // (`Share.batch_mul`/`Share.batch_open`) remain qualified.
+                    "Share.mul" => "mul".to_string(),
+                    "Share.open" => "open".to_string(),
+                    _ => crate::builtin_registry::builtin_registry()
+                        .vm_symbol_for_call(&raw_function_name)
+                        .map(str::to_string)
+                        .unwrap_or(raw_function_name),
+                };
 
                 self.record_client_io_call(&function_name, arguments);
                 self.record_share_list_append_call(&function_name, arguments);
@@ -3519,16 +3528,26 @@ pub fn generate_bytecode_with_opt_level_and_backend(
     opt_level: u8,
     mpc_backend: MpcBackend,
 ) -> CompilerResult<CompiledProgram> {
+    let timing =
+        std::env::var("STOFFEL_OPT_TIMING").is_ok_and(|value| value != "0" && !value.is_empty());
+    let codegen_start = std::time::Instant::now();
     let mut generator = CodeGenerator::new();
     generator.opt_level = opt_level;
     collect_reassigned_vars(node, &mut generator.reassigned_vars);
     let (_result_vr, _result_is_secret) = generator.compile_node(node)?;
     let mut program = generator.finalize_program()?;
+    let codegen_elapsed = codegen_start.elapsed().as_secs_f64();
     // Compute the program's MPC preprocessing demand interprocedurally over the
     // whole AST (call-multiplicity- and list-length-aware) and stamp it into the
     // client-IO manifest, replacing the placeholder set during finalisation.
+    let planner_start = std::time::Instant::now();
     program.client_io_manifest.preprocessing_demand =
         crate::preprocessing_planner::plan_preprocessing_demand_for_backend(node, mpc_backend);
+    let planner_elapsed = planner_start.elapsed().as_secs_f64();
+    if timing {
+        eprintln!("[compiler-timing] bytecode_generation: {codegen_elapsed:.3}s");
+        eprintln!("[compiler-timing] preprocessing_planner: {planner_elapsed:.3}s");
+    }
     program.client_io_manifest.mpc_backend = mpc_backend;
     if std::env::var("STOFFEL_DEBUG_DEMAND").is_ok() {
         eprintln!(

--- a/crates/stoffel-lang/src/compiler.rs
+++ b/crates/stoffel-lang/src/compiler.rs
@@ -37,6 +37,10 @@ pub struct CompilerOptions {
     pub unroll_budget: Option<usize>,
     /// Override for the per-loop unroll expansion cap (`None` = default).
     pub unroll_max_expansion: Option<usize>,
+    /// Scalar secret-pair products the MPC backend can execute in one online
+    /// multiply round. `None` selects the backend default (HoneyBadger assumes
+    /// the default threshold of one; AVSS is treated as unbounded).
+    pub mpc_mul_batch_capacity: Option<usize>,
     // Add more options as needed: output_path, target_platform, etc.
 }
 
@@ -47,6 +51,16 @@ impl CompilerOptions {
             inline: self.inline_budget,
             unroll: self.unroll_budget,
             unroll_max_expansion: self.unroll_max_expansion,
+        }
+    }
+
+    pub fn mpc_scheduling_options(&self) -> optimizations::MpcSchedulingOptions {
+        let multiply_batch_capacity = self.mpc_mul_batch_capacity.or_else(|| {
+            (self.mpc_backend == MpcBackend::HoneyBadger)
+                .then(|| stoffel_vm_types::mpc::honeybadger_mul_batch_capacity(1, None))
+        });
+        optimizations::MpcSchedulingOptions {
+            multiply_batch_capacity,
         }
     }
 }
@@ -128,10 +142,11 @@ pub fn compile(
 
     // 5. Optimization Passes
     let optimized_ast = if options.optimize {
-        let ast = optimizations::optimize_all_with_budgets(
+        let ast = optimizations::optimize_all_with_options(
             analyzed_ast,
             options.optimization_level,
             options.opt_budgets(),
+            options.mpc_scheduling_options(),
         );
         if options.print_ir {
             println!("--- Optimized AST (full optimize_all pipeline) ---");

--- a/crates/stoffel-lang/src/compiler.rs
+++ b/crates/stoffel-lang/src/compiler.rs
@@ -149,15 +149,18 @@ pub fn compile(
     } else {
         0
     };
-    let mut compiled_program =
-        match codegen::generate_bytecode_with_opt_level(&optimized_ast, codegen_opt_level) {
-            Ok(program) => program,
-            Err(e) => {
-                error_reporter.add_error(e);
-                // Stop if codegen fails
-                return Err(error_reporter.get_all().into_iter().cloned().collect());
-            }
-        };
+    let mut compiled_program = match codegen::generate_bytecode_with_opt_level_and_backend(
+        &optimized_ast,
+        codegen_opt_level,
+        options.mpc_backend,
+    ) {
+        Ok(program) => program,
+        Err(e) => {
+            error_reporter.add_error(e);
+            // Stop if codegen fails
+            return Err(error_reporter.get_all().into_iter().cloned().collect());
+        }
+    };
     compiled_program
         .prune_unreachable_functions_with_roots(options.entry_points.iter().map(String::as_str));
     compiled_program.client_io_manifest.mpc_backend = options.mpc_backend;

--- a/crates/stoffel-lang/src/ffi.rs
+++ b/crates/stoffel-lang/src/ffi.rs
@@ -27,6 +27,7 @@ impl From<CCompilerOptions> for CompilerOptions {
             inline_budget: None,
             unroll_budget: None,
             unroll_max_expansion: None,
+            mpc_mul_batch_capacity: None,
         }
     }
 }

--- a/crates/stoffel-lang/src/main.rs
+++ b/crates/stoffel-lang/src/main.rs
@@ -178,6 +178,9 @@ fn main() {
         inline_budget: env_budget("STOFFEL_INLINE_BUDGET"),
         unroll_budget: env_budget("STOFFEL_UNROLL_BUDGET"),
         unroll_max_expansion: env_budget("STOFFEL_UNROLL_MAX_EXPANSION"),
+        mpc_mul_batch_capacity: env_budget(
+            stoffel_vm_types::mpc::HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV,
+        ),
     };
 
     println!("Compiling {}...", filename);

--- a/crates/stoffel-lang/src/multi_file_compiler.rs
+++ b/crates/stoffel-lang/src/multi_file_compiler.rs
@@ -243,9 +243,12 @@ impl MultiFileCompiler {
         } else {
             0
         };
-        let mut program =
-            codegen::generate_bytecode_with_opt_level(&optimized_ast, codegen_opt_level)
-                .map_err(|e| vec![e])?;
+        let mut program = codegen::generate_bytecode_with_opt_level_and_backend(
+            &optimized_ast,
+            codegen_opt_level,
+            self.options.mpc_backend,
+        )
+        .map_err(|e| vec![e])?;
         program.client_io_manifest.mpc_backend = self.options.mpc_backend;
         program.client_io_manifest.mpc_curve = self.options.mpc_curve;
 

--- a/crates/stoffel-lang/src/multi_file_compiler.rs
+++ b/crates/stoffel-lang/src/multi_file_compiler.rs
@@ -225,10 +225,11 @@ impl MultiFileCompiler {
 
         // Apply optimizations
         let optimized_ast = if self.options.optimize {
-            optimizations::optimize_all_with_budgets(
+            optimizations::optimize_all_with_options(
                 analyzed_ast,
                 self.options.optimization_level,
                 self.options.opt_budgets(),
+                self.options.mpc_scheduling_options(),
             )
         } else {
             analyzed_ast

--- a/crates/stoffel-lang/src/optimizations.rs
+++ b/crates/stoffel-lang/src/optimizations.rs
@@ -30,6 +30,16 @@ pub struct OptBudgets {
     pub unroll_max_expansion: Option<usize>,
 }
 
+/// Backend execution limits that affect legal MPC batching.
+///
+/// A capacity is a number of scalar pairwise products that the selected backend
+/// can execute concurrently in one online multiply round. `None` means the
+/// backend exposes no compiler-visible width limit.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MpcSchedulingOptions {
+    pub multiply_batch_capacity: Option<usize>,
+}
+
 thread_local! {
     /// Per-thread, per-`optimize_all`-call snapshot of the active budgets. Set at
     /// the start of `optimize_all` and cleared at the end, so the value is only
@@ -41,10 +51,58 @@ thread_local! {
         unroll: None,
         unroll_max_expansion: None,
     }) };
+
+    /// Per-compilation MPC scheduling capability. Like the expansion budgets,
+    /// this is scoped to one synchronous optimizer invocation so parallel
+    /// compilations cannot influence one another.
+    static ACTIVE_MPC_SCHEDULING: Cell<MpcSchedulingOptions> = const {
+        Cell::new(MpcSchedulingOptions { multiply_batch_capacity: None })
+    };
+
+    /// Exact widths of interactive results, keyed by the result binding and the
+    /// statement location that produced it. The location component prevents an
+    /// unrelated same-named local in another scope from inheriting the fact.
+    /// Optimizer-generated bindings also have globally unique names.
+    static INTERACTIVE_WIDTHS: RefCell<HashMap<(String, SourceLocation), usize>> =
+        RefCell::new(HashMap::new());
+
+    /// Exact list shapes proven for shape-specialized function parameters.
+    /// The optimizer creates these variants after general loop unrolling, then
+    /// seeds the compact map-loop vectorizer from this table. Keeping the facts
+    /// out of the AST avoids turning a public shape proof into runtime code.
+    static SPECIALIZED_FUNCTION_SHAPES: RefCell<HashMap<String, Vec<Shape>>> =
+        RefCell::new(HashMap::new());
 }
 
 fn active_budgets() -> OptBudgets {
     ACTIVE_BUDGETS.with(|c| c.get())
+}
+
+fn active_mpc_scheduling() -> MpcSchedulingOptions {
+    ACTIVE_MPC_SCHEDULING.with(|c| c.get())
+}
+
+fn multiply_batch_capacity() -> Option<usize> {
+    active_mpc_scheduling()
+        .multiply_batch_capacity
+        .map(|capacity| capacity.max(1))
+}
+
+fn record_interactive_width(name: &str, location: &SourceLocation, width: usize) {
+    INTERACTIVE_WIDTHS.with(|widths| {
+        widths
+            .borrow_mut()
+            .insert((name.to_string(), location.clone()), width);
+    });
+}
+
+fn interactive_width(name: &str, location: &SourceLocation) -> Option<usize> {
+    INTERACTIVE_WIDTHS.with(|widths| {
+        widths
+            .borrow()
+            .get(&(name.to_string(), location.clone()))
+            .copied()
+    })
 }
 
 thread_local! {
@@ -72,6 +130,8 @@ fn generate_named_temp_name(prefix: &str) -> String {
 #[allow(dead_code)]
 pub fn reset_temp_counter() {
     BATCH_TEMP_COUNTER.store(0, Ordering::SeqCst);
+    INTERACTIVE_WIDTHS.with(|widths| widths.borrow_mut().clear());
+    SPECIALIZED_FUNCTION_SHAPES.with(|shapes| shapes.borrow_mut().clear());
 }
 
 /// Represents a detected Share.open() call that can potentially be batched
@@ -130,6 +190,10 @@ struct MultiplyCandidate {
     /// concatenating operand lists and re-slicing the wide result, rather than
     /// by building a list literal of scalar operands.
     is_batched: bool,
+    /// Exact scalar pair count contributed by this operation, when proven.
+    /// Scalar gates always contribute one; optimizer-generated vector calls
+    /// carry their exact lane count in `INTERACTIVE_WIDTHS`.
+    work: Option<usize>,
 }
 
 /// Collects all variable names referenced in an expression
@@ -430,8 +494,27 @@ fn secret_multiply_operands(value: &AstNode) -> Option<(&str, &AstNode, &AstNode
         } if op == "*" || op == "and" || op == "or" || op == "xor" => {
             Some((op.as_str(), left.as_ref(), right.as_ref()))
         }
+        AstNode::FunctionCall { arguments, .. }
+            if arguments.len() == 2 && call_resolves_to_vm_symbol(value, "Share.mul") =>
+        {
+            Some(("mul", &arguments[0], &arguments[1]))
+        }
         _ => None,
     }
+}
+
+/// Resolve a call through the builtin registry and compare its full VM symbol.
+/// Full-symbol matching is important for `mul`: `Field.mul` is a clear local
+/// operation and must never be classified as the interactive `Share.mul` merely
+/// because both have the same unqualified base name.
+fn call_resolves_to_vm_symbol(value: &AstNode, expected: &str) -> bool {
+    let Some(name) = call_name(value) else {
+        return false;
+    };
+    let canonical = crate::builtin_registry::builtin_registry()
+        .vm_symbol_for_call(name)
+        .unwrap_or(name);
+    canonical == expected
 }
 
 /// Detects a call-form `Share.batch_mul(L, R)` and returns its two list
@@ -446,10 +529,10 @@ fn batch_mul_call_operands(value: &AstNode) -> Option<(&AstNode, &AstNode)> {
     } = value
     {
         if arguments.len() == 2 {
-            if let AstNode::Identifier(name, _) = function.as_ref() {
-                if builtin_base_name(name) == "batch_mul" {
-                    return Some((&arguments[0], &arguments[1]));
-                }
+            if matches!(function.as_ref(), AstNode::Identifier(_, _))
+                && call_resolves_to_vm_symbol(value, "Share.batch_mul")
+            {
+                return Some((&arguments[0], &arguments[1]));
             }
         }
     }
@@ -539,6 +622,34 @@ fn expr_yields_secret(node: &AstNode, secret_lvalues: &HashSet<String>) -> bool 
     }
 }
 
+/// Exact number of scalar elements contributed by a batch operand when that
+/// fact is structural or was emitted by an optimizer transformation.
+fn exact_batch_operand_width(node: &AstNode) -> Option<usize> {
+    match node {
+        AstNode::ListLiteral { .. } => flatten_list_literal_leaves(node).map(|v| v.len()),
+        AstNode::FunctionCall { arguments, .. }
+            if call_name(node).is_some_and(|name| builtin_base_name(name) == "copy") =>
+        {
+            arguments.first().and_then(exact_batch_operand_width)
+        }
+        _ => None,
+    }
+}
+
+fn exact_batch_mul_work(
+    target: &str,
+    location: &SourceLocation,
+    left: &AstNode,
+    right: &AstNode,
+) -> Option<usize> {
+    if let Some(width) = interactive_width(target, location) {
+        return Some(width);
+    }
+    let left = exact_batch_operand_width(left)?;
+    let right = exact_batch_operand_width(right)?;
+    (left == right).then_some(left)
+}
+
 /// Extracts consecutive statement-level secret multiply candidates.
 fn extract_multiply_candidates(statements: &[AstNode]) -> Vec<MultiplyCandidate> {
     let mut candidates = Vec::new();
@@ -568,8 +679,12 @@ fn extract_multiply_candidates(statements: &[AstNode]) -> Vec<MultiplyCandidate>
                 // secret lvalue so a downstream multiply that consumes it is in turn
                 // recognized, flattening a whole nested gate tree.
                 let multiply = secret_multiply_operands(value);
-                let secret_multiply = multiply.is_some_and(|(_, left, right)| {
-                    declared_secret
+                let secret_multiply = multiply.is_some_and(|(op, left, right)| {
+                    // `Share.mul` is intrinsically an interactive share result;
+                    // semantic return metadata confirms it when present. The
+                    // exact VM-symbol check above excludes clear `Field.mul`.
+                    (op == "mul" && node_resolved_contains_secret(value).unwrap_or(true))
+                        || declared_secret
                         || expr_yields_secret(left, &secret_lvalues)
                         || expr_yields_secret(right, &secret_lvalues)
                 });
@@ -596,6 +711,7 @@ fn extract_multiply_candidates(statements: &[AstNode]) -> Vec<MultiplyCandidate>
                             is_mutable: *is_mutable,
                             is_secret: *is_secret,
                             is_batched: false,
+                            work: Some(1),
                         });
                     }
                 } else if !declared_secret && batch_mul_call_operands(value).is_some() {
@@ -622,6 +738,7 @@ fn extract_multiply_candidates(statements: &[AstNode]) -> Vec<MultiplyCandidate>
                             is_mutable: *is_mutable,
                             is_secret: *is_secret,
                             is_batched: true,
+                            work: exact_batch_mul_work(name, location, left, right),
                         });
                     }
                 }
@@ -653,6 +770,7 @@ fn extract_multiply_candidates(statements: &[AstNode]) -> Vec<MultiplyCandidate>
                                 is_mutable: false,
                                 is_secret: true,
                                 is_batched: false,
+                                work: Some(1),
                             });
                         }
                     }
@@ -821,22 +939,35 @@ fn group_batchable_multiplies(
     let mut defined_vars: HashSet<String> = HashSet::new();
     let mut last_index = None;
 
+    let fits_backend_round = |group: &[MultiplyCandidate], next: &MultiplyCandidate| {
+        let Some(capacity) = multiply_batch_capacity() else {
+            return true;
+        };
+        let Some(next_work) = next.work else {
+            // An unproven width cannot safely share a capacity-bounded call.
+            return false;
+        };
+        group
+            .iter()
+            .try_fold(next_work, |used, candidate| {
+                used.checked_add(candidate.work?)
+            })
+            .is_some_and(|used| used <= capacity)
+    };
+
     for candidate in candidates {
         let can_batch = match last_index {
             None => true,
             Some(last_idx) => {
-                // Scalar (`and`/`or`/`xor`) and batched (`Share.batch_mul`)
-                // candidates fuse with different output shapes, so never mix them
-                // in one group.
-                current_group
-                    .first()
-                    .is_none_or(|g| g.is_batched == candidate.is_batched)
-                    // A candidate whose operands cannot be flattened in alignment
-                    // (a malformed/unprovable nested-list shape) must never be
-                    // concatenated into a fused accumulator — keep it (and anything
-                    // anchored on it) as its own singleton call.
-                    && candidate_is_fuse_safe(&candidate)
+                // A candidate whose operands cannot be flattened in alignment
+                // (a malformed/unprovable nested-list shape) must never be
+                // concatenated into a fused accumulator — keep it (and anything
+                // anchored on it) as its own singleton call. Scalar products are
+                // represented as one-element contributions, so they can share a
+                // backend round with vector products when capacity permits.
+                candidate_is_fuse_safe(&candidate)
                     && current_group.first().is_none_or(candidate_is_fuse_safe)
+                    && fits_backend_round(&current_group, &candidate)
                     && candidate.statement_index > last_idx
                     && !candidate.referenced_vars.iter().any(|var| {
                         defined_vars
@@ -884,13 +1015,14 @@ fn group_batchable_multiplies(
 ///   var a: secret bool = __batch_mul_results_K[0]
 ///   var b: secret bool = __batch_mul_results_K[1]
 fn create_batch_multiply_statements(group: &[MultiplyCandidate]) -> Vec<AstNode> {
-    if group.first().is_some_and(|c| c.is_batched) {
+    if group.iter().any(|candidate| candidate.is_batched) {
         return create_batched_call_fusion(group);
     }
     let lefts_name = generate_named_temp_name("batch_mul_lefts");
     let rights_name = generate_named_temp_name("batch_mul_rights");
     let results_name = generate_named_temp_name("batch_mul_results");
     let location = group[0].location.clone();
+    record_interactive_width(&results_name, &location, group.len());
 
     let lefts_decl = AstNode::VariableDeclaration {
         name: lefts_name.clone(),
@@ -1189,11 +1321,11 @@ fn emit_batched_target(candidate: &MultiplyCandidate, value_expr: AstNode) -> As
     }
 }
 
-/// Fuses a group of independent call-form `Share.batch_mul(L, R)` candidates into
-/// a single wide `Share.batch_mul`. Each candidate's list operands are
-/// concatenated into one pair of accumulator lists, multiplied once, then the
-/// per-candidate products are recovered by slicing the wide result back at the
-/// cumulative operand-length offsets.
+/// Fuses independent scalar and/or call-form `Share.batch_mul(L, R)` candidates
+/// into one wide `Share.batch_mul`. Vector operands are concatenated and scalar
+/// operands contribute singleton lists. Each vector result is recovered by
+/// slicing at cumulative offsets; each scalar result reads one element and then
+/// applies the local XOR/OR reconstruction when needed.
 ///
 /// Transforms (operands/results are `list[secret bool]`, multiplied element-wise):
 ///   var m1 = Share.batch_mul(a, b)
@@ -1227,6 +1359,7 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
             let rights = flatten_list_literal_leaves(&c.right_expr)
                 .expect("nested operand is a list literal");
             let results_name = generate_named_temp_name("bm_results");
+            record_interactive_width(&results_name, &location, lefts.len());
             let mut result = Vec::new();
             result.push(AstNode::VariableDeclaration {
                 name: results_name.clone(),
@@ -1260,13 +1393,22 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
     let lefts_name = generate_named_temp_name("bm_lefts");
     let rights_name = generate_named_temp_name("bm_rights");
     let results_name = generate_named_temp_name("bm_results");
+    if let Some(work) = group.iter().try_fold(0usize, |total, candidate| {
+        total.checked_add(candidate.work?)
+    }) {
+        record_interactive_width(&results_name, &location, work);
+    }
 
-    // The accumulator contribution for an operand: a nested list literal is
-    // flattened to its scalar leaves (so `extend` never appends a whole sub-list,
-    // which would reach `Share.batch_mul` as a nested `Array` element); a flat or
-    // opaque operand is contributed verbatim — byte-identical to the legacy path
-    // for the AES/CTR/CBC operands, which are opaque identifiers.
-    let contribution = |operand: &AstNode| -> AstNode {
+    // The accumulator contribution for an operand: a scalar becomes a singleton
+    // list; a nested vector literal is flattened to scalar leaves (so `extend`
+    // never appends a whole sub-list); a flat/opaque vector stays unchanged.
+    let contribution = |candidate: &MultiplyCandidate, operand: &AstNode| -> AstNode {
+        if !candidate.is_batched {
+            return AstNode::ListLiteral {
+                elements: vec![operand.clone()],
+                location: location.clone(),
+            };
+        }
         if list_literal_is_nested(operand) {
             AstNode::ListLiteral {
                 elements: flatten_list_literal_leaves(operand)
@@ -1288,7 +1430,7 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
         type_annotation: None,
         value: Some(Box::new(make_unary_builtin_call(
             "copy",
-            contribution(&group[0].left_expr),
+            contribution(&group[0], &group[0].left_expr),
             &location,
         ))),
         is_mutable: true,
@@ -1300,7 +1442,7 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
         type_annotation: None,
         value: Some(Box::new(make_unary_builtin_call(
             "copy",
-            contribution(&group[0].right_expr),
+            contribution(&group[0], &group[0].right_expr),
             &location,
         ))),
         is_mutable: true,
@@ -1310,12 +1452,12 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
     for candidate in &group[1..] {
         result.push(make_extend_call(
             &lefts_name,
-            contribution(&candidate.left_expr),
+            contribution(candidate, &candidate.left_expr),
             &location,
         ));
         result.push(make_extend_call(
             &rights_name,
-            contribution(&candidate.right_expr),
+            contribution(candidate, &candidate.right_expr),
             &location,
         ));
     }
@@ -1342,8 +1484,10 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
     // recovery.
     let mut cur_off = make_int_literal(0, &location);
     for candidate in group {
-        let nested = list_literal_is_nested(&candidate.left_expr);
-        let len_expr = if nested {
+        let nested = candidate.is_batched && list_literal_is_nested(&candidate.left_expr);
+        let len_expr = if !candidate.is_batched {
+            make_int_literal(1, &location)
+        } else if nested {
             make_int_literal(
                 flatten_list_literal_leaves(&candidate.left_expr)
                     .expect("nested operand is a list literal")
@@ -1363,7 +1507,10 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
             location: location.clone(),
         });
         let end_ident = AstNode::Identifier(end_name, location.clone());
-        let value = if nested {
+        let value = if !candidate.is_batched {
+            let product = batch_result_access_at(&results_name, cur_off.clone(), &location);
+            batched_boolean_value_from_product(candidate, product)
+        } else if nested {
             let mut cursor = 0usize;
             renest_results_like(
                 &candidate.left_expr,
@@ -1383,18 +1530,24 @@ fn create_batched_call_fusion(group: &[MultiplyCandidate]) -> Vec<AstNode> {
 }
 
 fn batch_result_access(results_name: &str, idx: usize, location: &SourceLocation) -> AstNode {
+    batch_result_access_at(
+        results_name,
+        make_int_literal(idx as u128, location),
+        location,
+    )
+}
+
+fn batch_result_access_at(
+    results_name: &str,
+    index: AstNode,
+    location: &SourceLocation,
+) -> AstNode {
     AstNode::IndexAccess {
         base: Box::new(AstNode::Identifier(
             results_name.to_string(),
             location.clone(),
         )),
-        index: Box::new(AstNode::Literal {
-            value: crate::ast::Value::Int {
-                value: idx as u128,
-                kind: None,
-            },
-            location: location.clone(),
-        }),
+        index: Box::new(index),
         location: location.clone(),
     }
 }
@@ -1444,7 +1597,11 @@ fn batched_boolean_value_expr(
 ) -> AstNode {
     let location = &candidate.location;
     let product = batch_result_access(results_name, idx, location);
+    batched_boolean_value_from_product(candidate, product)
+}
 
+fn batched_boolean_value_from_product(candidate: &MultiplyCandidate, product: AstNode) -> AstNode {
+    let location = &candidate.location;
     match candidate.op.as_str() {
         "or" => {
             let sum = make_share_binary_call(
@@ -1587,13 +1744,15 @@ pub fn optimize_multiplies(node: AstNode) -> AstNode {
     }
 }
 
-/// Re-run dependency scheduling and multiply fusion until batching no longer
-/// changes the program. A first fusion can normalize scalar Boolean gates into
-/// `Share.batch_mul`, making them compatible with an adjacent call-form batch
-/// only on the next iteration.
+/// Re-run multiply fusion until batching no longer changes the program. The
+/// dependency scheduler has already chosen the protocol-round order; repeating
+/// it after batches become opaque nodes would discard their per-operation
+/// critical-path priorities and can coarsen a good scalar schedule. Fusion can
+/// legally cross its own reconstruction plumbing, so no second scheduling pass
+/// is needed to normalize scalar Boolean groups with call-form batches.
 fn optimize_multiply_batches_to_fixpoint(mut node: AstNode) -> AstNode {
     for _ in 0..8 {
-        let next = optimize_multiplies(schedule_for_batching(node.clone()));
+        let next = optimize_multiplies(node.clone());
         if next == node {
             break;
         }
@@ -1604,16 +1763,9 @@ fn optimize_multiply_batches_to_fixpoint(mut node: AstNode) -> AstNode {
 
 /// Checks if an AST node is a Share.open() receiver method call.
 fn is_share_open_call(node: &AstNode) -> Option<&AstNode> {
-    if let AstNode::FunctionCall {
-        function,
-        arguments,
-        ..
-    } = node
-    {
-        if let AstNode::Identifier(name, _) = function.as_ref() {
-            if matches!(builtin_base_name(name), "open" | "reveal") && arguments.len() == 1 {
-                return Some(&arguments[0]);
-            }
+    if let AstNode::FunctionCall { arguments, .. } = node {
+        if arguments.len() == 1 && call_resolves_to_vm_symbol(node, "Share.open") {
+            return Some(&arguments[0]);
         }
     }
     None
@@ -2017,7 +2169,8 @@ pub fn optimize_reveals(node: AstNode) -> AstNode {
 //   var x = a * 2            // uses a - FLUSH! (both a and b batched)
 //   var y = b * 3            // uses b - already revealed
 
-use std::collections::HashMap;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
 use std::rc::Rc;
 
 /// Information about a statement for reordering purposes
@@ -2031,6 +2184,15 @@ struct StatementInfo {
     is_reveal: bool,
     /// Does this statement use a revealed variable in a computation (triggers flush)?
     uses_revealed_var: bool,
+}
+
+/// Deterministic work performed by reveal reordering. Tests use these units to
+/// catch algorithmic regressions without depending on wall-clock timings.
+#[derive(Debug, Clone, Copy, Default)]
+struct RevealReorderWork {
+    dependency_key_probes: u64,
+    dependency_edges: u64,
+    ready_queue_operations: u64,
 }
 
 /// Collects variables defined by a statement
@@ -2147,13 +2309,6 @@ fn reveal_dep_keys(node: &AstNode) -> (HashSet<String>, HashSet<String>) {
     (reads, writes)
 }
 
-/// Two location keys (as produced by `reveal_dep_keys`) conflict when they name
-/// the same location, or when either is the catch-all `global:*` write target
-/// (`global_key()`), which aliases everything.
-fn reveal_keys_conflict(a: &str, b: &str) -> bool {
-    a == b || a == GLOBAL_KEY || b == GLOBAL_KEY
-}
-
 /// Checks if a statement is an implicit reveal (clear variable assigned from secret)
 fn is_implicit_reveal(node: &AstNode, secret_vars: &HashSet<String>) -> bool {
     match node {
@@ -2253,6 +2408,41 @@ fn uses_revealed_in_computation(node: &AstNode, revealed_vars: &HashSet<String>)
 
 /// Builds dependency graph and reorders statements to maximize reveal batching
 fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
+    reorder_block_for_reveals_with_work(statements, &mut RevealReorderWork::default())
+}
+
+fn reorder_block_for_reveals_with_work(
+    statements: Vec<AstNode>,
+    work: &mut RevealReorderWork,
+) -> Vec<AstNode> {
+    // Abrupt control transfer is an ordering boundary, not an ordinary neutral
+    // statement. Scheduling a later/earlier `return`, `break`, `continue`, or
+    // `yield` by data dependencies alone can make preceding MPC work
+    // unreachable or execute work from a path that should not be taken. Split
+    // the block into independent regions and retain every transfer (including
+    // one nested in structured control) at its exact source position.
+    if statements.iter().any(has_abrupt_loop_control) {
+        let mut reordered = Vec::with_capacity(statements.len());
+        let mut run = Vec::new();
+        for statement in statements {
+            if has_abrupt_loop_control(&statement) {
+                if !run.is_empty() {
+                    reordered.extend(reorder_block_for_reveals_with_work(
+                        std::mem::take(&mut run),
+                        work,
+                    ));
+                }
+                reordered.push(statement);
+            } else {
+                run.push(statement);
+            }
+        }
+        if !run.is_empty() {
+            reordered.extend(reorder_block_for_reveals_with_work(run, work));
+        }
+        return reordered;
+    }
+
     if statements.len() < 2 {
         return statements;
     }
@@ -2315,33 +2505,77 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
     // earlier RAW-only graph was a latent miscompile: a neutral reassignment
     // (or an index/field/mutator write, which the old graph ignored entirely)
     // could hoist ahead of a reveal that read the old value.
-    let mut must_precede: HashMap<usize, HashSet<usize>> = HashMap::new();
+    let mut successors: Vec<Vec<usize>> = vec![Vec::new(); stmt_infos.len()];
+    let mut indegree = vec![0usize; stmt_infos.len()];
     let mut last_writer: HashMap<String, usize> = HashMap::new();
     let mut active_readers: HashMap<String, Vec<usize>> = HashMap::new();
+    let mut last_global_writer: Option<usize> = None;
+    let mut last_global_reader: Option<usize> = None;
+    // Statements that wrote since the latest catch-all read. A later global
+    // read consumes this list once, making global barriers amortized-linear
+    // rather than repeatedly scanning the entire location map.
+    let mut writes_since_global_reader: Vec<usize> = Vec::new();
 
     for info in &stmt_infos {
         let (reads, writes) = reveal_dep_keys(&info.node);
         let mut predecessors = HashSet::new();
 
-        // RAW: depend on the latest writer of any conflicting location.
+        // RAW: exact locations use direct hash lookups. A catch-all read is a
+        // barrier after the prior global read and every write since it.
         for read in &reads {
-            for (key, &widx) in &last_writer {
-                if reveal_keys_conflict(key, read) {
-                    predecessors.insert(widx);
+            if read == GLOBAL_KEY {
+                work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                if let Some(reader) = last_global_reader {
+                    predecessors.insert(reader);
+                }
+                for &writer in &writes_since_global_reader {
+                    work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                    predecessors.insert(writer);
+                }
+            } else {
+                work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                if let Some(&writer) = last_writer.get(read) {
+                    predecessors.insert(writer);
+                } else if let Some(writer) = last_global_writer {
+                    predecessors.insert(writer);
                 }
             }
         }
-        // WAR + WAW: a write stays after earlier reads and the latest writer of
-        // any conflicting location.
+
+        // WAR + WAW: exact writes query only their own reader/writer state and
+        // the latest global barriers. A global write consumes all live state;
+        // those entries are subsequently cleared, so total scan work remains
+        // proportional to the number of accesses and emitted dependency edges.
         for write in &writes {
-            for (key, readers) in &active_readers {
-                if reveal_keys_conflict(key, write) {
+            if write == GLOBAL_KEY {
+                for readers in active_readers.values() {
+                    for &reader in readers {
+                        work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                        predecessors.insert(reader);
+                    }
+                }
+                for &writer in last_writer.values() {
+                    work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                    predecessors.insert(writer);
+                }
+                if let Some(writer) = last_global_writer {
+                    predecessors.insert(writer);
+                }
+                if let Some(reader) = last_global_reader {
+                    predecessors.insert(reader);
+                }
+            } else {
+                work.dependency_key_probes = work.dependency_key_probes.saturating_add(1);
+                if let Some(readers) = active_readers.get(write) {
                     predecessors.extend(readers.iter().copied());
                 }
-            }
-            for (key, &widx) in &last_writer {
-                if reveal_keys_conflict(key, write) {
-                    predecessors.insert(widx);
+                if let Some(&writer) = last_writer.get(write) {
+                    predecessors.insert(writer);
+                } else if let Some(writer) = last_global_writer {
+                    predecessors.insert(writer);
+                }
+                if let Some(reader) = last_global_reader {
+                    predecessors.insert(reader);
                 }
             }
         }
@@ -2349,20 +2583,44 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
         // A read-modify-write statement may have keyed itself on both sides;
         // it must never depend on itself.
         predecessors.remove(&info.index);
-        must_precede.insert(info.index, predecessors);
+        indegree[info.index] = predecessors.len();
+        work.dependency_edges = work
+            .dependency_edges
+            .saturating_add(predecessors.len() as u64);
+        for predecessor in predecessors {
+            debug_assert!(predecessor < info.index);
+            successors[predecessor].push(info.index);
+        }
 
         // Advance the live state. A write retires the reads it now orders ahead
         // of itself (later statements reach them transitively through this
         // write) and becomes the latest writer of its location.
-        for write in &writes {
-            active_readers.retain(|key, _| !reveal_keys_conflict(key, write));
-            last_writer.insert(write.clone(), info.index);
+        if writes.contains(GLOBAL_KEY) {
+            active_readers.clear();
+            last_writer.clear();
+            last_global_writer = Some(info.index);
+            // This write is ordered after the global reader and now dominates
+            // it for every future write.
+            last_global_reader = None;
+        } else {
+            for write in &writes {
+                active_readers.remove(write);
+                last_writer.insert(write.clone(), info.index);
+            }
+        }
+        if !writes.is_empty() {
+            writes_since_global_reader.push(info.index);
         }
         for read in &reads {
-            active_readers
-                .entry(read.clone())
-                .or_default()
-                .push(info.index);
+            if read == GLOBAL_KEY {
+                last_global_reader = Some(info.index);
+                writes_since_global_reader.clear();
+            } else {
+                active_readers
+                    .entry(read.clone())
+                    .or_default()
+                    .push(info.index);
+            }
         }
     }
 
@@ -2371,75 +2629,58 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
     // 2. Non-flush-triggering statements
     // 3. Flush-triggering statements last
 
-    let mut result: Vec<AstNode> = Vec::with_capacity(stmt_infos.len());
-    let mut scheduled: HashSet<usize> = HashSet::new();
-    let mut remaining: Vec<usize> = (0..stmt_infos.len()).collect();
-
-    while !remaining.is_empty() {
-        // Find candidates that can be scheduled (all predecessors already scheduled)
-        let mut candidates: Vec<usize> = remaining
-            .iter()
-            .filter(|&&idx| {
-                must_precede
-                    .get(&idx)
-                    .map(|preds| preds.iter().all(|p| scheduled.contains(p)))
-                    .unwrap_or(true)
-            })
-            .copied()
-            .collect();
-
-        if candidates.is_empty() {
-            // Cycle detected or error - just emit remaining in order
-            for idx in remaining {
-                result.push(stmt_infos[idx].node.clone());
-            }
-            break;
+    let priority = |info: &StatementInfo| -> u8 {
+        if info.uses_revealed_var {
+            2
+        } else if info.is_reveal {
+            1
+        } else {
+            0
         }
-
-        // Sort candidates by priority:
-        // 1. Neutral statements first (includes secret declarations that feed into reveals)
-        // 2. Reveals second (to group them together before flush triggers)
-        // 3. Flush-triggering statements last (to allow maximum batching)
-        candidates.sort_by(|&a, &b| {
-            let info_a = &stmt_infos[a];
-            let info_b = &stmt_infos[b];
-
-            // Priority: neutral > reveal > flush_trigger
-            // This ensures secret declarations come before reveals,
-            // and reveals come before computations that use them
-            let priority = |info: &StatementInfo| -> u8 {
-                if info.uses_revealed_var {
-                    2
-                }
-                // Flush triggers last
-                else if info.is_reveal {
-                    1
-                }
-                // Reveals second
-                else {
-                    0
-                } // Neutral first (includes secret declarations)
-            };
-
-            let pa = priority(info_a);
-            let pb = priority(info_b);
-
-            if pa != pb {
-                pa.cmp(&pb)
-            } else {
-                // Same priority: preserve original order
-                a.cmp(&b)
-            }
-        });
-
-        // Schedule the best candidate
-        let best = candidates[0];
-        result.push(stmt_infos[best].node.clone());
-        scheduled.insert(best);
-        remaining.retain(|&x| x != best);
+    };
+    let mut ready: BinaryHeap<Reverse<(u8, usize)>> = BinaryHeap::new();
+    for (index, &degree) in indegree.iter().enumerate() {
+        if degree == 0 {
+            ready.push(Reverse((priority(&stmt_infos[index]), index)));
+            work.ready_queue_operations = work.ready_queue_operations.saturating_add(1);
+        }
     }
 
-    result
+    let mut order = Vec::with_capacity(stmt_infos.len());
+    let mut scheduled = vec![false; stmt_infos.len()];
+    while let Some(Reverse((_, index))) = ready.pop() {
+        work.ready_queue_operations = work.ready_queue_operations.saturating_add(1);
+        scheduled[index] = true;
+        order.push(index);
+        for &successor in &successors[index] {
+            indegree[successor] -= 1;
+            if indegree[successor] == 0 {
+                ready.push(Reverse((priority(&stmt_infos[successor]), successor)));
+                work.ready_queue_operations = work.ready_queue_operations.saturating_add(1);
+            }
+        }
+    }
+
+    if order.len() != stmt_infos.len() {
+        // Edges always point from an earlier statement to a later one, so a
+        // cycle indicates an internal bookkeeping bug. Preserve the source
+        // order of anything not yet emitted as a conservative release fallback.
+        debug_assert!(
+            false,
+            "reveal dependency graph unexpectedly contains a cycle"
+        );
+        order.extend((0..stmt_infos.len()).filter(|&index| !scheduled[index]));
+    }
+
+    // Move each AST node into its scheduled position. The old implementation
+    // cloned every statement subtree during scheduling, amplifying both time
+    // and peak memory on fully unrolled programs.
+    let mut nodes: Vec<Option<AstNode>> =
+        stmt_infos.into_iter().map(|info| Some(info.node)).collect();
+    order
+        .into_iter()
+        .map(|index| nodes[index].take().expect("statement scheduled once"))
+        .collect()
 }
 
 /// Applies instruction reordering optimization to maximize implicit reveal batching
@@ -2522,10 +2763,986 @@ pub fn optimize_all_with_budgets(
     optimization_level: u8,
     budgets: OptBudgets,
 ) -> AstNode {
+    optimize_all_with_options(
+        node,
+        optimization_level,
+        budgets,
+        MpcSchedulingOptions::default(),
+    )
+}
+
+/// Optimize with explicit expansion budgets and backend MPC batching limits.
+pub fn optimize_all_with_options(
+    node: AstNode,
+    optimization_level: u8,
+    budgets: OptBudgets,
+    scheduling: MpcSchedulingOptions,
+) -> AstNode {
     let previous = ACTIVE_BUDGETS.with(|c| c.replace(budgets));
+    let previous_scheduling = ACTIVE_MPC_SCHEDULING.with(|c| c.replace(scheduling));
+    INTERACTIVE_WIDTHS.with(|widths| widths.borrow_mut().clear());
+    SPECIALIZED_FUNCTION_SHAPES.with(|shapes| shapes.borrow_mut().clear());
     let result = optimize_all_inner(node, optimization_level);
+    INTERACTIVE_WIDTHS.with(|widths| widths.borrow_mut().clear());
+    SPECIALIZED_FUNCTION_SHAPES.with(|shapes| shapes.borrow_mut().clear());
+    ACTIVE_MPC_SCHEDULING.with(|c| c.set(previous_scheduling));
     ACTIVE_BUDGETS.with(|c| c.set(previous));
     result
+}
+
+// ===========================================================================
+// Bounded interprocedural MPC shape specialization
+//
+// A capacity-bounded scheduler must know how many scalar products a vector
+// multiply contributes. A generic map helper such as `map(xs)` only exposes a
+// symbolic `xs.len()` inside its body, even when every caller knows the exact
+// length. Guessing is unsound, while inlining the circuit at every call site is
+// prohibitively large. This pass instead clones only the compact, still-rolled
+// helper for a bounded set of exact call shapes and rewrites matching calls.
+// The vectorizer that follows seeds its shape environment for each clone and
+// therefore emits exact batch widths without scalar-unrolling the map.
+//
+// The policy mirrors LLVM's general specialization discipline: require a
+// concrete profitability signal, cap variants per function, and charge every
+// clone against one compilation-wide code-growth budget. If any proof or budget
+// check fails, the generic call is retained unchanged.
+// ===========================================================================
+
+const MPC_SHAPE_MAX_VARIANTS_PER_FUNCTION: usize = 4;
+const MPC_SHAPE_MAX_VARIANTS_TOTAL: usize = 32;
+const MPC_SHAPE_MAX_ADDED_NODES: usize = 100_000;
+const MPC_SHAPE_GROWTH_DENOMINATOR: usize = 3;
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct ShapeSignature(Vec<Shape>);
+
+#[derive(Clone)]
+struct ShapeFunctionTemplate {
+    parameters: Vec<crate::ast::Parameter>,
+    body: AstNode,
+    size: usize,
+    own_shape_sensitive_mpc: bool,
+    calls: HashSet<String>,
+}
+
+fn has_shape_sensitive_mpc(node: &AstNode) -> bool {
+    match node {
+        AstNode::ForLoop { iterable, body, .. }
+            if range_bounds(iterable, &LenEnv::default()).is_none()
+                && vec_stmt_contains_multiply(body) =>
+        {
+            true
+        }
+        AstNode::FunctionCall { arguments, .. }
+            if call_name(node).is_some_and(|name| builtin_base_name(name) == "batch_mul")
+                && arguments
+                    .first()
+                    .is_none_or(|operand| exact_batch_operand_width(operand).is_none()) =>
+        {
+            true
+        }
+        AstNode::FunctionDefinition { .. } => false,
+        _ => {
+            let mut found = false;
+            for_each_child(node, &mut |child| {
+                if !found {
+                    found = has_shape_sensitive_mpc(child);
+                }
+            });
+            found
+        }
+    }
+}
+
+fn collect_shape_specialization_calls(
+    node: &AstNode,
+    defined: &HashSet<String>,
+    out: &mut HashSet<String>,
+) {
+    if let Some(name) = call_name(node) {
+        if defined.contains(name) {
+            out.insert(name.to_string());
+        }
+    }
+    if matches!(node, AstNode::FunctionDefinition { .. }) {
+        return;
+    }
+    for_each_child(node, &mut |child| {
+        collect_shape_specialization_calls(child, defined, out)
+    });
+}
+
+/// Gather only one lexical definition scope. Stoffel's compiled program
+/// functions live in the root block; declining nested/duplicate names keeps
+/// identifier rewriting unambiguous and preserves closures unchanged.
+fn gather_shape_function_templates(root: &AstNode) -> HashMap<String, ShapeFunctionTemplate> {
+    let AstNode::Block(statements) = root else {
+        return HashMap::new();
+    };
+    let mut counts = HashMap::<String, usize>::new();
+    for statement in statements {
+        if let AstNode::FunctionDefinition {
+            name: Some(name), ..
+        } = statement
+        {
+            *counts.entry(name.clone()).or_default() += 1;
+        }
+    }
+    let defined: HashSet<String> = counts
+        .iter()
+        .filter(|(_, count)| **count == 1)
+        .map(|(name, _)| name.clone())
+        .collect();
+    let mut templates = HashMap::new();
+    for statement in statements {
+        let AstNode::FunctionDefinition {
+            name: Some(name),
+            parameters,
+            body,
+            ..
+        } = statement
+        else {
+            continue;
+        };
+        if !defined.contains(name)
+            || parameters
+                .iter()
+                .any(|parameter| parameter.is_variadic || parameter.default_value.is_some())
+        {
+            continue;
+        }
+        let mut calls = HashSet::new();
+        collect_shape_specialization_calls(body, &defined, &mut calls);
+        templates.insert(
+            name.clone(),
+            ShapeFunctionTemplate {
+                parameters: parameters.clone(),
+                body: body.as_ref().clone(),
+                size: node_size(body),
+                own_shape_sensitive_mpc: has_shape_sensitive_mpc(body),
+                calls,
+            },
+        );
+    }
+    templates
+}
+
+fn shape_specialization_reachable(
+    templates: &HashMap<String, ShapeFunctionTemplate>,
+) -> HashSet<String> {
+    let mut useful: HashSet<String> = templates
+        .iter()
+        .filter(|(_, template)| template.own_shape_sensitive_mpc)
+        .map(|(name, _)| name.clone())
+        .collect();
+
+    // Walk the reverse call graph from directly shape-sensitive functions.
+    // The former whole-map fixpoint rescanned every function once per call-chain
+    // level, making a chain of F helpers O(F²).
+    let mut callers = HashMap::<String, Vec<String>>::new();
+    for (caller, template) in templates {
+        for callee in &template.calls {
+            if templates.contains_key(callee) {
+                callers
+                    .entry(callee.clone())
+                    .or_default()
+                    .push(caller.clone());
+            }
+        }
+    }
+    let mut queue: std::collections::VecDeque<String> = useful.iter().cloned().collect();
+    while let Some(callee) = queue.pop_front() {
+        if let Some(reverse_edges) = callers.get(&callee) {
+            for caller in reverse_edges {
+                if useful.insert(caller.clone()) {
+                    queue.push_back(caller.clone());
+                }
+            }
+        }
+    }
+    useful
+}
+
+fn shape_signature_for_call(
+    name: &str,
+    arguments: &[AstNode],
+    env: &LenEnv,
+    templates: &HashMap<String, ShapeFunctionTemplate>,
+) -> Option<ShapeSignature> {
+    let template = templates.get(name)?;
+    if arguments.len() != template.parameters.len()
+        || arguments
+            .iter()
+            .any(|argument| matches!(argument, AstNode::NamedArgument { .. }))
+    {
+        return None;
+    }
+    let signature = ShapeSignature(
+        arguments
+            .iter()
+            .map(|argument| eval_shape(argument, env))
+            .collect(),
+    );
+    signature
+        .0
+        .iter()
+        .any(|shape| shape.count().is_some())
+        .then_some(signature)
+}
+
+fn seed_shape_function_env(template: &ShapeFunctionTemplate, signature: &ShapeSignature) -> LenEnv {
+    let mut env = LenEnv::default();
+    for (parameter, shape) in template.parameters.iter().zip(&signature.0) {
+        if !matches!(shape, Shape::Unknown) {
+            env.shapes.insert(parameter.name.clone(), shape.clone());
+        }
+    }
+    env
+}
+
+fn shape_context_can_reduce_rounds(signature: &ShapeSignature, capacity: usize) -> bool {
+    // At least two equal-width products must fit in one backend session. Width
+    // zero carries no interactive work; an oversized width is already forced to
+    // span backend sessions and cannot profit from static coalescing here.
+    signature.0.iter().any(|shape| {
+        shape
+            .count()
+            .is_some_and(|width| width > 0 && width <= capacity / 2)
+    })
+}
+
+#[derive(Clone)]
+struct ShapeCallContext {
+    ordinal: usize,
+    callee: String,
+    signature: ShapeSignature,
+}
+
+fn collect_shape_call_contexts(
+    node: &AstNode,
+    env: &mut LenEnv,
+    templates: &HashMap<String, ShapeFunctionTemplate>,
+    useful: &HashSet<String>,
+    out: &mut Vec<ShapeCallContext>,
+    call_ordinal: &mut usize,
+    fuel: &mut usize,
+) {
+    match node {
+        AstNode::Block(statements) => {
+            for statement in statements {
+                collect_shape_call_contexts(
+                    statement,
+                    env,
+                    templates,
+                    useful,
+                    out,
+                    call_ordinal,
+                    fuel,
+                );
+                if !transfer_len_env(statement, env, fuel) {
+                    // Precision loss only disables specialization. Never retain
+                    // a fact after the abstract interpreter declined the proof.
+                    *env = LenEnv::default();
+                    *fuel = 0;
+                }
+            }
+        }
+        AstNode::FunctionDefinition { .. } => {}
+        AstNode::FunctionCall { arguments, .. } => {
+            let ordinal = *call_ordinal;
+            *call_ordinal = call_ordinal.saturating_add(1);
+            if let Some(name) = call_name(node) {
+                if useful.contains(name) {
+                    if let Some(signature) =
+                        shape_signature_for_call(name, arguments, env, templates)
+                    {
+                        out.push(ShapeCallContext {
+                            ordinal,
+                            callee: name.to_string(),
+                            signature,
+                        });
+                    }
+                }
+            }
+            for argument in arguments {
+                collect_shape_call_contexts(
+                    argument,
+                    env,
+                    templates,
+                    useful,
+                    out,
+                    call_ordinal,
+                    fuel,
+                );
+            }
+        }
+        AstNode::ForLoop {
+            variables,
+            iterable,
+            body,
+            ..
+        } => {
+            collect_shape_call_contexts(iterable, env, templates, useful, out, call_ordinal, fuel);
+            let mut body_env = scoped_len_env(env, &[body, iterable]);
+            bind_loop_var(&mut body_env, variables, iterable);
+            collect_shape_call_contexts(
+                body,
+                &mut body_env,
+                templates,
+                useful,
+                out,
+                call_ordinal,
+                fuel,
+            );
+        }
+        AstNode::WhileLoop {
+            condition, body, ..
+        } => {
+            collect_shape_call_contexts(condition, env, templates, useful, out, call_ordinal, fuel);
+            let mut body_env = scoped_len_env(env, &[body]);
+            collect_shape_call_contexts(
+                body,
+                &mut body_env,
+                templates,
+                useful,
+                out,
+                call_ordinal,
+                fuel,
+            );
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            collect_shape_call_contexts(condition, env, templates, useful, out, call_ordinal, fuel);
+            let mut then_env = scoped_len_env(env, &[then_branch]);
+            collect_shape_call_contexts(
+                then_branch,
+                &mut then_env,
+                templates,
+                useful,
+                out,
+                call_ordinal,
+                fuel,
+            );
+            if let Some(branch) = else_branch {
+                let mut else_env = scoped_len_env(env, &[branch]);
+                collect_shape_call_contexts(
+                    branch,
+                    &mut else_env,
+                    templates,
+                    useful,
+                    out,
+                    call_ordinal,
+                    fuel,
+                );
+            }
+        }
+        _ => for_each_child(node, &mut |child| {
+            collect_shape_call_contexts(child, env, templates, useful, out, call_ordinal, fuel)
+        }),
+    }
+}
+
+fn rewrite_shape_specialized_calls(
+    node: AstNode,
+    env: &mut LenEnv,
+    templates: &HashMap<String, ShapeFunctionTemplate>,
+    variants: &HashMap<(String, ShapeSignature), String>,
+    fuel: &mut usize,
+) -> AstNode {
+    match node {
+        AstNode::Block(statements) => {
+            let mut rewritten = Vec::with_capacity(statements.len());
+            for statement in statements {
+                let statement =
+                    rewrite_shape_specialized_calls(statement, env, templates, variants, fuel);
+                if !transfer_len_env(&statement, env, fuel) {
+                    *env = LenEnv::default();
+                    *fuel = 0;
+                }
+                rewritten.push(statement);
+            }
+            AstNode::Block(rewritten)
+        }
+        AstNode::FunctionCall {
+            function,
+            arguments,
+            location,
+            resolved_return_type,
+        } => {
+            let replacement = if let AstNode::Identifier(name, call_location) = function.as_ref() {
+                shape_signature_for_call(name, &arguments, env, templates)
+                    .and_then(|signature| variants.get(&(name.clone(), signature)))
+                    .map(|variant| AstNode::Identifier(variant.clone(), call_location.clone()))
+            } else {
+                None
+            };
+            let function = replacement.unwrap_or_else(|| *function);
+            let arguments = arguments
+                .into_iter()
+                .map(|argument| {
+                    rewrite_shape_specialized_calls(argument, env, templates, variants, fuel)
+                })
+                .collect();
+            AstNode::FunctionCall {
+                function: Box::new(function),
+                arguments,
+                location,
+                resolved_return_type,
+            }
+        }
+        AstNode::ForLoop {
+            variables,
+            iterable,
+            body,
+            location,
+        } => {
+            let iterable = Box::new(rewrite_shape_specialized_calls(
+                *iterable, env, templates, variants, fuel,
+            ));
+            let mut body_env = scoped_len_env(env, &[&body, &iterable]);
+            bind_loop_var(&mut body_env, &variables, &iterable);
+            let body = Box::new(rewrite_shape_specialized_calls(
+                *body,
+                &mut body_env,
+                templates,
+                variants,
+                fuel,
+            ));
+            AstNode::ForLoop {
+                variables,
+                iterable,
+                body,
+                location,
+            }
+        }
+        AstNode::WhileLoop {
+            condition,
+            body,
+            location,
+        } => {
+            let condition = Box::new(rewrite_shape_specialized_calls(
+                *condition, env, templates, variants, fuel,
+            ));
+            let mut body_env = scoped_len_env(env, &[&body]);
+            let body = Box::new(rewrite_shape_specialized_calls(
+                *body,
+                &mut body_env,
+                templates,
+                variants,
+                fuel,
+            ));
+            AstNode::WhileLoop {
+                condition,
+                body,
+                location,
+            }
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            let condition = Box::new(rewrite_shape_specialized_calls(
+                *condition, env, templates, variants, fuel,
+            ));
+            let mut then_env = scoped_len_env(env, &[&then_branch]);
+            let then_branch = Box::new(rewrite_shape_specialized_calls(
+                *then_branch,
+                &mut then_env,
+                templates,
+                variants,
+                fuel,
+            ));
+            let else_branch = else_branch.map(|branch| {
+                let mut else_env = scoped_len_env(env, &[&branch]);
+                Box::new(rewrite_shape_specialized_calls(
+                    *branch,
+                    &mut else_env,
+                    templates,
+                    variants,
+                    fuel,
+                ))
+            });
+            AstNode::IfExpression {
+                condition,
+                then_branch,
+                else_branch,
+            }
+        }
+        AstNode::FunctionDefinition { .. } => node,
+        other => map_children(other, &mut |child| {
+            rewrite_shape_specialized_calls(child, env, templates, variants, fuel)
+        }),
+    }
+}
+
+/// Rewrite using the exact call-site contexts already computed during variant
+/// discovery. The body is unchanged between discovery and cloning, so preorder
+/// call ordinals are stable and avoid running the same shape interpreter a
+/// second time merely to rediscover identical signatures.
+fn rewrite_shape_specialized_calls_from_context(
+    node: AstNode,
+    contexts: &[ShapeCallContext],
+    variants: &HashMap<(String, ShapeSignature), String>,
+) -> AstNode {
+    let replacements: HashMap<usize, String> = contexts
+        .iter()
+        .filter_map(|context| {
+            variants
+                .get(&(context.callee.clone(), context.signature.clone()))
+                .cloned()
+                .map(|variant| (context.ordinal, variant))
+        })
+        .collect();
+
+    fn rewrite(
+        node: AstNode,
+        replacements: &HashMap<usize, String>,
+        call_ordinal: &mut usize,
+    ) -> AstNode {
+        match node {
+            AstNode::FunctionCall {
+                function,
+                arguments,
+                location,
+                resolved_return_type,
+            } => {
+                let ordinal = *call_ordinal;
+                *call_ordinal = call_ordinal.saturating_add(1);
+                let function = match (replacements.get(&ordinal), *function) {
+                    (Some(variant), AstNode::Identifier(_, call_location)) => {
+                        AstNode::Identifier(variant.clone(), call_location)
+                    }
+                    (_, function) => function,
+                };
+                AstNode::FunctionCall {
+                    function: Box::new(function),
+                    arguments: arguments
+                        .into_iter()
+                        .map(|argument| rewrite(argument, replacements, call_ordinal))
+                        .collect(),
+                    location,
+                    resolved_return_type,
+                }
+            }
+            // The discovery traversal treats nested functions as separate
+            // templates, so their call ordinals belong to their own context.
+            AstNode::FunctionDefinition { .. } => node,
+            other => map_children(other, &mut |child| {
+                rewrite(child, replacements, call_ordinal)
+            }),
+        }
+    }
+
+    let mut call_ordinal = 0;
+    rewrite(node, &replacements, &mut call_ordinal)
+}
+
+fn shape_variant_stem(name: &str) -> String {
+    name.chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '_' {
+                character
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn specialize_mpc_call_shapes(root: AstNode) -> AstNode {
+    SPECIALIZED_FUNCTION_SHAPES.with(|shapes| shapes.borrow_mut().clear());
+    let Some(capacity) = multiply_batch_capacity() else {
+        return root;
+    };
+    if capacity < 2 {
+        return root;
+    }
+    let templates = gather_shape_function_templates(&root);
+    let useful = shape_specialization_reachable(&templates);
+    if useful.is_empty() {
+        return root;
+    }
+
+    let program_size = program_code_size(&root);
+    let growth_budget =
+        (program_size / MPC_SHAPE_GROWTH_DENOMINATOR).min(MPC_SHAPE_MAX_ADDED_NODES);
+    if growth_budget == 0 {
+        return root;
+    }
+
+    let mut queue = std::collections::VecDeque::new();
+    let mut analyzed = HashSet::<(String, ShapeSignature)>::new();
+    // Analyze each useful generic body once. These are discovery contexts only;
+    // the all-unknown signature never creates a variant.
+    let mut names: Vec<String> = useful.iter().cloned().collect();
+    names.sort();
+    for name in names {
+        let arity = templates[&name].parameters.len();
+        queue.push_back((name, ShapeSignature(vec![Shape::Unknown; arity])));
+    }
+
+    let mut accepted = Vec::<(String, ShapeSignature)>::new();
+    let mut accepted_set = HashSet::<(String, ShapeSignature)>::new();
+    let mut variants_per_function = HashMap::<String, usize>::new();
+    let mut discovered_calls = HashMap::<(String, ShapeSignature), Vec<ShapeCallContext>>::new();
+    let mut added_nodes = 0usize;
+    let mut analyzed_contexts = 0usize;
+    let mut discovery_body_nodes = 0usize;
+    let mut discovery_transfer_steps = 0usize;
+
+    while let Some((name, signature)) = queue.pop_front() {
+        let analysis_key = (name.clone(), signature.clone());
+        if !analyzed.insert(analysis_key.clone()) {
+            continue;
+        }
+        let Some(template) = templates.get(&name) else {
+            continue;
+        };
+        // A shape-sensitive leaf cannot discover a callee context. Its variants
+        // are created from the concrete call sites found in its callers, so
+        // interpreting the leaf here only burns the per-context transfer budget
+        // without changing the accepted variant set.
+        if !template.calls.iter().any(|callee| useful.contains(callee)) {
+            continue;
+        }
+        analyzed_contexts += 1;
+        discovery_body_nodes = discovery_body_nodes.saturating_add(template.size);
+        let mut env = seed_shape_function_env(template, &signature);
+        let mut contexts = Vec::new();
+        let mut call_ordinal = 0usize;
+        let mut fuel = 500_000usize;
+        collect_shape_call_contexts(
+            &template.body,
+            &mut env,
+            &templates,
+            &useful,
+            &mut contexts,
+            &mut call_ordinal,
+            &mut fuel,
+        );
+        discovery_transfer_steps =
+            discovery_transfer_steps.saturating_add(500_000usize.saturating_sub(fuel));
+        discovered_calls.insert(analysis_key, contexts.clone());
+        for context in contexts {
+            let callee = context.callee;
+            let signature = context.signature;
+            let key = (callee.clone(), signature.clone());
+            if analyzed.contains(&key) || accepted_set.contains(&key) {
+                continue;
+            }
+            let Some(callee_template) = templates.get(&callee) else {
+                continue;
+            };
+            let count = variants_per_function.get(&callee).copied().unwrap_or(0);
+            let fits_policy = accepted.len() < MPC_SHAPE_MAX_VARIANTS_TOTAL
+                && count < MPC_SHAPE_MAX_VARIANTS_PER_FUNCTION
+                && added_nodes.saturating_add(callee_template.size) <= growth_budget
+                && shape_context_can_reduce_rounds(&signature, capacity);
+            if !fits_policy {
+                continue;
+            }
+            added_nodes = added_nodes.saturating_add(callee_template.size);
+            variants_per_function.insert(callee.clone(), count + 1);
+            accepted_set.insert(key.clone());
+            accepted.push(key.clone());
+            queue.push_back(key);
+        }
+    }
+    if accepted.is_empty() {
+        if opt_timing_enabled() {
+            eprintln!(
+                "[opt-work] specialize_mpc_call_shapes: templates={} useful={} contexts={analyzed_contexts} discovery_nodes={discovery_body_nodes} transfer_steps={discovery_transfer_steps} variants=0 added_nodes=0",
+                templates.len(),
+                useful.len(),
+            );
+        }
+        return root;
+    }
+
+    let mut occupied: HashSet<String> = templates.keys().cloned().collect();
+    let mut variants = HashMap::<(String, ShapeSignature), String>::new();
+    for (ordinal, key) in accepted.iter().cloned().enumerate() {
+        let stem = shape_variant_stem(&key.0);
+        let mut discriminator = ordinal;
+        let variant = loop {
+            let candidate = format!("__stoffel_mpc_shape_{stem}_{discriminator}");
+            if occupied.insert(candidate.clone()) {
+                break candidate;
+            }
+            discriminator += 1;
+        };
+        variants.insert(key, variant);
+    }
+    let accepted_bases: HashSet<String> = accepted.iter().map(|(name, _)| name.clone()).collect();
+
+    let AstNode::Block(statements) = root else {
+        return root;
+    };
+    let mut expanded = Vec::with_capacity(statements.len() + accepted.len());
+    let mut top_env = LenEnv::default();
+    let mut top_fuel = 500_000usize;
+    let mut rewrite_body_nodes = 0usize;
+    let mut rewrite_transfer_steps = 0usize;
+    for statement in statements {
+        let AstNode::FunctionDefinition {
+            name: Some(name),
+            type_params,
+            parameters,
+            return_type,
+            body,
+            is_secret,
+            pragmas,
+            location,
+            node_id,
+        } = statement
+        else {
+            let statement = rewrite_shape_specialized_calls(
+                statement,
+                &mut top_env,
+                &templates,
+                &variants,
+                &mut top_fuel,
+            );
+            if !transfer_len_env(&statement, &mut top_env, &mut top_fuel) {
+                top_env = LenEnv::default();
+                top_fuel = 0;
+            }
+            expanded.push(statement);
+            continue;
+        };
+
+        let Some(template) = templates.get(&name) else {
+            expanded.push(AstNode::FunctionDefinition {
+                name: Some(name),
+                type_params,
+                parameters,
+                return_type,
+                body,
+                is_secret,
+                pragmas,
+                location,
+                node_id,
+            });
+            continue;
+        };
+
+        let can_rewrite_call = template
+            .calls
+            .iter()
+            .any(|callee| accepted_bases.contains(callee));
+        let generic_body = if can_rewrite_call {
+            rewrite_body_nodes = rewrite_body_nodes.saturating_add(template.size);
+            let generic_key = (
+                name.clone(),
+                ShapeSignature(vec![Shape::Unknown; parameters.len()]),
+            );
+            if let Some(contexts) = discovered_calls.get(&generic_key) {
+                rewrite_shape_specialized_calls_from_context(*body, contexts, &variants)
+            } else {
+                // A missing cache entry is not expected for a useful caller,
+                // but recomputing retains the old fail-closed behavior.
+                let mut generic_env = LenEnv::default();
+                let mut generic_fuel = 500_000usize;
+                let rewritten = rewrite_shape_specialized_calls(
+                    *body,
+                    &mut generic_env,
+                    &templates,
+                    &variants,
+                    &mut generic_fuel,
+                );
+                rewrite_transfer_steps = rewrite_transfer_steps
+                    .saturating_add(500_000usize.saturating_sub(generic_fuel));
+                rewritten
+            }
+        } else {
+            *body
+        };
+        expanded.push(AstNode::FunctionDefinition {
+            name: Some(name.clone()),
+            type_params: type_params.clone(),
+            parameters: parameters.clone(),
+            return_type: return_type.clone(),
+            body: Box::new(generic_body),
+            is_secret,
+            pragmas: pragmas.clone(),
+            location: location.clone(),
+            node_id,
+        });
+
+        for key @ (base, signature) in &accepted {
+            if base != &name {
+                continue;
+            }
+            let variant = &variants[key];
+            let variant_body = if can_rewrite_call {
+                rewrite_body_nodes = rewrite_body_nodes.saturating_add(template.size);
+                if let Some(contexts) = discovered_calls.get(key) {
+                    rewrite_shape_specialized_calls_from_context(
+                        template.body.clone(),
+                        contexts,
+                        &variants,
+                    )
+                } else {
+                    let mut variant_env = seed_shape_function_env(template, signature);
+                    let mut variant_fuel = 500_000usize;
+                    let rewritten = rewrite_shape_specialized_calls(
+                        template.body.clone(),
+                        &mut variant_env,
+                        &templates,
+                        &variants,
+                        &mut variant_fuel,
+                    );
+                    rewrite_transfer_steps = rewrite_transfer_steps
+                        .saturating_add(500_000usize.saturating_sub(variant_fuel));
+                    rewritten
+                }
+            } else {
+                template.body.clone()
+            };
+            SPECIALIZED_FUNCTION_SHAPES.with(|shapes| {
+                shapes
+                    .borrow_mut()
+                    .insert(variant.clone(), signature.0.clone());
+            });
+            expanded.push(AstNode::FunctionDefinition {
+                name: Some(variant.clone()),
+                type_params: type_params.clone(),
+                parameters: parameters.clone(),
+                return_type: return_type.clone(),
+                body: Box::new(variant_body),
+                is_secret,
+                pragmas: pragmas.clone(),
+                location: location.clone(),
+                node_id,
+            });
+        }
+    }
+    rewrite_transfer_steps =
+        rewrite_transfer_steps.saturating_add(500_000usize.saturating_sub(top_fuel));
+    if opt_timing_enabled() {
+        eprintln!(
+            "[opt-work] specialize_mpc_call_shapes: templates={} useful={} contexts={analyzed_contexts} discovery_nodes={discovery_body_nodes} transfer_steps={discovery_transfer_steps} variants={} added_nodes={added_nodes} rewrite_nodes={rewrite_body_nodes} rewrite_transfer_steps={rewrite_transfer_steps}",
+            templates.len(),
+            useful.len(),
+            accepted.len(),
+        );
+    }
+    AstNode::Block(expanded)
+}
+
+fn specialized_function_env(name: Option<&str>, parameters: &[crate::ast::Parameter]) -> LenEnv {
+    let Some(name) = name else {
+        return LenEnv::default();
+    };
+    SPECIALIZED_FUNCTION_SHAPES.with(|shapes| {
+        let shapes = shapes.borrow();
+        let Some(signature) = shapes.get(name) else {
+            return LenEnv::default();
+        };
+        let mut env = LenEnv::default();
+        for (parameter, shape) in parameters.iter().zip(signature) {
+            if !matches!(shape, Shape::Unknown) {
+                env.shapes.insert(parameter.name.clone(), shape.clone());
+            }
+        }
+        env
+    })
+}
+
+/// Re-run the exact shape interpreter over specialized bodies after loop
+/// vectorization. This covers both batches synthesized by the vectorizer and
+/// pre-existing `Share.batch_mul` calls whose operand lists are built by public
+/// loops inside the callee. Width metadata is a proof sidecar only; failure to
+/// execute any construct simply stops recording facts for that path.
+fn record_specialized_batch_widths(node: &AstNode) {
+    fn walk(node: &AstNode, env: &mut LenEnv, fuel: &mut usize) -> bool {
+        match node {
+            AstNode::Block(statements) => {
+                for statement in statements {
+                    match statement {
+                        AstNode::IfExpression {
+                            condition,
+                            then_branch,
+                            else_branch,
+                        } => match const_eval_bool_env(condition, env) {
+                            Some(true) => {
+                                let mut branch_env = env.clone();
+                                if !walk(then_branch, &mut branch_env, fuel) {
+                                    return false;
+                                }
+                            }
+                            Some(false) => {
+                                if let Some(branch) = else_branch {
+                                    let mut branch_env = env.clone();
+                                    if !walk(branch, &mut branch_env, fuel) {
+                                        return false;
+                                    }
+                                }
+                            }
+                            None => {}
+                        },
+                        AstNode::ForLoop {
+                            variables,
+                            iterable,
+                            body,
+                            ..
+                        } => {
+                            let mut body_env = scoped_len_env(env, &[body, iterable]);
+                            bind_loop_var(&mut body_env, variables, iterable);
+                            // Recording inside a loop is useful only when the
+                            // local context itself proves a width. The transfer
+                            // below remains the authority for post-loop facts.
+                            let _ = walk(body, &mut body_env, fuel);
+                        }
+                        AstNode::WhileLoop { body, .. } => {
+                            let mut body_env = scoped_len_env(env, &[body]);
+                            let _ = walk(body, &mut body_env, fuel);
+                        }
+                        _ => {}
+                    }
+                    if !transfer_len_env(statement, env, fuel) {
+                        return false;
+                    }
+                    record_batch_result_width_from_env(statement, env);
+                }
+                true
+            }
+            other => {
+                if !transfer_len_env(other, env, fuel) {
+                    return false;
+                }
+                record_batch_result_width_from_env(other, env);
+                true
+            }
+        }
+    }
+
+    let AstNode::Block(statements) = node else {
+        return;
+    };
+    for statement in statements {
+        let AstNode::FunctionDefinition {
+            name: Some(name),
+            parameters,
+            body,
+            ..
+        } = statement
+        else {
+            continue;
+        };
+        let is_specialized =
+            SPECIALIZED_FUNCTION_SHAPES.with(|shapes| shapes.borrow().contains_key(name));
+        if !is_specialized {
+            continue;
+        }
+        let mut env = specialized_function_env(Some(name), parameters);
+        let mut fuel = 500_000usize;
+        let _ = walk(body, &mut env, &mut fuel);
+    }
 }
 
 // ===========================================================================
@@ -2549,19 +3766,141 @@ pub fn optimize_all_with_budgets(
 // multiplies into wider batches (identical netlist, different round).
 // ===========================================================================
 
+#[derive(Debug, Clone, Copy, Default)]
+struct VectorizeWork {
+    statements: u64,
+    loop_candidates: u64,
+    prefilter_steps: u64,
+    prefilter_exhaustions: u64,
+    assignment_prefilter_steps: u64,
+    assignment_prefilter_exhaustions: u64,
+    nonlocal_assignment_rejections: u64,
+    multiply_candidates: u64,
+    flattened_candidates: u64,
+    local_unroll_steps: u64,
+    flattened_statements: u64,
+    post_flatten_multiply_candidates: u64,
+    straight_line_candidates: u64,
+    recognition_failures: u64,
+    vectorized_loops: u64,
+    transfer_steps: u64,
+    scoped_env_entries: u64,
+}
+
+fn vectorizer_transfer_len_env(
+    node: &AstNode,
+    env: &mut LenEnv,
+    fuel: &mut usize,
+    work: &mut VectorizeWork,
+) -> bool {
+    let before = *fuel;
+    let result = transfer_len_env(node, env, fuel);
+    work.transfer_steps = work
+        .transfer_steps
+        .saturating_add(before.saturating_sub(*fuel) as u64);
+    result
+}
+
 /// -O3 entry point: structurally recurse, vectorizing eligible map-loops in place.
 pub fn vectorize_map_loops(node: AstNode) -> AstNode {
+    let mut env = LenEnv::default();
+    let mut fuel = 500_000usize;
+    let mut work = VectorizeWork::default();
+    let out = vectorize_map_loops_with_env(node, &mut env, &mut fuel, &mut work);
+    if opt_timing_enabled() {
+        eprintln!(
+            "[opt-work] vectorize_map_loops: statements={} loop_candidates={} prefilter_steps={} prefilter_exhaustions={} assignment_prefilter_steps={} assignment_prefilter_exhaustions={} nonlocal_assignment_rejections={} multiply_candidates={} flattened_candidates={} local_unroll_steps={} flattened_statements={} post_flatten_multiply_candidates={} straight_line_candidates={} recognition_failures={} vectorized_loops={} transfer_steps={} scoped_env_entries={}",
+            work.statements,
+            work.loop_candidates,
+            work.prefilter_steps,
+            work.prefilter_exhaustions,
+            work.assignment_prefilter_steps,
+            work.assignment_prefilter_exhaustions,
+            work.nonlocal_assignment_rejections,
+            work.multiply_candidates,
+            work.flattened_candidates,
+            work.local_unroll_steps,
+            work.flattened_statements,
+            work.post_flatten_multiply_candidates,
+            work.straight_line_candidates,
+            work.recognition_failures,
+            work.vectorized_loops,
+            work.transfer_steps,
+            work.scoped_env_entries,
+        );
+    }
+    out
+}
+
+fn vectorize_map_loops_with_env(
+    node: AstNode,
+    env: &mut LenEnv,
+    fuel: &mut usize,
+    work: &mut VectorizeWork,
+) -> AstNode {
     match node {
         AstNode::Block(stmts) => {
             let mut out: Vec<AstNode> = Vec::with_capacity(stmts.len());
             for stmt in stmts {
+                work.statements = work.statements.saturating_add(1);
                 if matches!(stmt, AstNode::ForLoop { .. }) {
-                    if let Some(replacement) = try_vectorize_for(&stmt) {
+                    work.loop_candidates = work.loop_candidates.saturating_add(1);
+                    let width = match &stmt {
+                        AstNode::ForLoop { iterable, .. } => range_bounds(iterable, env)
+                            .and_then(|(lo, hi)| hi.checked_sub(lo))
+                            .and_then(|n| usize::try_from(n).ok()),
+                        _ => None,
+                    };
+                    if let Some(replacement) = try_vectorize_for_with_width(&stmt, width, work) {
+                        work.vectorized_loops = work.vectorized_loops.saturating_add(1);
+                        // Update from the original loop: the replacement is
+                        // semantics-equivalent, while the source form is easier
+                        // for the exact shape interpreter to understand.
+                        if !vectorizer_transfer_len_env(&stmt, env, fuel, work) {
+                            *env = LenEnv::default();
+                            *fuel = 0;
+                        }
                         out.extend(replacement);
                         continue;
                     }
                 }
-                out.push(vectorize_map_loops(stmt));
+                let needs_entry_env = matches!(
+                    stmt,
+                    AstNode::Block(_)
+                        | AstNode::ForLoop { .. }
+                        | AstNode::WhileLoop { .. }
+                        | AstNode::IfExpression { .. }
+                        | AstNode::TryCatch { .. }
+                );
+                // A recursive walk can only query identifiers present in its
+                // subtree. Copy just those entry facts instead of the entire
+                // accumulated function environment; cloning the latter at every
+                // nested scope is quadratic in long alpha-renamed functions.
+                // Function definitions build their own parameter environment in
+                // the match arm below and need no caller snapshot at all.
+                let mut nested_env = needs_entry_env.then(|| {
+                    let scoped = scoped_len_env(env, &[&stmt]);
+                    work.scoped_env_entries = work.scoped_env_entries.saturating_add(
+                        (scoped.shapes.len() + scoped.ints.len() + scoped.aliases.len()) as u64,
+                    );
+                    scoped
+                });
+                if !vectorizer_transfer_len_env(&stmt, env, fuel, work) {
+                    // Shape knowledge is only a profitability/work proof. Losing
+                    // it leaves the program unchanged and makes later batching
+                    // fail closed; it must never become a guessed width.
+                    *env = LenEnv::default();
+                    *fuel = 0;
+                } else {
+                    record_batch_result_width_from_env(&stmt, env);
+                }
+                if matches!(stmt, AstNode::FunctionDefinition { .. }) {
+                    out.push(vectorize_map_loops_with_env(stmt, env, fuel, work));
+                } else if let Some(nested_env) = &mut nested_env {
+                    out.push(vectorize_map_loops_with_env(stmt, nested_env, fuel, work));
+                } else {
+                    out.push(stmt);
+                }
             }
             AstNode::Block(out)
         }
@@ -2575,17 +3914,26 @@ pub fn vectorize_map_loops(node: AstNode) -> AstNode {
             pragmas,
             location,
             node_id,
-        } => AstNode::FunctionDefinition {
-            name,
-            type_params,
-            parameters,
-            return_type,
-            body: Box::new(vectorize_map_loops(*body)),
-            is_secret,
-            pragmas,
-            location,
-            node_id,
-        },
+        } => {
+            let mut function_env = specialized_function_env(name.as_deref(), &parameters);
+            let mut function_fuel = 500_000usize;
+            AstNode::FunctionDefinition {
+                name,
+                type_params,
+                parameters,
+                return_type,
+                body: Box::new(vectorize_map_loops_with_env(
+                    *body,
+                    &mut function_env,
+                    &mut function_fuel,
+                    work,
+                )),
+                is_secret,
+                pragmas,
+                location,
+                node_id,
+            }
+        }
         AstNode::ForLoop {
             variables,
             iterable,
@@ -2594,7 +3942,7 @@ pub fn vectorize_map_loops(node: AstNode) -> AstNode {
         } => AstNode::ForLoop {
             variables,
             iterable,
-            body: Box::new(vectorize_map_loops(*body)),
+            body: Box::new(vectorize_map_loops_with_env(*body, env, fuel, work)),
             location,
         },
         AstNode::WhileLoop {
@@ -2603,7 +3951,7 @@ pub fn vectorize_map_loops(node: AstNode) -> AstNode {
             location,
         } => AstNode::WhileLoop {
             condition,
-            body: Box::new(vectorize_map_loops(*body)),
+            body: Box::new(vectorize_map_loops_with_env(*body, env, fuel, work)),
             location,
         },
         AstNode::IfExpression {
@@ -2612,8 +3960,9 @@ pub fn vectorize_map_loops(node: AstNode) -> AstNode {
             else_branch,
         } => AstNode::IfExpression {
             condition,
-            then_branch: Box::new(vectorize_map_loops(*then_branch)),
-            else_branch: else_branch.map(|e| Box::new(vectorize_map_loops(*e))),
+            then_branch: Box::new(vectorize_map_loops_with_env(*then_branch, env, fuel, work)),
+            else_branch: else_branch
+                .map(|e| Box::new(vectorize_map_loops_with_env(*e, env, fuel, work))),
         },
         AstNode::TryCatch {
             try_block,
@@ -2621,9 +3970,16 @@ pub fn vectorize_map_loops(node: AstNode) -> AstNode {
             finally_block,
             location,
         } => AstNode::TryCatch {
-            try_block: Box::new(vectorize_map_loops(*try_block)),
-            catch_clauses,
-            finally_block: finally_block.map(|b| Box::new(vectorize_map_loops(*b))),
+            try_block: Box::new(vectorize_map_loops_with_env(*try_block, env, fuel, work)),
+            catch_clauses: catch_clauses
+                .into_iter()
+                .map(|c| crate::ast::CatchClause {
+                    body: Box::new(vectorize_map_loops_with_env(*c.body, env, fuel, work)),
+                    ..c
+                })
+                .collect(),
+            finally_block: finally_block
+                .map(|b| Box::new(vectorize_map_loops_with_env(*b, env, fuel, work))),
             location,
         },
         other => other,
@@ -2672,6 +4028,348 @@ fn vec_stmt_contains_multiply(stmt: &AstNode) -> bool {
     }
 }
 
+const VECTORIZER_PREFILTER_BUDGET: usize = 1_024;
+
+/// Bounded recursive search used before the expensive local unroller. `None`
+/// means the fixed budget was exhausted, in which case the caller must retain
+/// the candidate. A fixed per-loop budget makes the total prefilter work
+/// O(number of AST nodes), even for adversarially deep loop nesting.
+fn vec_bounded_contains_multiply(node: &AstNode, budget: &mut usize) -> Option<bool> {
+    if *budget == 0 {
+        return None;
+    }
+    *budget -= 1;
+
+    if matches!(
+        node,
+        AstNode::BinaryOperation { op, .. } if matches!(op.as_str(), "xor" | "and" | "or")
+    ) || matches!(
+        node,
+        AstNode::FunctionCall { .. }
+            if matches!(call_name(node).map(builtin_base_name), Some("mul") | Some("batch_mul"))
+    ) {
+        return Some(true);
+    }
+
+    let mut exhausted = false;
+    macro_rules! scan_child {
+        ($child:expr) => {
+            match vec_bounded_contains_multiply($child, budget) {
+                Some(true) => return Some(true),
+                Some(false) => {}
+                None => exhausted = true,
+            }
+        };
+    }
+
+    match node {
+        AstNode::Assignment { target, value, .. } => {
+            scan_child!(target);
+            scan_child!(value);
+        }
+        AstNode::VariableDeclaration {
+            type_annotation,
+            value,
+            ..
+        } => {
+            if let Some(node) = type_annotation {
+                scan_child!(node);
+            }
+            if let Some(node) = value {
+                scan_child!(node);
+            }
+        }
+        AstNode::BinaryOperation { left, right, .. }
+        | AstNode::IndexAccess {
+            base: left,
+            index: right,
+            ..
+        }
+        | AstNode::DictType {
+            key_type: left,
+            value_type: right,
+            ..
+        } => {
+            scan_child!(left);
+            scan_child!(right);
+        }
+        AstNode::UnaryOperation { operand, .. }
+        | AstNode::FieldAccess {
+            object: operand, ..
+        }
+        | AstNode::NamedArgument { value: operand, .. }
+        | AstNode::TypeAlias {
+            target_type: operand,
+            ..
+        }
+        | AstNode::SecretType(operand)
+        | AstNode::ListType(operand)
+        | AstNode::DiscardStatement {
+            expression: operand,
+            ..
+        } => scan_child!(operand),
+        AstNode::FunctionCall {
+            function,
+            arguments,
+            ..
+        }
+        | AstNode::CommandCall {
+            command: function,
+            arguments,
+            ..
+        } => {
+            scan_child!(function);
+            for argument in arguments {
+                scan_child!(argument);
+            }
+        }
+        AstNode::FunctionDefinition {
+            parameters,
+            return_type,
+            body,
+            pragmas,
+            ..
+        } => {
+            for parameter in parameters {
+                if let Some(node) = &parameter.type_annotation {
+                    scan_child!(node);
+                }
+                if let Some(node) = &parameter.default_value {
+                    scan_child!(node);
+                }
+            }
+            if let Some(node) = return_type {
+                scan_child!(node);
+            }
+            for pragma in pragmas {
+                if let crate::ast::Pragma::KeyValue(_, value, _) = pragma {
+                    scan_child!(value);
+                }
+            }
+            scan_child!(body);
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            scan_child!(condition);
+            scan_child!(then_branch);
+            if let Some(node) = else_branch {
+                scan_child!(node);
+            }
+        }
+        AstNode::WhileLoop {
+            condition, body, ..
+        } => {
+            scan_child!(condition);
+            scan_child!(body);
+        }
+        AstNode::ForLoop { iterable, body, .. } => {
+            scan_child!(iterable);
+            scan_child!(body);
+        }
+        AstNode::Block(nodes)
+        | AstNode::TupleLiteral(nodes)
+        | AstNode::SetLiteral(nodes)
+        | AstNode::TupleType(nodes) => {
+            for node in nodes {
+                scan_child!(node);
+            }
+        }
+        AstNode::Return { value, .. } | AstNode::Yield(value) => {
+            if let Some(node) = value {
+                scan_child!(node);
+            }
+        }
+        AstNode::ListLiteral { elements, .. } => {
+            for node in elements {
+                scan_child!(node);
+            }
+        }
+        AstNode::DictLiteral { pairs, .. } => {
+            for (key, value) in pairs {
+                scan_child!(key);
+                scan_child!(value);
+            }
+        }
+        AstNode::BuiltinTypeDefinition { target_type, .. } => {
+            if let Some(node) = target_type {
+                scan_child!(node);
+            }
+        }
+        AstNode::BuiltinObjectDefinition { methods, .. } => {
+            for node in methods {
+                scan_child!(node);
+            }
+        }
+        AstNode::ObjectDefinition {
+            base_type, fields, ..
+        } => {
+            if let Some(node) = base_type {
+                scan_child!(node);
+            }
+            for field in fields {
+                scan_child!(&field.type_annotation);
+            }
+        }
+        AstNode::EnumDefinition { members, .. } => {
+            for member in members {
+                if let Some(node) = &member.value {
+                    scan_child!(node);
+                }
+            }
+        }
+        AstNode::FunctionType {
+            parameter_types,
+            return_type,
+            ..
+        } => {
+            for node in parameter_types {
+                scan_child!(node);
+            }
+            scan_child!(return_type);
+        }
+        AstNode::GenericType { type_params, .. } => {
+            for node in type_params {
+                scan_child!(node);
+            }
+        }
+        AstNode::TryCatch {
+            try_block,
+            catch_clauses,
+            finally_block,
+            ..
+        } => {
+            scan_child!(try_block);
+            for clause in catch_clauses {
+                if let Some(node) = &clause.exception_type {
+                    scan_child!(node);
+                }
+                scan_child!(&clause.body);
+            }
+            if let Some(node) = finally_block {
+                scan_child!(node);
+            }
+        }
+        AstNode::Literal { .. }
+        | AstNode::Identifier(..)
+        | AstNode::Break
+        | AstNode::Continue
+        | AstNode::Import { .. } => {}
+    }
+
+    if exhausted {
+        None
+    } else {
+        Some(false)
+    }
+}
+
+fn vec_body_may_contain_multiply(body: &AstNode, work: &mut VectorizeWork) -> bool {
+    let mut budget = VECTORIZER_PREFILTER_BUDGET;
+    let result = vec_bounded_contains_multiply(body, &mut budget);
+    work.prefilter_steps = work
+        .prefilter_steps
+        .saturating_add((VECTORIZER_PREFILTER_BUDGET - budget) as u64);
+    if result.is_none() {
+        work.prefilter_exhaustions = work.prefilter_exhaustions.saturating_add(1);
+    }
+    result.unwrap_or(true)
+}
+
+const VECTORIZER_ASSIGNMENT_PREFILTER_BUDGET: usize = 16_384;
+
+/// Detect a loop-carried scalar write before speculative local unrolling. The
+/// vectorizer's expansion can only assign loop-local temporaries; an assignment
+/// to a name not declared earlier in the body is therefore a definitive reject.
+/// The scan is budgeted per loop, and exhaustion conservatively retains the
+/// candidate. Keeping declarations from exited nested scopes in `locals` can
+/// only cause a missed early rejection, never an incorrect rejection.
+fn vec_bounded_has_nonlocal_assignment(
+    node: &AstNode,
+    budget: &mut usize,
+    locals: &mut HashSet<String>,
+) -> Option<bool> {
+    if *budget == 0 {
+        return None;
+    }
+    *budget -= 1;
+
+    match node {
+        AstNode::FunctionDefinition { .. } => return Some(false),
+        AstNode::VariableDeclaration { name, .. } => {
+            locals.insert(name.clone());
+        }
+        AstNode::ForLoop { variables, .. } => {
+            locals.extend(variables.iter().cloned());
+        }
+        AstNode::Assignment { target, .. } => {
+            if let AstNode::Identifier(name, _) = target.as_ref() {
+                if !locals.contains(name) {
+                    return Some(true);
+                }
+            }
+        }
+        _ => {}
+    }
+
+    let mut found = false;
+    let mut exhausted = false;
+    for_each_child(node, &mut |child| {
+        if found {
+            return;
+        }
+        match vec_bounded_has_nonlocal_assignment(child, budget, locals) {
+            Some(true) => found = true,
+            Some(false) => {}
+            None => exhausted = true,
+        }
+    });
+    if found {
+        Some(true)
+    } else if exhausted {
+        None
+    } else {
+        Some(false)
+    }
+}
+
+fn vec_body_has_nonlocal_assignment(
+    body: &AstNode,
+    loop_var: &str,
+    work: &mut VectorizeWork,
+) -> bool {
+    let mut budget = VECTORIZER_ASSIGNMENT_PREFILTER_BUDGET;
+    let mut locals = HashSet::from([loop_var.to_string()]);
+    let result = vec_bounded_has_nonlocal_assignment(body, &mut budget, &mut locals);
+    work.assignment_prefilter_steps = work
+        .assignment_prefilter_steps
+        .saturating_add((VECTORIZER_ASSIGNMENT_PREFILTER_BUDGET - budget) as u64);
+    if result.is_none() {
+        work.assignment_prefilter_exhaustions =
+            work.assignment_prefilter_exhaustions.saturating_add(1);
+    }
+    result.unwrap_or(false)
+}
+
+fn vec_body_needs_local_flattening(body: &AstNode) -> bool {
+    let statements = match body {
+        AstNode::Block(statements) => statements.as_slice(),
+        statement => std::slice::from_ref(statement),
+    };
+    statements.iter().any(|statement| {
+        matches!(
+            statement,
+            AstNode::Block(_)
+                | AstNode::ForLoop { .. }
+                | AstNode::WhileLoop { .. }
+                | AstNode::IfExpression { .. }
+                | AstNode::TryCatch { .. }
+        )
+    })
+}
+
 fn is_int_literal_zero(node: &AstNode) -> bool {
     matches!(
         node,
@@ -2706,6 +4404,9 @@ struct VecCtx {
     acc_alias: HashMap<String, String>,
     /// loop-length variable name (`var __veclen = HI`).
     veclen: String,
+    /// Exact number of lanes, when proven by the surrounding block's shape
+    /// environment. Every generated lane list has this same width.
+    width: Option<usize>,
     /// (output accumulator name, committed value) — set by the single commit.
     commit: Option<(String, AstNode)>,
     empty_fns: HashSet<String>,
@@ -2721,7 +4422,7 @@ struct VecCtx {
 }
 
 impl VecCtx {
-    fn new(loop_var: String, loc: SourceLocation) -> Self {
+    fn new(loop_var: String, loc: SourceLocation, width: Option<usize>) -> Self {
         let mut locals = HashSet::new();
         locals.insert(loop_var.clone());
         VecCtx {
@@ -2733,10 +4434,17 @@ impl VecCtx {
             inner_accs: HashMap::new(),
             acc_alias: HashMap::new(),
             veclen: generate_named_temp_name("veclen"),
+            width,
             commit: None,
             empty_fns: HashSet::new(),
             locals,
             writes: HashSet::new(),
+        }
+    }
+
+    fn record_lane_width(&self, name: &str) {
+        if let Some(width) = self.width {
+            record_interactive_width(name, &self.loc, width);
         }
     }
 
@@ -2878,6 +4586,7 @@ impl VecCtx {
             return None;
         }
         let res = generate_named_temp_name("vlane");
+        self.record_lane_width(&res);
         self.emitted.push(self.empty_list_decl(&res));
         let body_expr = self.subst(expr);
         let append = self.append_stmt(&res, body_expr);
@@ -2890,6 +4599,7 @@ impl VecCtx {
     /// the boolean `op` (xor/and/or). Returns the result lane-list variable.
     fn emit_binmul(&mut self, op: &str, l: &str, r: &str) -> String {
         let prod = generate_named_temp_name("vprod");
+        self.record_lane_width(&prod);
         self.emitted.push(AstNode::VariableDeclaration {
             name: prod.clone(),
             type_annotation: None,
@@ -2907,6 +4617,7 @@ impl VecCtx {
             return prod;
         }
         let res = generate_named_temp_name(if op == "or" { "vor" } else { "vxor" });
+        self.record_lane_width(&res);
         self.emitted.push(self.empty_list_decl(&res));
         let li = self.index_lane(l);
         let ri = self.index_lane(r);
@@ -2930,6 +4641,7 @@ impl VecCtx {
     /// Emit a per-lane elementwise call `Share.<base>(a[I], b[I])`.
     fn emit_share_binary(&mut self, base: &str, a: &str, b: &str) -> String {
         let res = generate_named_temp_name("vlane");
+        self.record_lane_width(&res);
         self.emitted.push(self.empty_list_decl(&res));
         let call = make_share_binary_call(
             &format!("Share.{base}"),
@@ -3004,6 +4716,7 @@ impl VecCtx {
             // `not x` with a multiply inside x: vectorize x then negate per lane.
             let x = self.vec_of(operand)?;
             let res = generate_named_temp_name("vnot");
+            self.record_lane_width(&res);
             self.emitted.push(self.empty_list_decl(&res));
             let neg = AstNode::UnaryOperation {
                 op: "not".to_string(),
@@ -3030,6 +4743,7 @@ impl VecCtx {
                 "mul_scalar" if arguments.len() == 2 => {
                     let a = self.vec_of(&arguments[0])?;
                     let res = generate_named_temp_name("vlane");
+                    self.record_lane_width(&res);
                     self.emitted.push(self.empty_list_decl(&res));
                     let call = AstNode::FunctionCall {
                         function: Box::new(self.id("Share.mul_scalar")),
@@ -3231,7 +4945,16 @@ impl VecCtx {
 
 /// Attempt to vectorize a single `ForLoop`. Returns the replacement statements
 /// on success, or `None` to leave the loop unchanged.
+#[cfg(test)]
 fn try_vectorize_for(stmt: &AstNode) -> Option<Vec<AstNode>> {
+    try_vectorize_for_with_width(stmt, None, &mut VectorizeWork::default())
+}
+
+fn try_vectorize_for_with_width(
+    stmt: &AstNode,
+    width: Option<usize>,
+    work: &mut VectorizeWork,
+) -> Option<Vec<AstNode>> {
     let AstNode::ForLoop {
         variables,
         iterable,
@@ -3271,26 +4994,59 @@ fn try_vectorize_for(stmt: &AstNode) -> Option<Vec<AstNode>> {
         return None;
     }
 
+    // Most kept-rolled loops are public data movement. Reject them before
+    // cloning, locally unrolling, and constant-folding the body. The scan is
+    // exact for straight-line bodies and conservative for nested control flow,
+    // so it can only skip work that could not have produced a vectorization.
+    if !vec_body_may_contain_multiply(body, work) {
+        return None;
+    }
+    work.multiply_candidates = work.multiply_candidates.saturating_add(1);
+    if vec_body_has_nonlocal_assignment(body, &loop_var, work) {
+        work.nonlocal_assignment_rejections = work.nonlocal_assignment_rejections.saturating_add(1);
+        return None;
+    }
+
     // Locally flatten the body (unroll inner static loops + fold constant
     // branches) with a fresh budget, so a per-iteration gate DAG that the global
     // unroller left rolled (budget spent) becomes straight-line here.
-    let body_stmts: Vec<AstNode> = match body.as_ref() {
-        AstNode::Block(s) => s.clone(),
-        single => vec![single.clone()],
-    };
-    let mut fenv = LenEnv::default();
-    bind_loop_var(&mut fenv, variables, iterable);
-    let mut budget = UNROLL_BUDGET;
-    let flat = unroll_stmt_list(body_stmts, &mut fenv, &mut budget);
-    let flat = match fold_constant_branches(AstNode::Block(flat)) {
-        AstNode::Block(s) => s,
-        x => vec![x],
+    // Already-straight-line bodies are borrowed in place. This is the common
+    // case and avoids making a full speculative copy for candidates that later
+    // fail the dependence/commit proof.
+    let owned_flat: Vec<AstNode>;
+    let flat: &[AstNode] = if vec_body_needs_local_flattening(body) {
+        work.flattened_candidates = work.flattened_candidates.saturating_add(1);
+        let body_stmts: Vec<AstNode> = match body.as_ref() {
+            AstNode::Block(s) => s.clone(),
+            single => vec![single.clone()],
+        };
+        let mut fenv = LenEnv::default();
+        bind_loop_var(&mut fenv, variables, iterable);
+        let mut budget = UNROLL_BUDGET;
+        let unrolled = unroll_stmt_list(body_stmts, &mut fenv, &mut budget);
+        work.local_unroll_steps = work
+            .local_unroll_steps
+            .saturating_add((UNROLL_BUDGET - budget) as u64);
+        owned_flat = match fold_constant_branches(AstNode::Block(unrolled)) {
+            AstNode::Block(s) => s,
+            x => vec![x],
+        };
+        work.flattened_statements = work
+            .flattened_statements
+            .saturating_add(owned_flat.len() as u64);
+        &owned_flat
+    } else {
+        match body.as_ref() {
+            AstNode::Block(statements) => statements,
+            statement => std::slice::from_ref(statement),
+        }
     };
 
     // Nothing to gain (and nothing to risk) unless the body actually multiplies.
     if !flat.iter().any(vec_stmt_contains_multiply) {
         return None;
     }
+    work.post_flatten_multiply_candidates = work.post_flatten_multiply_candidates.saturating_add(1);
     // The flattened body must be straight-line: any residual loop/branch means
     // recognition cannot prove independence, so bail.
     if flat.iter().any(|s| {
@@ -3299,11 +5055,40 @@ fn try_vectorize_for(stmt: &AstNode) -> Option<Vec<AstNode>> {
             AstNode::ForLoop { .. } | AstNode::WhileLoop { .. } | AstNode::IfExpression { .. }
         )
     }) {
+        if opt_timing_enabled() {
+            let residual = flat
+                .iter()
+                .find(|s| {
+                    matches!(
+                        s,
+                        AstNode::ForLoop { .. }
+                            | AstNode::WhileLoop { .. }
+                            | AstNode::IfExpression { .. }
+                    )
+                })
+                .map(|s| match s {
+                    AstNode::ForLoop { location, .. } => format!("for@{location}"),
+                    AstNode::WhileLoop { location, .. } => format!("while@{location}"),
+                    AstNode::IfExpression { .. } => "if".to_string(),
+                    _ => unreachable!(),
+                })
+                .unwrap_or_default();
+            eprintln!(
+                "[opt-work] vectorizer residual control: candidate@{} flat_statements={} residual={residual}",
+                location,
+                flat.len(),
+            );
+        }
         return None;
     }
+    work.straight_line_candidates = work.straight_line_candidates.saturating_add(1);
 
-    let ctx = VecCtx::new(loop_var, location.clone());
-    ctx.run(&flat, hi)
+    let ctx = VecCtx::new(loop_var, location.clone(), width);
+    let replacement = ctx.run(flat, hi);
+    if replacement.is_none() {
+        work.recognition_failures = work.recognition_failures.saturating_add(1);
+    }
+    replacement
 }
 
 /// Does `node` reference identifier `name` anywhere?
@@ -3319,13 +5104,18 @@ fn opt_timing_enabled() -> bool {
     std::env::var("STOFFEL_OPT_TIMING").is_ok_and(|v| v != "0" && !v.is_empty())
 }
 
-fn timed_pass(name: &str, f: impl FnOnce() -> AstNode) -> AstNode {
+fn timed_pass(name: &str, input: AstNode, f: impl FnOnce(AstNode) -> AstNode) -> AstNode {
     if !opt_timing_enabled() {
-        return f();
+        return f(input);
     }
+    let input_nodes = program_code_size(&input);
     let start = std::time::Instant::now();
-    let out = f();
-    eprintln!("[opt-timing] {name}: {:.3}s", start.elapsed().as_secs_f64());
+    let out = f(input);
+    let elapsed = start.elapsed().as_secs_f64();
+    let output_nodes = program_code_size(&out);
+    eprintln!(
+        "[opt-timing] {name}: {elapsed:.3}s input_nodes={input_nodes} output_nodes={output_nodes}"
+    );
     out
 }
 
@@ -3343,7 +5133,7 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // gated to -O3. At lower levels LICM/CSE still run; they only ever *reduce* work,
     // so they are always safe.
     let node = if optimization_level >= 3 {
-        timed_pass("inline_functions", || inline_functions(node))
+        timed_pass("inline_functions", node, inline_functions)
     } else {
         node
     };
@@ -3353,7 +5143,7 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // register pressure (every unrolled iteration's live shares now coexist),
     // which is why it is gated to -O3.
     let node = if optimization_level >= 3 {
-        timed_pass("unroll_literal_loops", || unroll_literal_loops(node))
+        timed_pass("unroll_literal_loops", node, unroll_literal_loops)
     } else {
         node
     };
@@ -3370,7 +5160,7 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // scalar `xor` multiplies guarded by `if i == 0 / if i == 2`, so without this
     // every one of those secret-bool xors runs as its own unbatched round.
     let node = if optimization_level >= 3 {
-        timed_pass("fold_constant_branches", || fold_constant_branches(node))
+        timed_pass("fold_constant_branches", node, fold_constant_branches)
     } else {
         node
     };
@@ -3380,7 +5170,22 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // folding (so the counter increment is straight-line) and before the
     // multiply batchers (so folded gates never reach `Share.batch_mul`). -O3 only.
     let node = if optimization_level >= 3 {
-        timed_pass("fold_public_gates", || fold_public_gates(node))
+        timed_pass("fold_public_gates", node, fold_public_gates)
+    } else {
+        node
+    };
+    // Context-specialize only shape-sensitive MPC functions whose callers prove
+    // an exact list shape. This is deliberately after general unrolling: cloned
+    // bodies retain symbolic map loops, so the vectorizer below produces one
+    // compact transposed circuit per useful shape instead of N scalar copies.
+    // A LLVM-style global growth budget and per-function variant cap bound code
+    // size; unproven or unprofitable contexts keep calling the generic function.
+    let node = if optimization_level >= 3 {
+        timed_pass(
+            "specialize_mpc_call_shapes",
+            node,
+            specialize_mpc_call_shapes,
+        )
     } else {
         node
     };
@@ -3395,13 +5200,14 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // with a fixed number of vector statements, so code size stays O(1) in the
     // iteration count (no unroll blow-up).
     let node = if optimization_level >= 3 {
-        timed_pass("vectorize_map_loops", || vectorize_map_loops(node))
+        timed_pass("vectorize_map_loops", node, vectorize_map_loops)
     } else {
         node
     };
-    let node = timed_pass("inline_multiply_wrappers", || {
-        inline_multiply_wrappers(node)
-    });
+    if optimization_level >= 3 {
+        record_specialized_batch_widths(&node);
+    }
+    let node = timed_pass("inline_multiply_wrappers", node, inline_multiply_wrappers);
     // Round-minimizing interactive scheduler (-O3): model singular multiplies
     // and reveals as distinct protocol nodes in one dependency DAG, then make
     // every dependency-ready group consecutive. The lowering passes collapse
@@ -3409,31 +5215,34 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // register pressure (a whole round's shares are live at once) for fewer
     // communication rounds, so it is gated to -O3 alongside inlining/unrolling.
     let node = if optimization_level >= 3 {
-        timed_pass("schedule_for_batching", || schedule_for_batching(node))
+        timed_pass("schedule_for_batching", node, schedule_for_batching)
     } else {
         node
     };
-    let node = timed_pass("optimize_multiplies", || optimize_multiplies(node));
+    let node = timed_pass("optimize_multiplies", node, optimize_multiplies);
     // Batching materializes accumulator setup and result-slice statements around
-    // every fused call. Those new statements can expose another legal merge that
-    // did not exist in the input graph (most commonly independently vectorized
-    // regions at the same MPC depth). Rebuild the dependency DAG on each newly
-    // materialized form until it is structurally stable. The cap is a defensive
-    // compiler-time bound; in practice the corpus converges in one extra round.
+    // every fused call. Re-run fusion (without replacing the scheduler's chosen
+    // order) until this normalization is structurally stable. The cap is a
+    // defensive compiler-time bound; mixed scalar/vector groups now normally
+    // settle in the first pass.
     let node = if optimization_level >= 3 {
-        timed_pass("batching_fixpoint", || {
-            optimize_multiply_batches_to_fixpoint(node)
-        })
+        timed_pass(
+            "batching_fixpoint",
+            node,
+            optimize_multiply_batches_to_fixpoint,
+        )
     } else {
         node
     };
-    let node = timed_pass("reorder_for_reveal_batching", || {
-        reorder_for_reveal_batching(node)
-    });
+    let node = timed_pass(
+        "reorder_for_reveal_batching",
+        node,
+        reorder_for_reveal_batching,
+    );
     // Reordering can make formerly interleaved explicit opens consecutive.
     // Materialize those newly exposed groups as native batch opens now; the
     // earlier reveal pass could not see across their clear consumers.
-    let node = timed_pass("optimize_reveals_after_reorder", || optimize_reveals(node));
+    let node = timed_pass("optimize_reveals_after_reorder", node, optimize_reveals);
     // SROA / scalarization (-O3): after the batchers settled the block shape,
     // replace constant-index reads of locally-built lists with direct element
     // references and delete the corresponding build calls, rematerializing a
@@ -3443,18 +5252,18 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     // the emptied builds are swept. -O3 only: below -O3 loops stay rolled, so
     // indices are rarely constant and the pass would only add walk time.
     let node = if optimization_level >= 3 {
-        timed_pass("scalarize_local_arrays", || scalarize_local_arrays(node))
+        timed_pass("scalarize_local_arrays", node, scalarize_local_arrays)
     } else {
         node
     };
-    let node = timed_pass("optimize_licm_cse", || optimize_licm_cse(node));
-    let node = timed_pass("optimize_gvn", || optimize_gvn(node));
+    let node = timed_pass("optimize_licm_cse", node, optimize_licm_cse);
+    let node = timed_pass("optimize_gvn", node, optimize_gvn);
     // Finally, drop bindings whose value is never used (a pure dead store). This
     // sweeps up the intermediate temporaries that inlining, unrolling, and the
     // batchers leave behind — reducing live values (register pressure / spills)
     // and, when a dead binding's initializer was itself an MPC multiply, even
     // eliminating wasted preprocessing.
-    timed_pass("eliminate_dead_bindings", || eliminate_dead_bindings(node))
+    timed_pass("eliminate_dead_bindings", node, eliminate_dead_bindings)
 }
 
 // ===========================================================================
@@ -3524,10 +5333,8 @@ fn value_is_multiply(value: &AstNode) -> bool {
     match value {
         AstNode::BinaryOperation { op, .. } => matches!(op.as_str(), "and" | "or" | "xor"),
         AstNode::FunctionCall { .. } => {
-            let name_is_multiply = matches!(
-                call_name(value).map(builtin_base_name),
-                Some("mul") | Some("batch_mul")
-            );
+            let name_is_multiply = call_resolves_to_vm_symbol(value, "Share.mul")
+                || call_resolves_to_vm_symbol(value, "Share.batch_mul");
             // Use `contains_secret` so a batched multiply yielding a
             // `list[secret bool]` (not a scalar secret) still counts as a round.
             match node_resolved_contains_secret(value) {
@@ -3555,6 +5362,53 @@ fn interactive_kind(value: &AstNode) -> Option<InteractiveKind> {
         Some(InteractiveKind::Reveal)
     } else {
         None
+    }
+}
+
+/// Statement initializer/value for interactive work accounting.
+fn scheduled_statement_value(stmt: &AstNode) -> Option<&AstNode> {
+    match stmt {
+        AstNode::VariableDeclaration {
+            value: Some(value), ..
+        }
+        | AstNode::Assignment { value, .. } => Some(value),
+        AstNode::DiscardStatement { expression, .. } => Some(expression),
+        AstNode::FunctionCall { .. } => Some(stmt),
+        _ => None,
+    }
+}
+
+/// Exact scalar work of a singular/batched interactive statement. Unknown
+/// batch widths stay unknown; capacity-aware scheduling then isolates them
+/// instead of pretending they fit beside known work.
+fn scheduled_interactive_work(stmt: &AstNode, kind: Option<InteractiveKind>) -> Option<usize> {
+    match kind? {
+        InteractiveKind::Reveal => Some(1),
+        InteractiveKind::Multiply => {
+            let value = scheduled_statement_value(stmt)?;
+            let Some((left, right)) = batch_mul_call_operands(value) else {
+                return Some(1);
+            };
+            let target = match stmt {
+                AstNode::VariableDeclaration { name, location, .. } => {
+                    Some((name.as_str(), location))
+                }
+                AstNode::Assignment {
+                    target, location, ..
+                } => match target.as_ref() {
+                    AstNode::Identifier(name, _) => Some((name.as_str(), location)),
+                    _ => None,
+                },
+                _ => None,
+            };
+            target
+                .and_then(|(name, location)| interactive_width(name, location))
+                .or_else(|| {
+                    let left = exact_batch_operand_width(left)?;
+                    let right = exact_batch_operand_width(right)?;
+                    (left == right).then_some(left)
+                })
+        }
     }
 }
 
@@ -4105,10 +5959,28 @@ fn update_sched_env(
 /// Recurse into nested scopes, then reorder each block's statement list.
 pub fn schedule_for_batching(node: AstNode) -> AstNode {
     let pure_fns = compute_pure_functions(&node);
-    schedule_in_node(node, &pure_fns)
+    let mut fusion_stats = LoopFusionStats::default();
+    let out = schedule_in_node(node, &pure_fns, &mut fusion_stats);
+    if opt_timing_enabled() {
+        eprintln!(
+            "[opt-work] loop_fusion: candidate_probes={} fusions={}",
+            fusion_stats.candidate_probes, fusion_stats.fusions,
+        );
+    }
+    out
 }
 
-fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
+#[derive(Debug, Default)]
+struct LoopFusionStats {
+    candidate_probes: u64,
+    fusions: u64,
+}
+
+fn schedule_in_node(
+    node: AstNode,
+    pure_fns: &HashSet<String>,
+    fusion_stats: &mut LoopFusionStats,
+) -> AstNode {
     match node {
         AstNode::Block(stmts) => {
             // Flatten statement-position nested blocks (which inlining introduces
@@ -4119,10 +5991,14 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
             let stmts = flatten_statement_blocks(stmts);
             let stmts: Vec<AstNode> = stmts
                 .into_iter()
-                .map(|s| schedule_in_node(s, pure_fns))
+                .map(|s| schedule_in_node(s, pure_fns, fusion_stats))
                 .collect();
             let scheduled = schedule_statement_list(stmts, pure_fns);
-            AstNode::Block(fuse_independent_loops(scheduled, pure_fns))
+            AstNode::Block(fuse_independent_loops_with_stats(
+                scheduled,
+                pure_fns,
+                fusion_stats,
+            ))
         }
         AstNode::FunctionDefinition {
             name,
@@ -4139,7 +6015,7 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
             type_params,
             parameters,
             return_type,
-            body: Box::new(schedule_in_node(*body, pure_fns)),
+            body: Box::new(schedule_in_node(*body, pure_fns, fusion_stats)),
             is_secret,
             pragmas,
             location,
@@ -4151,7 +6027,7 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
             location,
         } => AstNode::WhileLoop {
             condition,
-            body: Box::new(schedule_in_node(*body, pure_fns)),
+            body: Box::new(schedule_in_node(*body, pure_fns, fusion_stats)),
             location,
         },
         AstNode::ForLoop {
@@ -4162,7 +6038,7 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
         } => AstNode::ForLoop {
             variables,
             iterable,
-            body: Box::new(schedule_in_node(*body, pure_fns)),
+            body: Box::new(schedule_in_node(*body, pure_fns, fusion_stats)),
             location,
         },
         AstNode::IfExpression {
@@ -4171,8 +6047,9 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
             else_branch,
         } => AstNode::IfExpression {
             condition,
-            then_branch: Box::new(schedule_in_node(*then_branch, pure_fns)),
-            else_branch: else_branch.map(|e| Box::new(schedule_in_node(*e, pure_fns))),
+            then_branch: Box::new(schedule_in_node(*then_branch, pure_fns, fusion_stats)),
+            else_branch: else_branch
+                .map(|e| Box::new(schedule_in_node(*e, pure_fns, fusion_stats))),
         },
         AstNode::TryCatch {
             try_block,
@@ -4180,15 +6057,16 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
             finally_block,
             location,
         } => AstNode::TryCatch {
-            try_block: Box::new(schedule_in_node(*try_block, pure_fns)),
+            try_block: Box::new(schedule_in_node(*try_block, pure_fns, fusion_stats)),
             catch_clauses: catch_clauses
                 .into_iter()
                 .map(|c| crate::ast::CatchClause {
-                    body: Box::new(schedule_in_node(*c.body, pure_fns)),
+                    body: Box::new(schedule_in_node(*c.body, pure_fns, fusion_stats)),
                     ..c
                 })
                 .collect(),
-            finally_block: finally_block.map(|b| Box::new(schedule_in_node(*b, pure_fns))),
+            finally_block: finally_block
+                .map(|b| Box::new(schedule_in_node(*b, pure_fns, fusion_stats))),
             location,
         },
         other => other,
@@ -4214,21 +6092,20 @@ fn flatten_statement_blocks(stmts: Vec<AstNode>) -> Vec<AstNode> {
 /// and intervening statements admit a dependence-preserving partition around
 /// the fused loop. This preserves code size while exposing same-iteration
 /// interactive operations to batching.
+#[cfg(test)]
 fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) -> Vec<AstNode> {
+    fuse_independent_loops_with_stats(statements, pure_fns, &mut LoopFusionStats::default())
+}
+
+fn fuse_independent_loops_with_stats(
+    statements: Vec<AstNode>,
+    pure_fns: &HashSet<String>,
+    fusion_stats: &mut LoopFusionStats,
+) -> Vec<AstNode> {
     fn conflicts(writes: &HashSet<String>, observed: &HashSet<String>) -> bool {
         writes
             .iter()
             .any(|write| observed.iter().any(|key| keys_conflict(write, key)))
-    }
-
-    fn independent(first: &AstNode, second: &AstNode) -> bool {
-        let (first_reads, first_writes) = statement_reads_and_writes(first);
-        let (second_reads, second_writes) = statement_reads_and_writes(second);
-        let mut first_observed = first_reads;
-        first_observed.extend(first_writes.iter().cloned());
-        let mut second_observed = second_reads;
-        second_observed.extend(second_writes.iter().cloned());
-        !conflicts(&first_writes, &second_observed) && !conflicts(&second_writes, &first_observed)
     }
 
     fn footprints_independent(
@@ -4237,14 +6114,22 @@ fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) 
         second_reads: &HashSet<String>,
         second_writes: &HashSet<String>,
     ) -> bool {
-        let mut first_observed = first_reads.clone();
-        first_observed.extend(first_writes.iter().cloned());
-        let mut second_observed = second_reads.clone();
-        second_observed.extend(second_writes.iter().cloned());
-        !conflicts(first_writes, &second_observed) && !conflicts(second_writes, &first_observed)
+        !conflicts(first_writes, second_reads)
+            && !conflicts(first_writes, second_writes)
+            && !conflicts(second_writes, first_reads)
+            && !conflicts(second_writes, first_writes)
     }
 
-    fn fuse(first: &AstNode, second: &AstNode, pure_fns: &HashSet<String>) -> Option<AstNode> {
+    #[allow(clippy::too_many_arguments)]
+    fn fuse(
+        first: &AstNode,
+        second: &AstNode,
+        first_reads: &HashSet<String>,
+        first_writes: &HashSet<String>,
+        second_reads: &HashSet<String>,
+        second_writes: &HashSet<String>,
+        pure_fns: &HashSet<String>,
+    ) -> Option<AstNode> {
         let (
             AstNode::ForLoop {
                 variables: first_vars,
@@ -4267,7 +6152,7 @@ fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) 
             || first_iter != second_iter
             || !loop_body_is_schedulable(first_body, pure_fns)
             || !loop_body_is_schedulable(second_body, pure_fns)
-            || !independent(first, second)
+            || !footprints_independent(first_reads, first_writes, second_reads, second_writes)
         {
             return None;
         }
@@ -4305,11 +6190,44 @@ fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) 
     }
 
     let mut out: Vec<AstNode> = Vec::with_capacity(statements.len());
+    let mut out_footprints: Vec<(HashSet<String>, HashSet<String>)> =
+        Vec::with_capacity(statements.len());
     for statement in statements {
+        let statement_footprint = statement_reads_and_writes(&statement);
         let mut replacement = None;
         if matches!(statement, AstNode::ForLoop { .. }) {
             for position in (0..out.len()).rev() {
-                let Some(fused) = fuse(&out[position], &statement, pure_fns) else {
+                fusion_stats.candidate_probes = fusion_stats.candidate_probes.saturating_add(1);
+
+                // Iterable equality is the cheapest necessary condition. Avoid
+                // charging/walking large loop bodies for the overwhelmingly
+                // common mismatched-range candidates.
+                let same_iterable = matches!(
+                    (&out[position], &statement),
+                    (
+                        AstNode::ForLoop {
+                            iterable: first, ..
+                        },
+                        AstNode::ForLoop {
+                            iterable: second, ..
+                        }
+                    ) if first == second
+                );
+                if !same_iterable {
+                    continue;
+                }
+
+                let (first_reads, first_writes) = &out_footprints[position];
+                let (second_reads, second_writes) = &statement_footprint;
+                let Some(fused) = fuse(
+                    &out[position],
+                    &statement,
+                    first_reads,
+                    first_writes,
+                    second_reads,
+                    second_writes,
+                    pure_fns,
+                ) else {
                     continue;
                 };
                 let middle = &out[position + 1..];
@@ -4323,46 +6241,61 @@ fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) 
                 // Compute the transitive A-dependent suffix partition in one
                 // forward pass. Once a statement observes A or any prior member
                 // of the suffix, it too must remain after the fused loop.
-                let (first_reads, first_writes) = statement_reads_and_writes(&out[position]);
                 let mut after_reads = HashSet::new();
                 let mut after_writes = HashSet::new();
                 let mut before = Vec::new();
+                let mut before_footprints = Vec::new();
                 let mut after = Vec::new();
-                for node in middle {
-                    let (reads, writes) = statement_reads_and_writes(node);
+                let mut after_footprints = Vec::new();
+                for (node, (reads, writes)) in
+                    middle.iter().zip(out_footprints[position + 1..].iter())
+                {
                     let depends_on_first =
-                        !footprints_independent(&first_reads, &first_writes, &reads, &writes);
+                        !footprints_independent(first_reads, first_writes, reads, writes);
                     let depends_on_suffix =
                         !footprints_independent(&after_reads, &after_writes, &reads, &writes);
                     if depends_on_first || depends_on_suffix {
-                        after_reads.extend(reads);
-                        after_writes.extend(writes);
+                        after_reads.extend(reads.iter().cloned());
+                        after_writes.extend(writes.iter().cloned());
                         after.push(node.clone());
+                        after_footprints.push((reads.clone(), writes.clone()));
                     } else {
                         before.push(node.clone());
+                        before_footprints.push((reads.clone(), writes.clone()));
                     }
                 }
 
-                let (second_reads, second_writes) = statement_reads_and_writes(&statement);
-                if !footprints_independent(
-                    &after_reads,
-                    &after_writes,
-                    &second_reads,
-                    &second_writes,
-                ) {
+                if !footprints_independent(&after_reads, &after_writes, second_reads, second_writes)
+                {
                     continue;
                 }
-                replacement = Some((position, before, fused, after));
+                replacement = Some((
+                    position,
+                    before,
+                    before_footprints,
+                    fused,
+                    after,
+                    after_footprints,
+                ));
+                fusion_stats.fusions = fusion_stats.fusions.saturating_add(1);
                 break;
             }
         }
-        if let Some((position, before, fused, after)) = replacement {
+        if let Some((position, before, before_footprints, fused, after, after_footprints)) =
+            replacement
+        {
             out.truncate(position);
+            out_footprints.truncate(position);
             out.extend(before);
+            out_footprints.extend(before_footprints);
+            let fused_footprint = statement_reads_and_writes(&fused);
             out.push(fused);
+            out_footprints.push(fused_footprint);
             out.extend(after);
+            out_footprints.extend(after_footprints);
         } else {
             out.push(statement);
+            out_footprints.push(statement_footprint);
         }
     }
     out
@@ -4421,21 +6354,48 @@ fn schedule_run(stmts: Vec<AstNode>) -> Vec<AstNode> {
             info
         })
         .collect();
+    let interactive_work: Vec<Option<usize>> = stmts
+        .iter()
+        .zip(&infos)
+        .map(|(stmt, info)| scheduled_interactive_work(stmt, info.interactive))
+        .collect();
+    let multiply_capacity = multiply_batch_capacity();
 
     // Intern the catch-all up front so the relevance pass can identify it
     // (no-op for the DAG: nothing reads or writes a key merely by interning).
     let global_key = interner.global();
     let key_bound = interner.key_bound();
     let order = if sched_cone_ab_check() {
-        let full = build_schedule_order(&infos, key_bound, global_key, false);
-        let pruned = build_schedule_order(&infos, key_bound, global_key, true);
+        let full = build_schedule_order(
+            &infos,
+            &interactive_work,
+            key_bound,
+            global_key,
+            false,
+            multiply_capacity,
+        );
+        let pruned = build_schedule_order(
+            &infos,
+            &interactive_work,
+            key_bound,
+            global_key,
+            true,
+            multiply_capacity,
+        );
         assert_eq!(
             full, pruned,
             "cone-pruned schedule diverged from the full-cone schedule"
         );
         pruned
     } else {
-        build_schedule_order(&infos, key_bound, global_key, sched_cone_prune_enabled())
+        build_schedule_order(
+            &infos,
+            &interactive_work,
+            key_bound,
+            global_key,
+            sched_cone_prune_enabled(),
+            multiply_capacity,
+        )
     };
 
     let Some(order) = order else {
@@ -4536,11 +6496,14 @@ fn pruned_cone(
 /// term in `schedule_for_batching`.
 fn build_schedule_order(
     infos: &[SchedInfo],
+    interactive_work: &[Option<usize>],
     key_bound: usize,
     global_key: u32,
     prune: bool,
+    multiply_capacity: Option<usize>,
 ) -> Option<Vec<usize>> {
     let n = infos.len();
+    debug_assert_eq!(interactive_work.len(), n);
     // Build the dependency DAG (deduplicated successor sets).
     let mut succ: Vec<HashSet<usize>> = vec![HashSet::new(); n];
     let mut indeg: Vec<usize> = vec![0usize; n];
@@ -4655,23 +6618,64 @@ fn build_schedule_order(
         }
     }
 
-    // List-schedule: drain ready local work, then fire all currently-ready
-    // operations of one interactive protocol kind. Multiply and reveal nodes
-    // never share a batch, but each kind automatically coalesces its independent
-    // scalar operations. Ready buckets are min-heaps on source index for stable,
-    // deterministic output.
+    // Bottom-level priority (the number of interactive rounds on the longest
+    // remaining path). This is the standard critical-path list-scheduling
+    // priority: capacity is spent first on work whose delay can lengthen the
+    // program, with source index as the deterministic tie-breaker.
+    let multiply_round_cost = |i: usize| match (multiply_capacity, interactive_work[i]) {
+        (Some(capacity), Some(work)) => work.div_ceil(capacity.max(1)).max(1),
+        _ => 1,
+    };
+    let mut bottom_level = vec![0usize; n];
+    for i in (0..n).rev() {
+        let tail = succ[i].iter().map(|&s| bottom_level[s]).max().unwrap_or(0);
+        let own = match infos[i].interactive {
+            Some(InteractiveKind::Multiply) => multiply_round_cost(i),
+            Some(InteractiveKind::Reveal) => 1,
+            None => 0,
+        };
+        bottom_level[i] = own.saturating_add(tail);
+    }
+
+    // List-schedule: exhaust ready local work, then fire one legal protocol
+    // round. Multiply rounds are capacity-bounded; reveal rounds have no
+    // compiler-visible width ceiling. Unknown multiply widths are isolated so
+    // the scheduler never obtains a false one-round proof from guessed work.
     use std::cmp::Reverse;
     use std::collections::BinaryHeap;
     let mut ready_free: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
-    let mut ready_mult: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
-    let mut ready_reveal: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
+    let mut ready_mult: BinaryHeap<(usize, Reverse<usize>)> = BinaryHeap::new();
+    let mut ready_reveal: BinaryHeap<(usize, Reverse<usize>)> = BinaryHeap::new();
+
+    fn push_ready(
+        i: usize,
+        infos: &[SchedInfo],
+        bottom_level: &[usize],
+        ready_free: &mut BinaryHeap<Reverse<usize>>,
+        ready_mult: &mut BinaryHeap<(usize, Reverse<usize>)>,
+        ready_reveal: &mut BinaryHeap<(usize, Reverse<usize>)>,
+    ) {
+        match infos[i].interactive {
+            Some(InteractiveKind::Multiply) => {
+                ready_mult.push((bottom_level[i], Reverse(i)));
+            }
+            Some(InteractiveKind::Reveal) => {
+                ready_reveal.push((bottom_level[i], Reverse(i)));
+            }
+            None => ready_free.push(Reverse(i)),
+        }
+    }
+
     for i in 0..n {
         if indeg[i] == 0 {
-            match infos[i].interactive {
-                Some(InteractiveKind::Multiply) => ready_mult.push(Reverse(i)),
-                Some(InteractiveKind::Reveal) => ready_reveal.push(Reverse(i)),
-                None => ready_free.push(Reverse(i)),
-            }
+            push_ready(
+                i,
+                infos,
+                &bottom_level,
+                &mut ready_free,
+                &mut ready_mult,
+                &mut ready_reveal,
+            );
         }
     }
 
@@ -4682,19 +6686,45 @@ fn build_schedule_order(
             // Emit one ready free statement.
             vec![ready_free.pop().map(|Reverse(i)| i).unwrap()]
         } else if !ready_mult.is_empty() {
-            // If both protocols are ready, preserve the source order of their
-            // earliest node. The chosen kind then fires as one batch.
+            // Pick the protocol whose most-critical ready operation comes
+            // first. Equal criticality preserves source order.
             let reveal_first = matches!(
                 (ready_reveal.peek(), ready_mult.peek()),
-                (Some(Reverse(reveal)), Some(Reverse(mul))) if reveal < mul
+                (Some((rh, Reverse(reveal))), Some((mh, Reverse(mul))))
+                    if rh > mh || (rh == mh && reveal < mul)
             );
             if reveal_first {
-                std::iter::from_fn(|| ready_reveal.pop().map(|Reverse(i)| i)).collect()
+                std::iter::from_fn(|| ready_reveal.pop().map(|(_, Reverse(i))| i)).collect()
             } else {
-                std::iter::from_fn(|| ready_mult.pop().map(|Reverse(i)| i)).collect()
+                let (_, Reverse(first)) = ready_mult.pop().expect("multiply ready");
+                let mut selected = vec![first];
+                if let (Some(capacity), Some(first_work)) =
+                    (multiply_capacity, interactive_work[first])
+                {
+                    let capacity = capacity.max(1);
+                    if first_work <= capacity {
+                        let mut remaining = capacity - first_work;
+                        let mut deferred = Vec::new();
+                        while let Some(entry @ (_, Reverse(i))) = ready_mult.pop() {
+                            match interactive_work[i] {
+                                Some(work) if work <= remaining => {
+                                    selected.push(i);
+                                    remaining -= work;
+                                }
+                                _ => deferred.push(entry),
+                            }
+                        }
+                        ready_mult.extend(deferred);
+                    }
+                } else if multiply_capacity.is_none() {
+                    selected.extend(std::iter::from_fn(|| {
+                        ready_mult.pop().map(|(_, Reverse(i))| i)
+                    }));
+                }
+                selected
             }
         } else if !ready_reveal.is_empty() {
-            std::iter::from_fn(|| ready_reveal.pop().map(|Reverse(i)| i)).collect()
+            std::iter::from_fn(|| ready_reveal.pop().map(|(_, Reverse(i))| i)).collect()
         } else {
             break; // cycle (unexpected) — fall back below.
         };
@@ -4703,11 +6733,14 @@ fn build_schedule_order(
             for &s in &succ[i] {
                 indeg[s] -= 1;
                 if indeg[s] == 0 {
-                    match infos[s].interactive {
-                        Some(InteractiveKind::Multiply) => ready_mult.push(Reverse(s)),
-                        Some(InteractiveKind::Reveal) => ready_reveal.push(Reverse(s)),
-                        None => ready_free.push(Reverse(s)),
-                    }
+                    push_ready(
+                        s,
+                        infos,
+                        &bottom_level,
+                        &mut ready_free,
+                        &mut ready_mult,
+                        &mut ready_reveal,
+                    );
                 }
             }
         }
@@ -5873,6 +7906,11 @@ fn function_is_inlinable(params: &[crate::ast::Parameter], body: &AstNode) -> bo
 /// Entry point: inline non-recursive, single-return functions to a fixpoint
 /// (bounded by `INLINE_BUDGET`), so that nested calls are also inlined.
 pub fn inline_functions(node: AstNode) -> AstNode {
+    inline_functions_with_round_limit(node, 12)
+}
+
+/// A bounded number of whole-program inlining waves.
+fn inline_functions_with_round_limit(node: AstNode, round_limit: usize) -> AstNode {
     // Multi-return normalization+inlining is an aggressive transform: it enlarges
     // the functions it touches, which (stacked on the existing -O3 inline+unroll)
     // can push the post-inline program past the unroll budget into a partially
@@ -5888,7 +7926,7 @@ pub fn inline_functions(node: AstNode) -> AstNode {
     }
     let mut node = node;
     let mut budget = active_budgets().inline.unwrap_or(INLINE_BUDGET);
-    for _ in 0..12 {
+    for _ in 0..round_limit {
         let before = budget;
         node = inline_in_node(node, &infos, &mut budget);
         if budget == before {
@@ -5980,7 +8018,7 @@ fn unroll_max_expansion() -> usize {
 // ---------------------------------------------------------------------------
 
 /// Statically known list shape: a length and its recursive element shape.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum Shape {
     List { len: usize, elem: Box<Shape> },
     Unknown,
@@ -6436,6 +8474,46 @@ fn apply_statement_to_env(stmt: &AstNode, env: &mut LenEnv) {
         }
         AstNode::DiscardStatement { expression, .. } => apply_call_to_env(expression, env),
         other => apply_call_to_env(other, env),
+    }
+}
+
+/// Persist the exact width of a real (non-speculative) `Share.batch_mul`
+/// binding after the shape environment has executed that statement. The shape
+/// interpreter is also used speculatively by profitability proofs, so metadata
+/// recording is intentionally kept at actual pass traversal sites rather than
+/// inside `apply_statement_to_env` itself.
+fn record_batch_result_width_from_env(stmt: &AstNode, env: &LenEnv) {
+    let (target, location, value) = match stmt {
+        AstNode::VariableDeclaration {
+            name,
+            value: Some(value),
+            location,
+            ..
+        } => (Some(name.as_str()), location, value.as_ref()),
+        AstNode::Assignment {
+            target,
+            value,
+            location,
+        } => (
+            match target.as_ref() {
+                AstNode::Identifier(name, _) => Some(name.as_str()),
+                _ => None,
+            },
+            location,
+            value.as_ref(),
+        ),
+        _ => return,
+    };
+    if batch_mul_call_operands(value).is_none() {
+        return;
+    }
+    if let Some((target, width)) = target.and_then(|target| {
+        env.shapes
+            .get(target)
+            .and_then(Shape::count)
+            .map(|width| (target, width))
+    }) {
+        record_interactive_width(target, location, width);
     }
 }
 
@@ -7109,6 +9187,113 @@ enum ConstVal {
 
 type GateEnv = std::collections::HashMap<String, ConstVal>;
 
+/// A cloned, bounded view of a user function that may participate in exact
+/// public-value evaluation. Only functions independently proven pure are added
+/// to this table; evaluation still fails closed on any unsupported construct.
+#[derive(Clone)]
+struct GateFunction {
+    parameters: Vec<String>,
+    body: AstNode,
+}
+
+#[derive(Default)]
+struct GateContext {
+    functions: HashMap<String, GateFunction>,
+    pure_functions: HashSet<String>,
+}
+
+impl GateContext {
+    fn for_program(root: &AstNode) -> Self {
+        let pure_functions = compute_pure_functions(root);
+        let mut called = HashSet::new();
+        fn collect_program_calls(node: &AstNode, out: &mut HashSet<String>) {
+            if let Some(name) = call_name(node) {
+                out.insert(name.to_string());
+            }
+            match node {
+                AstNode::FunctionDefinition { body, .. } => collect_program_calls(body, out),
+                AstNode::Block(statements) => {
+                    for statement in statements {
+                        collect_program_calls(statement, out);
+                    }
+                }
+                _ => for_each_child(node, &mut |child| collect_program_calls(child, out)),
+            }
+        }
+        collect_program_calls(root, &mut called);
+        let mut functions = HashMap::new();
+
+        fn gather(
+            node: &AstNode,
+            called: &HashSet<String>,
+            pure: &HashSet<String>,
+            out: &mut HashMap<String, GateFunction>,
+        ) {
+            match node {
+                AstNode::FunctionDefinition {
+                    name: Some(name),
+                    parameters,
+                    body,
+                    ..
+                } => {
+                    // Uncalled entry points and fully-inlined dead helpers can be
+                    // enormous. They cannot affect a call expression, so avoid
+                    // cloning them into the evaluator's compact call table.
+                    if called.contains(name) && pure.contains(name) {
+                        out.insert(
+                            name.clone(),
+                            GateFunction {
+                                parameters: parameters
+                                    .iter()
+                                    .map(|parameter| parameter.name.clone())
+                                    .collect(),
+                                body: body.as_ref().clone(),
+                            },
+                        );
+                    }
+                    gather(body, called, pure, out);
+                }
+                AstNode::Block(statements) => {
+                    for statement in statements {
+                        gather(statement, called, pure, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        gather(root, &called, &pure_functions, &mut functions);
+        Self {
+            functions,
+            pure_functions,
+        }
+    }
+}
+
+thread_local! {
+    /// Scoped exactly to one `fold_public_gates` invocation. `Rc` makes reads
+    /// cheap and releases the `RefCell` borrow before recursive evaluation.
+    static ACTIVE_GATE_CONTEXT: RefCell<Option<Rc<GateContext>>> = const {
+        RefCell::new(None)
+    };
+}
+
+fn active_gate_context() -> Option<Rc<GateContext>> {
+    ACTIVE_GATE_CONTEXT.with(|context| context.borrow().clone())
+}
+
+fn gate_expr_is_pure(node: &AstNode) -> bool {
+    // The public-loop simulator is also exercised directly by unit tests and
+    // may be reused by callers outside the top-level folding driver. Builtin
+    // purity does not require a program context; only user-function purity
+    // does. Falling back to the empty proven-user-function set therefore keeps
+    // the standalone path useful without trusting an unknown call.
+    active_gate_context().map_or_else(
+        || expr_is_pure(node, &HashSet::new()),
+        |context| expr_is_pure(node, &context.pure_functions),
+    )
+}
+
 fn gate_value_is_concrete(value: &ConstVal) -> bool {
     match value {
         ConstVal::Int(_) | ConstVal::Bit { .. } => true,
@@ -7229,27 +9414,21 @@ fn gate_simulate_public_node(node: &AstNode, env: &mut GateEnv, fuel: &mut usize
             let AstNode::FunctionCall { arguments, .. } = expression else {
                 return false;
             };
-            if !arguments
-                .iter()
-                .all(|argument| expr_is_pure(argument, &HashSet::new()))
-            {
+            if !arguments.iter().all(gate_expr_is_pure) {
                 return false;
             }
             let _ = gate_process_stmt(node.clone(), env);
             true
         }
         AstNode::VariableDeclaration { value, .. } => {
-            if !value
-                .as_deref()
-                .is_none_or(|value| expr_is_pure(value, &HashSet::new()))
-            {
+            if !value.as_deref().is_none_or(gate_expr_is_pure) {
                 return false;
             }
             let _ = gate_process_stmt(node.clone(), env);
             true
         }
         AstNode::Assignment { target, value, .. } => {
-            if !expr_is_pure(target, &HashSet::new()) || !expr_is_pure(value, &HashSet::new()) {
+            if !gate_expr_is_pure(target) || !gate_expr_is_pure(value) {
                 return false;
             }
             let _ = gate_process_stmt(node.clone(), env);
@@ -7286,12 +9465,13 @@ fn try_partial_evaluate_public_for(
         .filter(|name| name != variable && !locals.contains(name))
         .collect();
     outer.sort();
-    if outer.is_empty()
-        || outer.iter().any(|name| {
-            env.get(name)
-                .is_none_or(|value| !gate_value_is_concrete(value))
-        })
-    {
+    if outer.is_empty() {
+        return None;
+    }
+    if outer.iter().any(|name| {
+        env.get(name)
+            .is_none_or(|value| !gate_value_is_concrete(value))
+    }) {
         return None;
     }
     let initial: HashMap<String, ConstVal> = outer
@@ -7376,8 +9556,18 @@ fn annotation_contains_secret_type(annotation: Option<&AstNode>) -> bool {
 
 /// Fold provably-public boolean gates throughout the program. Entry point.
 pub fn fold_public_gates(node: AstNode) -> AstNode {
+    let context = Rc::new(GateContext::for_program(&node));
+    let previous = ACTIVE_GATE_CONTEXT.with(|active| active.replace(Some(context)));
+    let result = fold_public_gates_inner(node);
+    ACTIVE_GATE_CONTEXT.with(|active| active.replace(previous));
+    result
+}
+
+fn fold_public_gates_inner(node: AstNode) -> AstNode {
     match node {
-        AstNode::Block(stmts) => AstNode::Block(stmts.into_iter().map(fold_public_gates).collect()),
+        AstNode::Block(stmts) => {
+            AstNode::Block(stmts.into_iter().map(fold_public_gates_inner).collect())
+        }
         AstNode::FunctionDefinition {
             name,
             type_params,
@@ -7424,7 +9614,7 @@ fn gate_process_node(node: AstNode, env: &mut GateEnv) -> AstNode {
     match node {
         AstNode::Block(stmts) => AstNode::Block(gate_process_stmts(stmts, env)),
         // A nested function definition (closure) starts a fresh scope.
-        def @ AstNode::FunctionDefinition { .. } => fold_public_gates(def),
+        def @ AstNode::FunctionDefinition { .. } => fold_public_gates_inner(def),
         other => gate_process_stmt(other, env),
     }
 }
@@ -7445,7 +9635,7 @@ fn gate_process_stmt(stmt: AstNode, env: &mut GateEnv) -> AstNode {
         // (inlining/unrolling wrap their output in blocks), so thread `env`
         // through it rather than leaving it unprocessed.
         AstNode::Block(stmts) => AstNode::Block(gate_process_stmts(stmts, env)),
-        AstNode::FunctionDefinition { .. } => fold_public_gates(stmt),
+        AstNode::FunctionDefinition { .. } => fold_public_gates_inner(stmt),
         AstNode::VariableDeclaration {
             name,
             type_annotation,
@@ -7932,14 +10122,17 @@ fn try_localize_public_batch_mul(
         AstNode::Identifier(name, _) if builtin_base_name(name) == "batch_mul" => {}
         _ => return None,
     }
+    // Evaluate each operand once. Large vectorized circuits routinely carry
+    // thousands of exact lane facts here, so re-walking both operands for the
+    // whole-public and mixed-public cases needlessly doubles this pass's cost.
+    let left_fact = gate_eval(&arguments[0], env);
+    let right_fact = gate_eval(&arguments[1], env);
     // Fast path: one whole operand is public. The other operand need not have a
     // materialized provenance list; the already-valid batch call proves it has
     // the same runtime length.
-    let whole_public = all_public_bits(&gate_eval(&arguments[0], env))
+    let whole_public = all_public_bits(&left_fact)
         .map(|values| (values, &arguments[1]))
-        .or_else(|| {
-            all_public_bits(&gate_eval(&arguments[1], env)).map(|values| (values, &arguments[0]))
-        });
+        .or_else(|| all_public_bits(&right_fact).map(|values| (values, &arguments[0])));
     if let Some((scalars, share_id @ AstNode::Identifier(..))) = whole_public {
         let elements = scalars
             .iter()
@@ -7965,11 +10158,11 @@ fn try_localize_public_batch_mul(
     // General mixed-list path. Every lane must be proven either public or
     // secret; one public lane is enough to make the split profitable. Unknown
     // lanes fail closed and keep the original batch untouched.
-    let mut left_values = match gate_eval(&arguments[0], env) {
+    let mut left_values = match left_fact {
         ConstVal::List(values) => values,
         _ => return None,
     };
-    let mut right_values = match gate_eval(&arguments[1], env) {
+    let mut right_values = match right_fact {
         ConstVal::List(values) => values,
         _ => return None,
     };
@@ -8095,6 +10288,201 @@ fn try_localize_public_batch_mul(
 /// Purely evaluate an expression to a provenance fact. Returns `Top` for
 /// anything not provably public — this is the crypto-safety backstop.
 fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
+    let context = active_gate_context();
+    let mut state = GateEvalState {
+        fuel: 500_000,
+        stack: HashSet::new(),
+    };
+    gate_eval_with_state(node, env, context.as_deref(), &mut state)
+}
+
+struct GateEvalState {
+    fuel: usize,
+    stack: HashSet<String>,
+}
+
+enum GateExecResult {
+    Continue,
+    Return(ConstVal),
+    Failed,
+}
+
+fn gate_take_fuel(state: &mut GateEvalState) -> bool {
+    if state.fuel == 0 {
+        false
+    } else {
+        state.fuel -= 1;
+        true
+    }
+}
+
+fn gate_eval_user_function(
+    name: &str,
+    arguments: Vec<ConstVal>,
+    context: Option<&GateContext>,
+    state: &mut GateEvalState,
+) -> ConstVal {
+    let Some(context) = context else {
+        return ConstVal::Top;
+    };
+    if !context.pure_functions.contains(name) {
+        return ConstVal::Top;
+    }
+    let Some(function) = context.functions.get(name) else {
+        return ConstVal::Top;
+    };
+    if function.parameters.len() != arguments.len()
+        || arguments.iter().any(|value| !gate_value_is_concrete(value))
+        || !state.stack.insert(name.to_string())
+    {
+        return ConstVal::Top;
+    }
+
+    let mut function_env: GateEnv = function.parameters.iter().cloned().zip(arguments).collect();
+    let result = match gate_exec_node(&function.body, &mut function_env, context, state) {
+        GateExecResult::Return(value) if gate_value_is_concrete(&value) => value,
+        GateExecResult::Continue | GateExecResult::Return(_) | GateExecResult::Failed => {
+            ConstVal::Top
+        }
+    };
+    state.stack.remove(name);
+    result
+}
+
+/// Bounded exact interpreter for proven-pure user functions. It intentionally
+/// accepts only the small structured subset needed for constant dispatch and
+/// table construction; unsupported nodes fail closed.
+fn gate_exec_node(
+    node: &AstNode,
+    env: &mut GateEnv,
+    context: &GateContext,
+    state: &mut GateEvalState,
+) -> GateExecResult {
+    if !gate_take_fuel(state) {
+        return GateExecResult::Failed;
+    }
+    match node {
+        AstNode::Block(statements) => {
+            for statement in statements {
+                match gate_exec_node(statement, env, context, state) {
+                    GateExecResult::Continue => {}
+                    result => return result,
+                }
+            }
+            GateExecResult::Continue
+        }
+        AstNode::VariableDeclaration { name, value, .. } => {
+            let Some(value) = value else {
+                env.insert(name.clone(), ConstVal::Top);
+                return GateExecResult::Continue;
+            };
+            let value = gate_eval_with_state(value, env, Some(context), state);
+            if !gate_value_is_concrete(&value) {
+                return GateExecResult::Failed;
+            }
+            env.insert(name.clone(), value);
+            GateExecResult::Continue
+        }
+        AstNode::Assignment { target, value, .. } => {
+            let AstNode::Identifier(name, _) = target.as_ref() else {
+                return GateExecResult::Failed;
+            };
+            let value = gate_eval_with_state(value, env, Some(context), state);
+            if !gate_value_is_concrete(&value) {
+                return GateExecResult::Failed;
+            }
+            env.insert(name.clone(), value);
+            GateExecResult::Continue
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => match gate_eval_with_state(condition, env, Some(context), state) {
+            ConstVal::Bit { val: 0, .. } => else_branch
+                .as_deref()
+                .map_or(GateExecResult::Continue, |branch| {
+                    gate_exec_node(branch, env, context, state)
+                }),
+            ConstVal::Bit { .. } => gate_exec_node(then_branch, env, context, state),
+            _ => GateExecResult::Failed,
+        },
+        AstNode::Return {
+            value: Some(value), ..
+        } => {
+            let value = gate_eval_with_state(value, env, Some(context), state);
+            if gate_value_is_concrete(&value) {
+                GateExecResult::Return(value)
+            } else {
+                GateExecResult::Failed
+            }
+        }
+        AstNode::Return { value: None, .. } => GateExecResult::Failed,
+        AstNode::ForLoop {
+            variables,
+            iterable,
+            body,
+            ..
+        } => {
+            let [variable] = variables.as_slice() else {
+                return GateExecResult::Failed;
+            };
+            let AstNode::BinaryOperation {
+                op, left, right, ..
+            } = iterable.as_ref()
+            else {
+                return GateExecResult::Failed;
+            };
+            if op != ".." {
+                return GateExecResult::Failed;
+            }
+            let (ConstVal::Int(lo), ConstVal::Int(hi)) = (
+                gate_eval_with_state(left, env, Some(context), state),
+                gate_eval_with_state(right, env, Some(context), state),
+            ) else {
+                return GateExecResult::Failed;
+            };
+            if hi < lo || (hi - lo) as u128 > UNROLL_MAX_ITERATIONS {
+                return GateExecResult::Failed;
+            }
+            for value in lo..hi {
+                env.insert(variable.clone(), ConstVal::Int(value));
+                match gate_exec_node(body, env, context, state) {
+                    GateExecResult::Continue => {}
+                    result => return result,
+                }
+            }
+            env.remove(variable);
+            GateExecResult::Continue
+        }
+        // A standalone pure call has no state effect. Evaluate it so an opaque
+        // or non-terminating body still fails the exact interpreter.
+        AstNode::FunctionCall { .. } | AstNode::DiscardStatement { .. } => {
+            let expression = match node {
+                AstNode::FunctionCall { .. } => node,
+                AstNode::DiscardStatement { expression, .. } => expression.as_ref(),
+                _ => unreachable!(),
+            };
+            let value = gate_eval_with_state(expression, env, Some(context), state);
+            if gate_value_is_concrete(&value) {
+                GateExecResult::Continue
+            } else {
+                GateExecResult::Failed
+            }
+        }
+        _ => GateExecResult::Failed,
+    }
+}
+
+fn gate_eval_with_state(
+    node: &AstNode,
+    env: &GateEnv,
+    context: Option<&GateContext>,
+    state: &mut GateEvalState,
+) -> ConstVal {
+    if !gate_take_fuel(state) {
+        return ConstVal::Top;
+    }
     match node {
         AstNode::Literal {
             value: crate::ast::Value::Int { value, .. },
@@ -8110,8 +10498,10 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
             from_list: false,
         },
         AstNode::Identifier(name, _) => env.get(name).cloned().unwrap_or(ConstVal::Top),
-        AstNode::UnaryOperation { op, operand, .. } => match (op.as_str(), gate_eval(operand, env))
-        {
+        AstNode::UnaryOperation { op, operand, .. } => match (
+            op.as_str(),
+            gate_eval_with_state(operand, env, context, state),
+        ) {
             ("-", ConstVal::Int(v)) => ConstVal::Int(-v),
             ("not", ConstVal::Bit { val, from_list }) => ConstVal::Bit {
                 val: (val ^ 1) & 1,
@@ -8121,9 +10511,12 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
         },
         AstNode::BinaryOperation {
             op, left, right, ..
-        } => gate_eval_binop(op, left, right, env),
+        } => gate_eval_binop_with_state(op, left, right, env, context, state),
         AstNode::IndexAccess { base, index, .. } => {
-            match (gate_eval(base, env), gate_eval(index, env)) {
+            match (
+                gate_eval_with_state(base, env, context, state),
+                gate_eval_with_state(index, env, context, state),
+            ) {
                 (ConstVal::List(elems), ConstVal::Int(i))
                     if i >= 0 && (i as usize) < elems.len() =>
                 {
@@ -8145,9 +10538,12 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
                 _ => ConstVal::Top,
             }
         }
-        AstNode::ListLiteral { elements, .. } => {
-            ConstVal::List(elements.iter().map(|e| gate_eval(e, env)).collect())
-        }
+        AstNode::ListLiteral { elements, .. } => ConstVal::List(
+            elements
+                .iter()
+                .map(|element| gate_eval_with_state(element, env, context, state))
+                .collect(),
+        ),
         AstNode::FunctionCall {
             function,
             arguments,
@@ -8155,15 +10551,25 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
         } => {
             let call = call_name_of(function);
             let base = call.as_deref().map(builtin_base_name);
+            if call.as_deref().is_some_and(is_len_builtin) && arguments.len() == 1 {
+                if let ConstVal::List(values) =
+                    gate_eval_with_state(&arguments[0], env, context, state)
+                {
+                    return ConstVal::Int(values.len() as i128);
+                }
+            }
             if matches!(base, Some("from_clear_int") | Some("from_clear_uint"))
                 && arguments.len() >= 2
             {
-                let v = match gate_eval(&arguments[0], env) {
+                let v = match gate_eval_with_state(&arguments[0], env, context, state) {
                     ConstVal::Int(v) => Some(v),
                     ConstVal::Bit { val, .. } => Some(val as i128),
                     _ => None,
                 };
-                let width_one = matches!(gate_eval(&arguments[1], env), ConstVal::Int(1));
+                let width_one = matches!(
+                    gate_eval_with_state(&arguments[1], env, context, state),
+                    ConstVal::Int(1)
+                );
                 if let (Some(v), true) = (v, width_one) {
                     if v == 0 || v == 1 {
                         return ConstVal::Bit {
@@ -8178,8 +10584,8 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
             // propagation and is required to recognize public batch operands
             // assembled from local helper calls rather than direct literals.
             if arguments.len() == 2 {
-                let lhs = gate_eval(&arguments[0], env);
-                let rhs = gate_eval(&arguments[1], env);
+                let lhs = gate_eval_with_state(&arguments[0], env, context, state);
+                let rhs = gate_eval_with_state(&arguments[1], env, context, state);
                 match base {
                     Some("add") | Some("sub") => {
                         if let (
@@ -8241,16 +10647,28 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
                 }
             }
             if matches!(base, Some("copy")) && arguments.len() == 1 {
-                return gate_eval(&arguments[0], env);
+                return gate_eval_with_state(&arguments[0], env, context, state);
             }
             if matches!(base, Some("slice")) && arguments.len() == 3 {
                 if let (ConstVal::List(values), ConstVal::Int(start), ConstVal::Int(end)) = (
-                    gate_eval(&arguments[0], env),
-                    gate_eval(&arguments[1], env),
-                    gate_eval(&arguments[2], env),
+                    gate_eval_with_state(&arguments[0], env, context, state),
+                    gate_eval_with_state(&arguments[1], env, context, state),
+                    gate_eval_with_state(&arguments[2], env, context, state),
                 ) {
                     if start >= 0 && end >= start && (end as usize) <= values.len() {
                         return ConstVal::List(values[start as usize..end as usize].to_vec());
+                    }
+                }
+            }
+            if let Some(name) = call.as_deref() {
+                if context.is_some_and(|context| context.functions.contains_key(name)) {
+                    let values = arguments
+                        .iter()
+                        .map(|argument| gate_eval_with_state(argument, env, context, state))
+                        .collect();
+                    let result = gate_eval_user_function(name, values, context, state);
+                    if gate_value_is_concrete(&result) {
+                        return result;
                     }
                 }
             }
@@ -8276,9 +10694,16 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
 /// Evaluate a binary operation over provenance facts. Arithmetic folds over
 /// `Int`; `and`/`or`/`xor` fold ONLY when BOTH sides are public bits (no
 /// short-circuit — that keeps the reasoning trivially sound).
-fn gate_eval_binop(op: &str, left: &AstNode, right: &AstNode, env: &GateEnv) -> ConstVal {
-    let l = gate_eval(left, env);
-    let r = gate_eval(right, env);
+fn gate_eval_binop_with_state(
+    op: &str,
+    left: &AstNode,
+    right: &AstNode,
+    env: &GateEnv,
+    context: Option<&GateContext>,
+    state: &mut GateEvalState,
+) -> ConstVal {
+    let l = gate_eval_with_state(left, env, context, state);
+    let r = gate_eval_with_state(right, env, context, state);
     match op {
         "+" | "-" | "*" | "/" | "%" => {
             if let (ConstVal::Int(a), ConstVal::Int(b)) = (&l, &r) {
@@ -8293,6 +10718,24 @@ fn gate_eval_binop(op: &str, left: &AstNode, right: &AstNode, env: &GateEnv) -> 
                 return res.map(ConstVal::Int).unwrap_or(ConstVal::Top);
             }
             ConstVal::Top
+        }
+        "==" | "!=" | "<" | "<=" | ">" | ">=" => {
+            if let (ConstVal::Int(a), ConstVal::Int(b)) = (&l, &r) {
+                let value = match op {
+                    "==" => a == b,
+                    "!=" => a != b,
+                    "<" => a < b,
+                    "<=" => a <= b,
+                    ">" => a > b,
+                    _ => a >= b,
+                };
+                ConstVal::Bit {
+                    val: u8::from(value),
+                    from_list: false,
+                }
+            } else {
+                ConstVal::Top
+            }
         }
         "and" | "or" | "xor" => {
             if let (
@@ -8669,6 +11112,7 @@ fn process_kept_statement(node: AstNode, env: &mut LenEnv, budget: &mut usize) -
         }
         _ => {
             apply_statement_to_env(&node, env);
+            record_batch_result_width_from_env(&node, env);
             node
         }
     }
@@ -12361,7 +14805,107 @@ mod tests {
     }
 
     #[test]
-    fn batching_fixpoint_fuses_newly_normalized_scalar_and_vector_multiplies() {
+    fn pure_constant_dispatch_result_propagates_across_a_call_boundary() {
+        let loc = make_loc();
+        let ident = |name: &str| AstNode::Identifier(name.to_string(), loc.clone());
+        let dispatch = AstNode::FunctionDefinition {
+            name: Some("dispatch_bit".to_string()),
+            type_params: Vec::new(),
+            parameters: vec![Parameter {
+                name: "selector".to_string(),
+                type_annotation: Some(Box::new(ident("int64"))),
+                default_value: None,
+                is_secret: false,
+                is_variadic: false,
+            }],
+            return_type: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+            body: Box::new(AstNode::Block(vec![
+                AstNode::IfExpression {
+                    condition: Box::new(AstNode::BinaryOperation {
+                        op: "==".to_string(),
+                        left: Box::new(ident("selector")),
+                        right: Box::new(super::make_int_literal(1, &loc)),
+                        location: loc.clone(),
+                    }),
+                    then_branch: Box::new(AstNode::Block(vec![AstNode::Return {
+                        value: Some(Box::new(make_from_clear_int_bit(1, &loc))),
+                        location: loc.clone(),
+                    }])),
+                    else_branch: None,
+                },
+                AstNode::Return {
+                    value: Some(Box::new(make_from_clear_int_bit(0, &loc))),
+                    location: loc.clone(),
+                },
+            ])),
+            is_secret: false,
+            pragmas: Vec::new(),
+            location: loc.clone(),
+            node_id: 0,
+        };
+        let main = AstNode::FunctionDefinition {
+            name: Some("main".to_string()),
+            type_params: Vec::new(),
+            parameters: Vec::new(),
+            return_type: None,
+            body: Box::new(AstNode::Block(vec![
+                AstNode::VariableDeclaration {
+                    name: "selected".to_string(),
+                    type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+                    value: Some(Box::new(AstNode::FunctionCall {
+                        function: Box::new(ident("dispatch_bit")),
+                        arguments: vec![super::make_int_literal(1, &loc)],
+                        location: loc.clone(),
+                        resolved_return_type: None,
+                    })),
+                    is_mutable: false,
+                    is_secret: true,
+                    location: loc.clone(),
+                },
+                AstNode::VariableDeclaration {
+                    name: "product".to_string(),
+                    type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+                    value: Some(Box::new(AstNode::BinaryOperation {
+                        op: "and".to_string(),
+                        left: Box::new(ident("selected")),
+                        right: Box::new(make_from_clear_int_bit(1, &loc)),
+                        location: loc.clone(),
+                    })),
+                    is_mutable: false,
+                    is_secret: true,
+                    location: loc.clone(),
+                },
+            ])),
+            is_secret: false,
+            pragmas: Vec::new(),
+            location: loc.clone(),
+            node_id: 1,
+        };
+
+        let AstNode::Block(functions) = fold_public_gates(AstNode::Block(vec![dispatch, main]))
+        else {
+            panic!("expected program block");
+        };
+        let AstNode::FunctionDefinition { body, .. } = &functions[1] else {
+            panic!("expected main function");
+        };
+        let AstNode::Block(statements) = body.as_ref() else {
+            panic!("expected main body");
+        };
+        assert!(matches!(
+            &statements[0],
+            AstNode::VariableDeclaration { value: Some(value), .. }
+                if call_name(value) == Some("dispatch_bit")
+        ));
+        assert!(matches!(
+            &statements[1],
+            AstNode::VariableDeclaration { value: Some(value), .. }
+                if call_name(value) == Some("Share.from_clear_int")
+        ));
+    }
+
+    #[test]
+    fn batcher_directly_fuses_scalar_and_vector_multiplies() {
         reset_temp_counter();
         let loc = make_loc();
         let ident = |name: &str| AstNode::Identifier(name.to_string(), loc.clone());
@@ -12409,13 +14953,13 @@ mod tests {
 
         assert_eq!(
             count_batch_calls(&once),
-            2,
-            "first pass has incompatible forms"
+            1,
+            "a scalar contributes one lane to the vector protocol call"
         );
         assert_eq!(
             count_batch_calls(&fixed),
             1,
-            "fixpoint must fuse the normalized scalar batch with the vector batch"
+            "the mixed batch must already be structurally stable"
         );
     }
 
@@ -12860,9 +15404,14 @@ mod tests {
             .collect();
         let global_key = interner.global();
         let key_bound = interner.key_bound();
+        let work: Vec<Option<usize>> = stmts
+            .iter()
+            .zip(&infos)
+            .map(|(stmt, info)| scheduled_interactive_work(stmt, info.interactive))
+            .collect();
 
-        let full = build_schedule_order(&infos, key_bound, global_key, false);
-        let pruned = build_schedule_order(&infos, key_bound, global_key, true);
+        let full = build_schedule_order(&infos, &work, key_bound, global_key, false, None);
+        let pruned = build_schedule_order(&infos, &work, key_bound, global_key, true, None);
         assert!(full.is_some(), "unexpected dependency cycle");
         assert_eq!(full, pruned);
         // The mutator calls pin the accumulator order, so appends must stay in
@@ -13306,6 +15855,18 @@ mod tests {
             resolved_return_type: None,
         };
         assert_eq!(is_share_open_call(&reveal_call), Some(&share_expr));
+
+        let user_open = AstNode::FunctionCall {
+            function: Box::new(make_identifier("open")),
+            arguments: vec![share_expr],
+            location: make_loc(),
+            resolved_return_type: Some(crate::symbol_table::SymbolType::Int64),
+        };
+        assert_eq!(
+            is_share_open_call(&user_open),
+            None,
+            "an unrelated user function named open must not be scheduled as an MPC reveal"
+        );
     }
 
     #[test]
@@ -13484,6 +16045,39 @@ mod tests {
             &batched[0],
             AstNode::VariableDeclaration { value: Some(value), .. }
                 if call_name(value) == Some("Share.batch_open")
+        ));
+    }
+
+    #[test]
+    fn reveal_reorder_preserves_abrupt_control_boundaries() {
+        let conditional_return = AstNode::IfExpression {
+            condition: Box::new(make_identifier("opened")),
+            then_branch: Box::new(AstNode::Block(vec![AstNode::Return {
+                value: Some(Box::new(make_int_literal(1))),
+                location: make_loc(),
+            }])),
+            else_branch: None,
+        };
+        let trailing_return = AstNode::Return {
+            value: Some(Box::new(make_int_literal(0))),
+            location: make_loc(),
+        };
+        let reordered = reorder_for_reveal_batching(AstNode::Block(vec![
+            make_var_decl("opened", make_share_open(make_identifier("secret"))),
+            conditional_return,
+            trailing_return,
+        ]));
+
+        let AstNode::Block(statements) = reordered else {
+            panic!("expected block");
+        };
+        assert!(matches!(
+            &statements[..],
+            [
+                AstNode::VariableDeclaration { name, .. },
+                AstNode::IfExpression { .. },
+                AstNode::Return { .. },
+            ] if name == "opened"
         ));
     }
 
@@ -13771,6 +16365,128 @@ mod tests {
     }
 
     #[test]
+    fn explicit_share_mul_calls_are_first_class_batch_candidates() {
+        reset_temp_counter();
+        let mul = |left: &str, right: &str| {
+            make_call(
+                "Share.mul",
+                vec![make_identifier(left), make_identifier(right)],
+            )
+        };
+        let block = AstNode::Block(vec![
+            make_var_decl("a", mul("x", "y")),
+            make_var_decl("b", mul("p", "q")),
+        ]);
+
+        let scheduled = schedule_for_batching(block);
+        let optimized = optimize_multiply_batches_to_fixpoint(scheduled);
+        assert_eq!(
+            count_calls_named(&optimized, "Share.batch_mul"),
+            1,
+            "independent singular Share.mul calls must lower to one native batch"
+        );
+        assert_eq!(
+            count_calls_named(&optimized, "Share.mul"),
+            0,
+            "no scalar Share.mul call should survive the fused round"
+        );
+    }
+
+    #[test]
+    fn explicit_share_mul_dependency_still_requires_two_rounds() {
+        reset_temp_counter();
+        let mul = |left: &str, right: &str| {
+            make_call(
+                "Share.mul",
+                vec![make_identifier(left), make_identifier(right)],
+            )
+        };
+        let block = AstNode::Block(vec![
+            make_var_decl("a", mul("x", "y")),
+            make_var_decl("b", mul("a", "q")),
+        ]);
+
+        let scheduled = schedule_for_batching(block);
+        let optimized = optimize_multiply_batches_to_fixpoint(scheduled);
+        assert_eq!(
+            count_calls_named(&optimized, "Share.batch_mul"),
+            2,
+            "a consumer cannot share its producer's online round"
+        );
+    }
+
+    #[test]
+    fn explicit_share_mul_batching_respects_backend_capacity() {
+        reset_temp_counter();
+        let mul = |left: &str, right: &str| {
+            make_call(
+                "Share.mul",
+                vec![make_identifier(left), make_identifier(right)],
+            )
+        };
+        let block = AstNode::Block(vec![
+            make_var_decl("a", mul("a0", "a1")),
+            make_var_decl("b", mul("b0", "b1")),
+            make_var_decl("c", mul("c0", "c1")),
+        ]);
+
+        let optimized = with_multiply_capacity(2, || {
+            let scheduled = schedule_for_batching(block);
+            optimize_multiply_batches_to_fixpoint(scheduled)
+        });
+        assert_eq!(
+            count_calls_named(&optimized, "Share.batch_mul"),
+            2,
+            "three independent products require two capacity-two protocol calls"
+        );
+    }
+
+    #[test]
+    fn clear_field_mul_is_not_an_interactive_batch_candidate() {
+        reset_temp_counter();
+        let block = AstNode::Block(vec![
+            make_var_decl(
+                "a",
+                make_call(
+                    "Field.mul",
+                    vec![make_identifier("x"), make_identifier("y")],
+                ),
+            ),
+            make_var_decl(
+                "b",
+                make_call(
+                    "Field.mul",
+                    vec![make_identifier("p"), make_identifier("q")],
+                ),
+            ),
+        ]);
+
+        let optimized = optimize_multiply_batches_to_fixpoint(schedule_for_batching(block));
+        assert_eq!(count_calls_named(&optimized, "Share.batch_mul"), 0);
+        assert_eq!(count_calls_named(&optimized, "Field.mul"), 2);
+    }
+
+    #[test]
+    fn user_defined_mul_returning_share_is_not_a_builtin_batch_candidate() {
+        use crate::symbol_table::SymbolType;
+
+        let user_mul = || AstNode::FunctionCall {
+            function: Box::new(make_identifier("mul")),
+            arguments: vec![make_identifier("x"), make_identifier("y")],
+            location: make_loc(),
+            resolved_return_type: Some(SymbolType::Object("Share".to_string())),
+        };
+        let block = AstNode::Block(vec![
+            make_var_decl("a", user_mul()),
+            make_var_decl("b", user_mul()),
+        ]);
+
+        let optimized = optimize_multiply_batches_to_fixpoint(schedule_for_batching(block));
+        assert_eq!(count_calls_named(&optimized, "Share.batch_mul"), 0);
+        assert_eq!(count_calls_named(&optimized, "mul"), 2);
+    }
+
+    #[test]
     fn test_no_batch_secret_multiply_with_dependency() {
         reset_temp_counter();
 
@@ -13958,6 +16674,41 @@ mod tests {
             assert_eq!(get_var_decl_name(&stmts[3]), Some("x"));
         } else {
             panic!("Expected Block");
+        }
+    }
+
+    fn reveal_reorder_work(units: usize) -> RevealReorderWork {
+        let mut statements = Vec::with_capacity(units * 3);
+        for index in 0..units {
+            let secret = format!("s{index}");
+            let revealed = format!("r{index}");
+            let flushed = format!("f{index}");
+            statements.push(make_secret_var_decl(
+                &secret,
+                make_identifier(&format!("input{index}")),
+            ));
+            statements.push(make_var_decl(&revealed, make_identifier(&secret)));
+            statements.push(make_var_decl(
+                &flushed,
+                make_binary_op(make_identifier(&revealed), "+", make_int_literal(1)),
+            ));
+        }
+        let mut work = RevealReorderWork::default();
+        let reordered = reorder_block_for_reveals_with_work(statements, &mut work);
+        assert_eq!(reordered.len(), units * 3);
+        work
+    }
+
+    #[test]
+    fn reveal_reorder_work_scales_with_graph_size() {
+        let small = reveal_reorder_work(64);
+        let medium = reveal_reorder_work(128);
+        let large = reveal_reorder_work(256);
+
+        for (units, work) in [(64, small), (128, medium), (256, large)] {
+            assert_eq!(work.dependency_key_probes, units * 9);
+            assert_eq!(work.dependency_edges, units * 2);
+            assert_eq!(work.ready_queue_operations, units * 6);
         }
     }
 
@@ -14516,6 +17267,17 @@ mod tests {
 
     // ===== Round-minimizing list scheduler =====
 
+    fn with_multiply_capacity<T>(capacity: usize, f: impl FnOnce() -> T) -> T {
+        let previous = ACTIVE_MPC_SCHEDULING.with(|active| {
+            active.replace(MpcSchedulingOptions {
+                multiply_batch_capacity: Some(capacity),
+            })
+        });
+        let result = f();
+        ACTIVE_MPC_SCHEDULING.with(|active| active.set(previous));
+        result
+    }
+
     #[test]
     fn test_scheduler_clusters_independent_chains_by_round() {
         // Two independent 2-deep multiply chains, interleaved by definition order:
@@ -14550,6 +17312,134 @@ mod tests {
             vec!["a1", "b1", "a2", "b2"],
             "depth-1 multiplies cluster, then depth-2 multiplies"
         );
+    }
+
+    #[test]
+    fn capacity_scheduler_prioritizes_the_critical_multiply_chain() {
+        // With capacity two, source-order scheduling would spend the first
+        // round on b1+c1 and only then start the three-deep `a` chain (4 total
+        // rounds). Bottom-level priority starts a1 immediately and fills the
+        // spare slot with b1, attaining the critical-path lower bound of 3.
+        let block = AstNode::Block(vec![
+            make_secret_var_decl(
+                "b1",
+                make_binary_op(make_identifier("bx"), "and", make_identifier("by")),
+            ),
+            make_secret_var_decl(
+                "c1",
+                make_binary_op(make_identifier("cx"), "and", make_identifier("cy")),
+            ),
+            make_secret_var_decl(
+                "a1",
+                make_binary_op(make_identifier("ax"), "and", make_identifier("ay")),
+            ),
+            make_secret_var_decl(
+                "a2",
+                make_binary_op(make_identifier("a1"), "and", make_identifier("az")),
+            ),
+            make_secret_var_decl(
+                "a3",
+                make_binary_op(make_identifier("a2"), "and", make_identifier("aw")),
+            ),
+        ]);
+
+        let scheduled = with_multiply_capacity(2, || schedule_for_batching(block));
+        let AstNode::Block(stmts) = &scheduled else {
+            panic!("expected block");
+        };
+        let names: Vec<&str> = stmts.iter().filter_map(get_var_decl_name).collect();
+        assert_eq!(names, vec!["a1", "b1", "a2", "c1", "a3"]);
+
+        let batched = with_multiply_capacity(2, || optimize_multiplies(scheduled));
+        assert_eq!(
+            count_calls_named(&batched, "Share.batch_mul"),
+            3,
+            "capacity-aware fusion must preserve the three legal rounds"
+        );
+    }
+
+    #[test]
+    fn capacity_bounded_batcher_does_not_guess_unknown_vector_widths() {
+        let block = AstNode::Block(vec![
+            make_var_decl("m1", make_typed_batch_mul("a", "b")),
+            make_var_decl("m2", make_typed_batch_mul("c", "d")),
+        ]);
+        let out = with_multiply_capacity(256, || optimize_multiplies(block));
+        assert_eq!(
+            count_calls_named(&out, "Share.batch_mul"),
+            2,
+            "opaque widths are isolated instead of being assumed to fit"
+        );
+    }
+
+    #[test]
+    fn singular_multiply_joins_an_exact_vector_round_only_when_it_fits() {
+        fn circuit() -> AstNode {
+            let list = |names: &[&str]| AstNode::ListLiteral {
+                elements: names.iter().map(|name| make_identifier(name)).collect(),
+                location: make_loc(),
+            };
+            AstNode::Block(vec![
+                make_var_decl("lefts", list(&["a", "b"])),
+                make_var_decl("rights", list(&["x", "y"])),
+                make_var_decl("vector", make_typed_batch_mul("lefts", "rights")),
+                make_secret_var_decl(
+                    "scalar",
+                    make_binary_op(make_identifier("c"), "and", make_identifier("z")),
+                ),
+            ])
+        }
+
+        let optimize = |capacity| {
+            reset_temp_counter();
+            with_multiply_capacity(capacity, || {
+                let exact = unroll_literal_loops(circuit());
+                let scheduled = schedule_for_batching(exact);
+                optimize_multiply_batches_to_fixpoint(scheduled)
+            })
+        };
+
+        assert_eq!(
+            count_calls_named(&optimize(3), "Share.batch_mul"),
+            1,
+            "two vector lanes plus one singular product fit one round"
+        );
+        assert_eq!(
+            count_calls_named(&optimize(2), "Share.batch_mul"),
+            2,
+            "the singular product must not overflow a full vector round"
+        );
+    }
+
+    #[test]
+    fn unroller_exports_exact_source_batch_work_without_scope_guessing() {
+        reset_temp_counter();
+        let list = |names: &[&str]| AstNode::ListLiteral {
+            elements: names.iter().map(|name| make_identifier(name)).collect(),
+            location: make_loc(),
+        };
+        let block = AstNode::Block(vec![
+            make_var_decl("lefts", list(&["a", "b", "c"])),
+            make_var_decl("rights", list(&["x", "y", "z"])),
+            make_var_decl("products", make_typed_batch_mul("lefts", "rights")),
+        ]);
+        let _ = unroll_literal_loops(block);
+        let location = make_loc();
+        assert_eq!(interactive_width("products", &location), Some(3));
+
+        // A same-named result at another source site is a separate fact and
+        // cannot overwrite or supply the first statement's capacity proof.
+        let other_location = SourceLocation {
+            line: location.line + 1,
+            ..location.clone()
+        };
+        record_interactive_width("products", &other_location, 4);
+        assert_eq!(
+            interactive_width("products", &location),
+            Some(3),
+            "same-named bindings at distinct sites must not share widths"
+        );
+        assert_eq!(interactive_width("products", &other_location), Some(4));
     }
 
     #[test]
@@ -14895,6 +17785,7 @@ mod tests {
         left: AstNode,
         right: AstNode,
     ) -> MultiplyCandidate {
+        let work = exact_batch_operand_width(&left);
         MultiplyCandidate {
             statement_index: idx,
             target_key: target.to_string(),
@@ -14909,6 +17800,7 @@ mod tests {
             is_mutable: false,
             is_secret: false,
             is_batched: true,
+            work,
         }
     }
 

--- a/crates/stoffel-lang/src/optimizations.rs
+++ b/crates/stoffel-lang/src/optimizations.rs
@@ -1587,6 +1587,21 @@ pub fn optimize_multiplies(node: AstNode) -> AstNode {
     }
 }
 
+/// Re-run dependency scheduling and multiply fusion until batching no longer
+/// changes the program. A first fusion can normalize scalar Boolean gates into
+/// `Share.batch_mul`, making them compatible with an adjacent call-form batch
+/// only on the next iteration.
+fn optimize_multiply_batches_to_fixpoint(mut node: AstNode) -> AstNode {
+    for _ in 0..8 {
+        let next = optimize_multiplies(schedule_for_batching(node.clone()));
+        if next == node {
+            break;
+        }
+        node = next;
+    }
+    node
+}
+
 /// Checks if an AST node is a Share.open() receiver method call.
 fn is_share_open_call(node: &AstNode) -> Option<&AstNode> {
     if let AstNode::FunctionCall {
@@ -3376,6 +3391,19 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     };
     let node = timed_pass("optimize_reveals", || optimize_reveals(node));
     let node = timed_pass("optimize_multiplies", || optimize_multiplies(node));
+    // Batching materializes accumulator setup and result-slice statements around
+    // every fused call. Those new statements can expose another legal merge that
+    // did not exist in the input graph (most commonly independently vectorized
+    // regions at the same MPC depth). Rebuild the dependency DAG on each newly
+    // materialized form until it is structurally stable. The cap is a defensive
+    // compiler-time bound; in practice the corpus converges in one extra round.
+    let node = if optimization_level >= 3 {
+        timed_pass("batching_fixpoint", || {
+            optimize_multiply_batches_to_fixpoint(node)
+        })
+    } else {
+        node
+    };
     let node = timed_pass("reorder_for_reveal_batching", || {
         reorder_for_reveal_batching(node)
     });
@@ -3734,13 +3762,13 @@ fn loop_sched_info(
 /// (control flow, returns, reveals, unknown/user calls) that pins the schedule.
 fn stmt_is_schedulable(stmt: &AstNode, pure_fns: &HashSet<String>) -> bool {
     match stmt {
-        AstNode::VariableDeclaration { value, .. } => {
-            value.as_deref().is_none_or(|v| expr_is_pure(v, pure_fns))
-        }
+        AstNode::VariableDeclaration { value, .. } => value
+            .as_deref()
+            .is_none_or(|v| expr_is_reorderable(v, pure_fns)),
         AstNode::Assignment { target, value, .. } => {
             (matches!(target.as_ref(), AstNode::Identifier(_, _)) || root_var(target).is_some())
                 && expr_is_pure(target, pure_fns)
-                && expr_is_pure(value, pure_fns)
+                && expr_is_reorderable(value, pure_fns)
         }
         AstNode::FunctionCall { arguments, .. } => call_name(stmt).is_some_and(|name| {
             is_mutator_call_name(name) && arguments.iter().all(|arg| expr_is_pure(arg, pure_fns))
@@ -5589,12 +5617,16 @@ const UNROLL_MAX_ITERATIONS: u128 = 1024;
 /// would otherwise allow it.
 const UNROLL_MAX_EXPANSION: usize = 50_000;
 
+/// Base O3 threshold for a loop whose iterations have a whole-variable
+/// recurrence. This mirrors LLVM's aggressive full-unroll threshold: without
+/// cross-iteration MPC batching benefit, ordinary code-size profitability
+/// applies. Independent loops receive the much larger MPC-specific boost above.
+const SERIAL_UNROLL_MAX_EXPANSION: usize = 300;
+
 /// A loop with at most this many iterations is allowed to unroll even when its
 /// inner-unrolled estimate exceeds `UNROLL_MAX_EXPANSION`, provided the *raw*
-/// duplication cost (iterations * raw body) still fits the global budget. This
-/// exposes the statically-known per-iteration shape of low-trip outer loops over
-/// heavy bodies (the CTR/CBC per-block loop) to the inner-loop batcher. See the
-/// LEVER 1 note in `try_unroll_for`.
+/// duplication cost still fits the global budget. This exposes statically-known
+/// low-trip outer-loop shapes to the MPC multiply batcher.
 const SMALL_TRIP_UNROLL: usize = 10;
 
 /// Global blowup budget, overridable via the `unroll` budget (threaded from
@@ -5635,7 +5667,7 @@ fn unroll_max_expansion() -> usize {
 // ---------------------------------------------------------------------------
 
 /// Statically known list shape: a length and its recursive element shape.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum Shape {
     List { len: usize, elem: Box<Shape> },
     Unknown,
@@ -5892,14 +5924,30 @@ fn eval_shape(node: &AstNode, env: &LenEnv) -> Shape {
             ..
         } => {
             if let AstNode::Identifier(name, _) = function.as_ref() {
-                match name.as_str() {
+                match builtin_base_name(name) {
                     "create_array" => Shape::flat(0),
                     // `batch_mul` yields a list of products the same length as
-                    // its (left) input.
-                    "Share.batch_mul" => arguments
+                    // its (left) input. `copy` mints a fresh list object but
+                    // preserves all list dimensions.
+                    "batch_mul" | "copy" => arguments
                         .first()
                         .map(|a| eval_shape(a, env))
                         .unwrap_or(Shape::Unknown),
+                    "slice" => match (
+                        arguments.first().map(|a| eval_shape(a, env)),
+                        arguments.get(1).and_then(|a| eval_int(a, env)),
+                        arguments.get(2).and_then(|a| eval_int(a, env)),
+                    ) {
+                        (Some(Shape::List { len, elem }), Some(start), Some(end))
+                            if end >= start && end <= len as u128 =>
+                        {
+                            Shape::List {
+                                len: (end - start) as usize,
+                                elem,
+                            }
+                        }
+                        _ => Shape::Unknown,
+                    },
                     _ => Shape::Unknown,
                 }
             } else {
@@ -6076,6 +6124,230 @@ fn apply_statement_to_env(stmt: &AstNode, env: &mut LenEnv) {
         AstNode::DiscardStatement { expression, .. } => apply_call_to_env(expression, env),
         other => apply_call_to_env(other, env),
     }
+}
+
+/// Intersect two control-flow environments.  A fact survives a join only when
+/// both incoming paths prove exactly the same value.  Alias facts obey the same
+/// rule: dropping an alias on just one path would let a later mutation leave a
+/// stale shape on the other name.
+fn meet_len_env(left: LenEnv, right: &LenEnv) -> LenEnv {
+    let shapes = left
+        .shapes
+        .into_iter()
+        .filter(|(name, shape)| right.shapes.get(name) == Some(shape))
+        .collect();
+    let ints = left
+        .ints
+        .into_iter()
+        .filter(|(name, value)| right.ints.get(name) == Some(value))
+        .collect();
+    let aliases = left
+        .aliases
+        .into_iter()
+        .filter(|(name, group)| {
+            right
+                .aliases
+                .get(name)
+                .is_some_and(|other| other.as_ref() == group.as_ref())
+        })
+        .collect();
+    LenEnv {
+        shapes,
+        ints,
+        aliases,
+    }
+}
+
+/// Conservatively forget every fact a control-flow construct may mutate.
+fn invalidate_node_mutations(node: &AstNode, env: &mut LenEnv) {
+    let mut mutated = HashSet::new();
+    collect_mutated_vars(node, &mut mutated);
+    for name in mutated {
+        env.invalidate(&name);
+        env.alias_unbind(&name);
+    }
+}
+
+/// Whether exact iteration of a nested counted loop would have to model an
+/// abrupt exit.  The loop-shape analysis deliberately declines those cases;
+/// normal compiler control-flow lowering can make them analyzable later.
+fn has_abrupt_loop_control(node: &AstNode) -> bool {
+    match node {
+        AstNode::Return { .. } | AstNode::Yield(_) | AstNode::Break | AstNode::Continue => true,
+        // A nested function is a separate control-flow region.
+        AstNode::FunctionDefinition { .. } => false,
+        _ => {
+            let mut abrupt = false;
+            for_each_child(node, &mut |child| {
+                abrupt |= has_abrupt_loop_control(child);
+            });
+            abrupt
+        }
+    }
+}
+
+/// Abstractly execute a node using only exact list-shape and clear-integer
+/// facts.  `fuel` bounds compile time on large inlined programs.  Returning
+/// false means the caller must discard the attempted proof.
+fn transfer_len_env(node: &AstNode, env: &mut LenEnv, fuel: &mut usize) -> bool {
+    if *fuel == 0 {
+        return false;
+    }
+    *fuel -= 1;
+    match node {
+        AstNode::Block(statements) => {
+            for statement in statements {
+                if !transfer_len_env(statement, env, fuel) {
+                    return false;
+                }
+            }
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => match const_eval_bool_env(condition, env) {
+            Some(true) => return transfer_len_env(then_branch, env, fuel),
+            Some(false) => {
+                if let Some(branch) = else_branch {
+                    return transfer_len_env(branch, env, fuel);
+                }
+            }
+            None => {
+                let before = env.clone();
+                let mut then_env = before.clone();
+                if !transfer_len_env(then_branch, &mut then_env, fuel) {
+                    return false;
+                }
+                let mut else_env = before;
+                if let Some(branch) = else_branch {
+                    if !transfer_len_env(branch, &mut else_env, fuel) {
+                        return false;
+                    }
+                }
+                *env = meet_len_env(then_env, &else_env);
+            }
+        },
+        AstNode::ForLoop {
+            variables,
+            iterable,
+            body,
+            ..
+        } => {
+            let Some((lo, hi)) = range_bounds(iterable, env) else {
+                invalidate_node_mutations(body, env);
+                return true;
+            };
+            let [variable] = variables.as_slice() else {
+                invalidate_node_mutations(body, env);
+                return true;
+            };
+            if hi < lo
+                || hi.saturating_sub(lo) > UNROLL_MAX_ITERATIONS
+                || has_abrupt_loop_control(body)
+            {
+                invalidate_node_mutations(body, env);
+                return true;
+            }
+            for value in lo..hi {
+                env.alias_unbind(variable);
+                env.shapes.remove(variable);
+                env.ints.insert(variable.clone(), value);
+                if !transfer_len_env(body, env, fuel) {
+                    return false;
+                }
+            }
+            env.alias_unbind(variable);
+            env.shapes.remove(variable);
+            env.ints.remove(variable);
+        }
+        node @ AstNode::WhileLoop { .. } | node @ AstNode::TryCatch { .. } => {
+            invalidate_node_mutations(node, env);
+        }
+        AstNode::FunctionDefinition { .. } => {}
+        AstNode::Return { .. } | AstNode::Yield(_) | AstNode::Break | AstNode::Continue => {
+            return false;
+        }
+        other => apply_statement_to_env(other, env),
+    }
+    true
+}
+
+/// Prove exact facts that are stable from a loop header to the next header.
+/// If abstract execution maps shape S back to S, retaining S in a kept loop is
+/// an induction proof, not a heuristic: every concrete iteration begins and
+/// ends with the same list dimensions.  Facts absent at entry are irrelevant.
+fn loop_invariant_facts(
+    body: &AstNode,
+    entry: &LenEnv,
+    mutated: &HashSet<String>,
+) -> (HashMap<String, Shape>, HashMap<String, u128>) {
+    if !mutated
+        .iter()
+        .any(|name| entry.shapes.contains_key(name) || entry.ints.contains_key(name))
+    {
+        return (HashMap::new(), HashMap::new());
+    }
+
+    // This is only a profitability analysis.  Exhausting the bound loses
+    // precision and falls back to the existing invalidation behavior.
+    let mut exit = entry.clone();
+    let mut fuel = 500_000usize;
+    if !transfer_len_env(body, &mut exit, &mut fuel) {
+        return (HashMap::new(), HashMap::new());
+    }
+
+    let shapes = mutated
+        .iter()
+        .filter_map(|name| {
+            let before = entry.shapes.get(name)?;
+            (exit.shapes.get(name) == Some(before)).then(|| (name.clone(), before.clone()))
+        })
+        .collect();
+    let ints = mutated
+        .iter()
+        .filter_map(|name| {
+            let before = entry.ints.get(name)?;
+            (exit.ints.get(name) == Some(before)).then(|| (name.clone(), *before))
+        })
+        .collect();
+    (shapes, ints)
+}
+
+/// Whether executing the first iteration establishes a new exact outer-list
+/// length for a loop-carried value.  This is the profitability predicate for
+/// one-iteration peeling: the peeled iteration supplies an induction base that
+/// lets the residual kept loop retain the shape with [`loop_invariant_facts`].
+fn first_iteration_established_shapes(
+    body: &AstNode,
+    entry: &LenEnv,
+    var: &str,
+    lo: u128,
+) -> HashMap<String, Shape> {
+    if has_abrupt_loop_control(body) {
+        return HashMap::new();
+    }
+    let mut mutated = HashSet::new();
+    collect_mutated_vars(body, &mut mutated);
+    let mut body_locals = HashSet::new();
+    collect_declared_names(body, &mut body_locals);
+    let mut exit = entry.clone();
+    exit.alias_unbind(var);
+    exit.shapes.remove(var);
+    exit.ints.insert(var.to_string(), lo);
+    let mut fuel = 500_000usize;
+    if !transfer_len_env(body, &mut exit, &mut fuel) {
+        return HashMap::new();
+    }
+    mutated
+        .into_iter()
+        .filter(|name| {
+            !body_locals.contains(name)
+                && entry.shapes.get(name).and_then(Shape::count).is_none()
+                && exit.shapes.get(name).and_then(Shape::count).is_some()
+        })
+        .filter_map(|name| exit.shapes.get(&name).cloned().map(|shape| (name, shape)))
+        .collect()
 }
 
 /// Apply a bare expression statement (typically a call) to the env: model the
@@ -6480,15 +6752,11 @@ fn fold_branches_in_stmts(stmts: Vec<AstNode>) -> Vec<AstNode> {
 // ===========================================================================
 // Public-gate folding (`fold_public_gates`)
 //
-// In the CTR example the 128-bit counter `ctr0` is a *publicly known* constant
-// (`public_block([240..255])`), and `increment_counter_block` ripples a serial
-// `gate_and`/`gate_xor` carry across its bits. Those bits are typed `secret
-// bool`, so the type-driven recognizers treat each gate as an MPC multiply — but
-// every operand's clear VALUE is compile-time public. This pass proves, with a
-// strict flow-sensitive provenance analysis, that BOTH operands of an
-// `and`/`or`/`xor` are public bits *read out of a tracked public list*, and only
-// then rewrites that single gate node to `Share.from_clear_int(bit, 1)` (a local,
-// communication-free share of the computed bit).
+// Flow-sensitive public/secret provenance lowers Boolean gates that do not need
+// an interactive multiplication. A fully-public gate becomes
+// `Share.from_clear_int`; a semantically-secret value combined with a known
+// public bit becomes `Share.mul_scalar`, `Share.add_constant`, an identity, or a
+// known result according to the GF(2) truth table.
 //
 // CRYPTO SAFETY (the analysis is conservative-by-default — `Top` = leave alone):
 //   * A `Bit`/`Int`/`List` value originates ONLY from integer/bool literals and
@@ -6496,14 +6764,11 @@ fn fold_branches_in_stmts(stmts: Vec<AstNode>) -> Vec<AstNode> {
 //     `take_client_byte`/`take_share_bool` input, a `Share.mul`/`batch_mul`
 //     result, a `reveal`, an unknown call, an untracked variable) evaluates to
 //     `Top`, so a genuinely-secret operand can never be proven public.
-//   * The ONLY AST rewrite performed is replacing a scalar `and`/`or`/`xor`
-//     BinaryOperation with a scalar `Share.from_clear_int` — list values are
-//     never materialized back into the tree, so no list can ever be substituted
-//     where a scalar share is read (e.g. by a later `Share.batch_mul`).
-//   * A gate folds only if at least one operand was read from a public list
-//     (`from_list`). This is what distinguishes the CTR counter (bits live in the
-//     `counter`/`out` byte lists) from two directly-`from_clear_int` scalars
-//     and-ed together, which must stay a real multiply.
+//   * Secret-by-public localization requires the other operand to carry an
+//     explicit semantic-secret fact. A generic `Top` value may be clear runtime
+//     data and is never rewritten to a Share builtin.
+//   * Replacements use only local share algebra; they consume no preprocessing
+//     and add no online round.
 // ===========================================================================
 
 /// A flow-sensitive provenance fact for a value. `Top` is the conservative
@@ -6511,6 +6776,12 @@ fn fold_branches_in_stmts(stmts: Vec<AstNode>) -> Vec<AstNode> {
 #[derive(Clone)]
 enum ConstVal {
     Top,
+    /// A value proven by semantic typing to be secret, but whose clear value is
+    /// not known at compile time.  Keeping this distinct from `Top` is what
+    /// makes secret-by-public gate localization safe: `Top` may also be an
+    /// ordinary runtime clear value, which must not be rewritten to a Share
+    /// builtin.
+    Secret,
     Int(i128),
     /// A public single bit. `from_list` records that the value was read out of a
     /// tracked public list (directly or via pure propagation) — the signal that
@@ -6524,6 +6795,24 @@ enum ConstVal {
 }
 
 type GateEnv = std::collections::HashMap<String, ConstVal>;
+
+fn annotation_contains_secret_type(annotation: Option<&AstNode>) -> bool {
+    fn contains(node: &AstNode) -> bool {
+        match node {
+            AstNode::SecretType(_) => true,
+            AstNode::ListType(inner) => contains(inner),
+            AstNode::TupleType(items) => items.iter().any(contains),
+            AstNode::DictType {
+                key_type,
+                value_type,
+                ..
+            } => contains(key_type) || contains(value_type),
+            AstNode::GenericType { type_params, .. } => type_params.iter().any(contains),
+            _ => false,
+        }
+    }
+    annotation.is_some_and(contains)
+}
 
 /// Fold provably-public boolean gates throughout the program. Entry point.
 pub fn fold_public_gates(node: AstNode) -> AstNode {
@@ -6540,9 +6829,18 @@ pub fn fold_public_gates(node: AstNode) -> AstNode {
             location,
             node_id,
         } => {
-            // Parameters are unknown at the definition site → `Top`, so a
-            // standalone (uninlined) `gate_and` body never folds.
             let mut env = GateEnv::new();
+            // Parameter values are unknown at the definition site, but their
+            // secrecy is known.  This lets a generic helper such as
+            // `xor_public_bit(secret_x, 1)` lower to a local share operation
+            // without relying on inlining or on an AES-specific calling shape.
+            for parameter in &parameters {
+                if parameter.is_secret
+                    || annotation_contains_secret_type(parameter.type_annotation.as_deref())
+                {
+                    env.insert(parameter.name.clone(), ConstVal::Secret);
+                }
+            }
             let body = Box::new(gate_process_node(*body, &mut env));
             AstNode::FunctionDefinition {
                 name,
@@ -6602,22 +6900,46 @@ fn gate_process_stmt(stmt: AstNode, env: &mut GateEnv) -> AstNode {
             // batcher can gather it. This both saves the multiply rounds and closes
             // the only path that would feed a fully-folded public counter byte (a
             // nested `Array`) into `Share.batch_mul`.
-            let value = value.map(|v| match try_localize_public_batch_mul(&v, env) {
-                Some(localized) => Box::new(localized),
-                None => v,
+            let mut prefix = Vec::new();
+            let value = value.map(|v| {
+                if let Some((batch_prefix, localized)) = try_localize_public_batch_mul(&v, env) {
+                    prefix = batch_prefix;
+                    Box::new(localized)
+                } else {
+                    v
+                }
             });
-            let cv = match &value {
+            // A split prefix contains only the reduced `Share.batch_mul` result.
+            // Teach the ongoing provenance walk that indexing it yields secret
+            // lanes, so a later mixed batch can itself be reduced.
+            for statement in &prefix {
+                if let AstNode::VariableDeclaration { name, .. } = statement {
+                    env.insert(name.clone(), ConstVal::Secret);
+                }
+            }
+            let mut cv = match &value {
                 Some(v) => gate_eval(v, env),
                 None => ConstVal::Top,
             };
+            if matches!(cv, ConstVal::Top)
+                && (is_secret || annotation_contains_secret_type(type_annotation.as_deref()))
+            {
+                cv = ConstVal::Secret;
+            }
             env.insert(name.clone(), cv);
-            AstNode::VariableDeclaration {
+            let declaration = AstNode::VariableDeclaration {
                 name,
                 type_annotation,
                 value,
                 is_mutable,
                 is_secret,
                 location,
+            };
+            if prefix.is_empty() {
+                declaration
+            } else {
+                prefix.push(declaration);
+                AstNode::Block(prefix)
             }
         }
         AstNode::Assignment {
@@ -6628,7 +6950,15 @@ fn gate_process_stmt(stmt: AstNode, env: &mut GateEnv) -> AstNode {
             let value = Box::new(gate_rewrite_expr(*value, env));
             match target.as_ref() {
                 AstNode::Identifier(name, _) => {
-                    let cv = gate_eval(&value, env);
+                    let mut cv = gate_eval(&value, env);
+                    // Assignment does not change a binding's semantic type. If
+                    // the RHS is opaque to this small evaluator, retain a known
+                    // secret fact from the existing binding.
+                    if matches!(cv, ConstVal::Top)
+                        && matches!(env.get(name), Some(ConstVal::Secret))
+                    {
+                        cv = ConstVal::Secret;
+                    }
                     env.insert(name.clone(), cv);
                 }
                 other => {
@@ -6842,41 +7172,32 @@ fn gate_rewrite_expr(node: AstNode, env: &GateEnv) -> AstNode {
         } => {
             let left = Box::new(gate_rewrite_expr(*left, env));
             let right = Box::new(gate_rewrite_expr(*right, env));
-            // Fold a provably-public boolean gate — `and`, `or`, or `xor` — whose
-            // operands are public bits read out of a tracked public list. The CTR
-            // counter ripple is a serial `gate_and` carry chain plus a parallel
-            // `gate_xor` output per bit; folding BOTH empties the counter of every
-            // gate (it becomes a fully-public list of `Share.from_clear_int` bits),
-            // which removes the serial carry-chain rounds AND the parallel xor-bit
-            // multiplies. Folding the `xor` outputs used to be unsafe because a
-            // fully-constant counter byte is then a nested `Array` that the
-            // cross-block batcher mis-fed into `Share.batch_mul`; that path is now
-            // closed by `try_localize_public_batch_mul`, which lowers any
-            // `Share.batch_mul` with a provably-public operand to local
-            // `Share.mul_scalar` BEFORE the batcher runs, so no public list (and no
-            // nested `Array`) ever reaches `batch_mul`.
+            // Fold fully-public gates and localize secret-by-public gates.  In
+            // GF(2), multiplying by a known bit and adding a known bit are local
+            // share operations, so none of these cases requires a Beaver triple
+            // or an online round.
             if op == "and" || op == "or" || op == "xor" {
-                if let (
-                    ConstVal::Bit {
-                        val: a,
-                        from_list: fa,
-                    },
-                    ConstVal::Bit {
-                        val: b,
-                        from_list: fb,
-                    },
-                ) = (gate_eval(&left, env), gate_eval(&right, env))
-                {
-                    // Only fold a gate that consumes at least one public-list bit
-                    // (the counter-table idiom); two free scalar shares stay a
-                    // real multiply (see `inlining_preserves_secret_multiplication`).
-                    if fa || fb {
-                        let bit = match op.as_str() {
-                            "or" => a | b,
-                            "xor" => a ^ b,
-                            _ => a & b,
-                        } & 1;
-                        return make_from_clear_int_bit(bit, &location);
+                let left_value = gate_eval(&left, env);
+                let right_value = gate_eval(&right, env);
+                if let (Some(a), Some(b)) = (
+                    public_bit_value(&left_value),
+                    public_bit_value(&right_value),
+                ) {
+                    let bit = match op.as_str() {
+                        "or" => a | b,
+                        "xor" => a ^ b,
+                        _ => a & b,
+                    } & 1;
+                    return make_from_clear_int_bit(bit, &location);
+                }
+                if matches!(left_value, ConstVal::Secret) {
+                    if let Some(bit) = public_bit_value(&right_value) {
+                        return localize_secret_public_gate(&op, *left, bit, &location);
+                    }
+                }
+                if matches!(right_value, ConstVal::Secret) {
+                    if let Some(bit) = public_bit_value(&left_value) {
+                        return localize_secret_public_gate(&op, *right, bit, &location);
                     }
                 }
             }
@@ -6946,6 +7267,52 @@ fn make_from_clear_int_bit(bit: u8, location: &SourceLocation) -> AstNode {
     }
 }
 
+fn public_bit_value(value: &ConstVal) -> Option<u8> {
+    match value {
+        ConstVal::Bit { val, .. } => Some(*val & 1),
+        _ => None,
+    }
+}
+
+/// Lower a Boolean gate with one semantically-secret operand and one known
+/// public bit to communication-free share algebra.
+fn localize_secret_public_gate(
+    op: &str,
+    secret: AstNode,
+    public: u8,
+    location: &SourceLocation,
+) -> AstNode {
+    match (op, public & 1) {
+        ("and", bit) => make_share_mul_scalar_expr(secret, bit as u128, location),
+        ("xor", 0) | ("or", 0) => secret,
+        ("xor", 1) => AstNode::FunctionCall {
+            function: Box::new(AstNode::Identifier(
+                "Share.add_constant".to_string(),
+                location.clone(),
+            )),
+            arguments: vec![secret, make_int_literal(1, location)],
+            location: location.clone(),
+            resolved_return_type: None,
+        },
+        // x OR 1 is one, but still evaluate `x`: an operand expression may
+        // consume a ClientStore input even though its value cannot affect the
+        // result. Multiplying it by zero and adding one are both local.
+        ("or", 1) => AstNode::FunctionCall {
+            function: Box::new(AstNode::Identifier(
+                "Share.add_constant".to_string(),
+                location.clone(),
+            )),
+            arguments: vec![
+                make_share_mul_scalar_expr(secret, 0, location),
+                make_int_literal(1, location),
+            ],
+            location: location.clone(),
+            resolved_return_type: None,
+        },
+        _ => unreachable!("caller only passes boolean gates and one-bit constants"),
+    }
+}
+
 /// If `cv` is a non-empty list whose every element is a public bit, return those
 /// bit values; otherwise `None`. This is the "fully-public list operand" test.
 fn all_public_bits(cv: &ConstVal) -> Option<Vec<u8>> {
@@ -6977,7 +7344,10 @@ fn all_public_bits(cv: &ConstVal) -> Option<Vec<u8>> {
 /// Array panic cannot occur. Only fires when the public operand is fully public
 /// (every element a tracked public bit) and the OTHER operand is a plain
 /// identifier we can cheaply index without duplicating a large expression.
-fn try_localize_public_batch_mul(value: &AstNode, env: &GateEnv) -> Option<AstNode> {
+fn try_localize_public_batch_mul(
+    value: &AstNode,
+    env: &GateEnv,
+) -> Option<(Vec<AstNode>, AstNode)> {
     let (function, arguments, location) = match value {
         AstNode::FunctionCall {
             function,
@@ -6994,35 +7364,164 @@ fn try_localize_public_batch_mul(value: &AstNode, env: &GateEnv) -> Option<AstNo
         AstNode::Identifier(name, _) if builtin_base_name(name) == "batch_mul" => {}
         _ => return None,
     }
-    // Pick the provably-public operand; the OTHER (kept) operand is scaled
-    // element-wise by the known public bit values.
-    let (scalars, share_operand) = if let Some(v) = all_public_bits(&gate_eval(&arguments[0], env))
-    {
-        (v, &arguments[1])
-    } else {
-        let v = all_public_bits(&gate_eval(&arguments[1], env))?;
-        (v, &arguments[0])
-    };
-    let share_id = match share_operand {
-        id @ AstNode::Identifier(..) => id.clone(),
+    // Fast path: one whole operand is public. The other operand need not have a
+    // materialized provenance list; the already-valid batch call proves it has
+    // the same runtime length.
+    let whole_public = all_public_bits(&gate_eval(&arguments[0], env))
+        .map(|values| (values, &arguments[1]))
+        .or_else(|| {
+            all_public_bits(&gate_eval(&arguments[1], env)).map(|values| (values, &arguments[0]))
+        });
+    if let Some((scalars, share_id @ AstNode::Identifier(..))) = whole_public {
+        let elements = scalars
+            .iter()
+            .enumerate()
+            .map(|(i, &v)| {
+                let elem = AstNode::IndexAccess {
+                    base: Box::new(share_id.clone()),
+                    index: Box::new(make_int_literal(i as u128, location)),
+                    location: location.clone(),
+                };
+                make_share_mul_scalar_expr(elem, v as u128, location)
+            })
+            .collect();
+        return Some((
+            Vec::new(),
+            AstNode::ListLiteral {
+                elements,
+                location: location.clone(),
+            },
+        ));
+    }
+
+    // General mixed-list path. Every lane must be proven either public or
+    // secret; one public lane is enough to make the split profitable. Unknown
+    // lanes fail closed and keep the original batch untouched.
+    let mut left_values = match gate_eval(&arguments[0], env) {
+        ConstVal::List(values) => values,
         _ => return None,
     };
-    let elements = scalars
-        .iter()
-        .enumerate()
-        .map(|(i, &v)| {
-            let elem = AstNode::IndexAccess {
-                base: Box::new(share_id.clone()),
+    let mut right_values = match gate_eval(&arguments[1], env) {
+        ConstVal::List(values) => values,
+        _ => return None,
+    };
+    // Index existing operands rather than cloning arbitrary list-literal
+    // elements: a literal element could contain an effectful call, and splitting
+    // it would otherwise change evaluation order. Identifier reads are pure and
+    // the original batch call already guarantees aligned lengths.
+    if !matches!(&arguments[0], AstNode::Identifier(..))
+        || !matches!(&arguments[1], AstNode::Identifier(..))
+    {
+        return None;
+    }
+    if left_values.len() != right_values.len() || left_values.is_empty() {
+        return None;
+    }
+    let element_expr = |operand: &AstNode, i: usize| -> Option<AstNode> {
+        match operand {
+            AstNode::Identifier(..) => Some(AstNode::IndexAccess {
+                base: Box::new(operand.clone()),
                 index: Box::new(make_int_literal(i as u128, location)),
                 location: location.clone(),
-            };
-            make_share_mul_scalar_expr(elem, v as u128, location)
+            }),
+            _ => None,
+        }
+    };
+    let mut interactive_lefts = Vec::new();
+    let mut interactive_rights = Vec::new();
+    let mut output_lanes: Vec<Option<AstNode>> = Vec::with_capacity(left_values.len());
+    let mut localized = 0usize;
+    for (i, (left_value, right_value)) in left_values
+        .drain(..)
+        .zip(right_values.drain(..))
+        .enumerate()
+    {
+        let left_expr = element_expr(&arguments[0], i)?;
+        let right_expr = element_expr(&arguments[1], i)?;
+        let lane = match (left_value, right_value) {
+            (ConstVal::Bit { val: a, .. }, ConstVal::Bit { val: b, .. }) => {
+                localized += 1;
+                Some(make_from_clear_int_bit(a & b, location))
+            }
+            (ConstVal::Secret, ConstVal::Bit { val, .. }) => {
+                localized += 1;
+                Some(make_share_mul_scalar_expr(left_expr, val as u128, location))
+            }
+            (ConstVal::Bit { val, .. }, ConstVal::Secret) => {
+                localized += 1;
+                Some(make_share_mul_scalar_expr(
+                    right_expr,
+                    val as u128,
+                    location,
+                ))
+            }
+            (ConstVal::Secret, ConstVal::Secret) => {
+                interactive_lefts.push(left_expr);
+                interactive_rights.push(right_expr);
+                None
+            }
+            _ => return None,
+        };
+        output_lanes.push(lane);
+    }
+    if localized == 0 {
+        return None;
+    }
+
+    let mut prefix = Vec::new();
+    let interactive_name = if interactive_lefts.is_empty() {
+        None
+    } else {
+        let name = generate_named_temp_name("public_split_products");
+        prefix.push(AstNode::VariableDeclaration {
+            name: name.clone(),
+            type_annotation: None,
+            value: Some(Box::new(make_batch_mul_call(
+                AstNode::ListLiteral {
+                    elements: interactive_lefts,
+                    location: location.clone(),
+                },
+                AstNode::ListLiteral {
+                    elements: interactive_rights,
+                    location: location.clone(),
+                },
+                location,
+            ))),
+            is_mutable: false,
+            is_secret: false,
+            location: location.clone(),
+        });
+        Some(name)
+    };
+    let mut interactive_index = 0usize;
+    let elements = output_lanes
+        .into_iter()
+        .map(|lane| {
+            lane.unwrap_or_else(|| {
+                let base = AstNode::Identifier(
+                    interactive_name
+                        .as_ref()
+                        .expect("an interactive lane created the result batch")
+                        .clone(),
+                    location.clone(),
+                );
+                let result = AstNode::IndexAccess {
+                    base: Box::new(base),
+                    index: Box::new(make_int_literal(interactive_index as u128, location)),
+                    location: location.clone(),
+                };
+                interactive_index += 1;
+                result
+            })
         })
         .collect();
-    Some(AstNode::ListLiteral {
-        elements,
-        location: location.clone(),
-    })
+    Some((
+        prefix,
+        AstNode::ListLiteral {
+            elements,
+            location: location.clone(),
+        },
+    ))
 }
 
 /// Purely evaluate an expression to a provenance fact. Returns `Top` for
@@ -7070,6 +7569,11 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
                         other => other,
                     }
                 }
+                // Semantic analysis already proved the index operation valid.
+                // A secret-containing collection yields a secret-containing
+                // element even when this lightweight provenance domain does not
+                // retain the collection's exact shape.
+                (ConstVal::Secret, ConstVal::Int(_)) => ConstVal::Secret,
                 _ => ConstVal::Top,
             }
         }
@@ -7100,6 +7604,82 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
                         };
                     }
                 }
+            }
+            // Preserve public-bit provenance through communication-free share
+            // algebra. This is the share-domain equivalent of ordinary constant
+            // propagation and is required to recognize public batch operands
+            // assembled from local helper calls rather than direct literals.
+            if arguments.len() == 2 {
+                let lhs = gate_eval(&arguments[0], env);
+                let rhs = gate_eval(&arguments[1], env);
+                match base {
+                    Some("add") | Some("sub") => {
+                        if let (
+                            ConstVal::Bit {
+                                val: a,
+                                from_list: fa,
+                            },
+                            ConstVal::Bit {
+                                val: b,
+                                from_list: fb,
+                            },
+                        ) = (&lhs, &rhs)
+                        {
+                            return ConstVal::Bit {
+                                val: (a ^ b) & 1,
+                                from_list: *fa || *fb,
+                            };
+                        }
+                    }
+                    Some("mul_scalar") => {
+                        if let (ConstVal::Bit { val, from_list }, ConstVal::Int(scalar)) =
+                            (&lhs, &rhs)
+                        {
+                            return ConstVal::Bit {
+                                val: val & ((*scalar as u8) & 1),
+                                from_list: *from_list,
+                            };
+                        }
+                    }
+                    Some("add_constant") | Some("add_scalar") => {
+                        if let (ConstVal::Bit { val, from_list }, ConstVal::Int(scalar)) =
+                            (&lhs, &rhs)
+                        {
+                            return ConstVal::Bit {
+                                val: val ^ ((*scalar as u8) & 1),
+                                from_list: *from_list,
+                            };
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            if matches!(base, Some("copy")) && arguments.len() == 1 {
+                return gate_eval(&arguments[0], env);
+            }
+            if matches!(base, Some("slice")) && arguments.len() == 3 {
+                if let (ConstVal::List(values), ConstVal::Int(start), ConstVal::Int(end)) = (
+                    gate_eval(&arguments[0], env),
+                    gate_eval(&arguments[1], env),
+                    gate_eval(&arguments[2], env),
+                ) {
+                    if start >= 0 && end >= start && (end as usize) <= values.len() {
+                        return ConstVal::List(values[start as usize..end as usize].to_vec());
+                    }
+                }
+            }
+            if node_resolved_contains_secret(node) == Some(true)
+                || matches!(
+                    base,
+                    Some("add")
+                        | Some("sub")
+                        | Some("mul")
+                        | Some("mul_scalar")
+                        | Some("add_constant")
+                        | Some("add_scalar")
+                )
+            {
+                return ConstVal::Secret;
             }
             ConstVal::Top
         }
@@ -7149,6 +7729,9 @@ fn gate_eval_binop(op: &str, left: &AstNode, right: &AstNode, env: &GateEnv) -> 
                     val: bit,
                     from_list: *fa || *fb,
                 };
+            }
+            if matches!((&l, &r), (ConstVal::Secret, ConstVal::Secret)) {
+                return ConstVal::Secret;
             }
             ConstVal::Top
         }
@@ -7297,6 +7880,7 @@ fn unroll_in_node(node: AstNode, env: &mut LenEnv, budget: &mut usize) -> AstNod
             let mut assigned = HashSet::new();
             collect_assigned_vars(&body, &mut assigned);
             let mut benv = scoped_len_env(env, &[&body]);
+            let (preserved_shapes, preserved_ints) = loop_invariant_facts(&body, &benv, &mutated);
             // Shapes/aliases of anything possibly mutated (incl. lists passed to
             // callees) are unknown mid-loop; a SCALAR's int survives unless the
             // body assigns it (by-value call semantics) — keep those facts so
@@ -7308,14 +7892,20 @@ fn unroll_in_node(node: AstNode, env: &mut LenEnv, budget: &mut usize) -> AstNod
                 .collect();
             for m in &mutated {
                 benv.invalidate(m);
+                benv.alias_unbind(m);
             }
+            benv.shapes.extend(preserved_shapes.clone());
+            benv.ints.extend(preserved_ints.clone());
             for (name, v) in kept_ints {
                 benv.ints.insert(name, v);
             }
             let body = Box::new(unroll_in_node(*body, &mut benv, budget));
             for m in mutated {
                 env.invalidate(&m);
+                env.alias_unbind(&m);
             }
+            env.shapes.extend(preserved_shapes);
+            env.ints.extend(preserved_ints);
             AstNode::WhileLoop {
                 condition,
                 body,
@@ -7343,6 +7933,7 @@ fn unroll_in_node(node: AstNode, env: &mut LenEnv, budget: &mut usize) -> AstNod
                 assigned.insert(v.clone());
             }
             let mut benv = scoped_len_env(env, &[&body, &iterable]);
+            let (preserved_shapes, preserved_ints) = loop_invariant_facts(&body, &benv, &mutated);
             let kept_ints: Vec<(String, u128)> = mutated
                 .iter()
                 .filter(|m| !assigned.contains(*m))
@@ -7350,7 +7941,10 @@ fn unroll_in_node(node: AstNode, env: &mut LenEnv, budget: &mut usize) -> AstNod
                 .collect();
             for m in &mutated {
                 benv.invalidate(m);
+                benv.alias_unbind(m);
             }
+            benv.shapes.extend(preserved_shapes.clone());
+            benv.ints.extend(preserved_ints.clone());
             for (name, v) in kept_ints {
                 benv.ints.insert(name, v);
             }
@@ -7358,7 +7952,10 @@ fn unroll_in_node(node: AstNode, env: &mut LenEnv, budget: &mut usize) -> AstNod
             let body = Box::new(unroll_in_node(*body, &mut benv, budget));
             for m in mutated {
                 env.invalidate(&m);
+                env.alias_unbind(&m);
             }
+            env.shapes.extend(preserved_shapes);
+            env.ints.extend(preserved_ints);
             AstNode::ForLoop {
                 variables,
                 iterable,
@@ -7403,8 +8000,19 @@ fn unroll_stmt_list(stmts: Vec<AstNode>, env: &mut LenEnv, budget: &mut usize) -
     // themselves be loops, or appends that resolve a later loop's bound) are
     // processed in order, updating the env as we go.
     let mut out: Vec<AstNode> = Vec::with_capacity(stmts.len());
-    let mut pending: std::collections::VecDeque<AstNode> = stmts.into_iter().collect();
-    while let Some(stmt) = pending.pop_front() {
+    let mut pending: std::collections::VecDeque<UnrollWorkItem> =
+        stmts.into_iter().map(UnrollWorkItem::Node).collect();
+    while let Some(item) = pending.pop_front() {
+        let stmt = match item {
+            UnrollWorkItem::Node(stmt) => stmt,
+            UnrollWorkItem::EstablishedShapes(shapes) => {
+                for (name, shape) in shapes {
+                    env.alias_unbind(&name);
+                    env.shapes.insert(name, shape);
+                }
+                continue;
+            }
+        };
         // Env-aware constant-branch folding (generalizes `fold_constant_branches`
         // to conditions over `.len()`/int-tracked locals): when the current env
         // proves an `if` condition constant, splice the taken branch flat into the
@@ -7428,7 +8036,7 @@ fn unroll_stmt_list(stmts: Vec<AstNode>, env: &mut LenEnv, budget: &mut usize) -
                     // Front-splice in order via reversed push_front (O(k), same
                     // resulting queue as inserting at offsets 0..k).
                     for produced in branch_into_stmts(b).into_iter().rev() {
-                        pending.push_front(produced);
+                        pending.push_front(UnrollWorkItem::Node(produced));
                     }
                 }
                 continue;
@@ -7440,7 +8048,18 @@ fn unroll_stmt_list(stmts: Vec<AstNode>, env: &mut LenEnv, budget: &mut usize) -
                 // effects apply as each is popped, and nested loops get a fresh
                 // unroll attempt with the now-richer env.
                 for produced in iterations.into_iter().rev() {
-                    pending.push_front(produced);
+                    pending.push_front(UnrollWorkItem::Node(produced));
+                }
+            }
+            UnrollOutcome::Peeled {
+                statements,
+                established_shapes,
+                residual,
+            } => {
+                pending.push_front(UnrollWorkItem::Node(residual));
+                pending.push_front(UnrollWorkItem::EstablishedShapes(established_shapes));
+                for statement in statements.into_iter().rev() {
+                    pending.push_front(UnrollWorkItem::Node(statement));
                 }
             }
             UnrollOutcome::Kept(node) => out.push(process_kept_statement(node, env, budget)),
@@ -7472,8 +8091,20 @@ fn process_kept_statement(node: AstNode, env: &mut LenEnv, budget: &mut usize) -
 enum UnrollOutcome {
     /// The loop was flattened into these statements.
     Flattened(Vec<AstNode>),
+    /// Exactly one iteration was peeled to establish these facts before a
+    /// residual loop. The work-list installs them at the precise boundary.
+    Peeled {
+        statements: Vec<AstNode>,
+        established_shapes: HashMap<String, Shape>,
+        residual: AstNode,
+    },
     /// The statement was left as-is (still needs recursive processing).
     Kept(AstNode),
+}
+
+enum UnrollWorkItem {
+    Node(AstNode),
+    EstablishedShapes(HashMap<String, Shape>),
 }
 
 /// Read-only estimate of how many AST nodes a statement list expands to *after
@@ -7656,22 +8287,17 @@ fn try_unroll_for(stmt: AstNode, env: &LenEnv, budget: &mut usize) -> UnrollOutc
     let body_stmts = loop_body_statements(&body);
     // Raw (un-inner-unrolled) duplication cost of flattening this loop. The
     // flattened copies are re-queued and their inner loops draw from the same
-    // budget when *they* unroll, so this — not `decision_expansion` — is the code
-    // actually materialized at this level.
+    // budget when *they* unroll.
     let raw_body_count: usize = body_stmts.iter().map(node_size).sum();
     let raw_duplication = (iterations as usize).saturating_mul(raw_body_count.max(1));
 
-    // LEVER 1 — small-trip heavy-body unroll. A low-trip outer loop over a heavy
-    // body (the CTR/CBC per-block loop: `for i in 0..blocks.len()` with the whole
-    // inlined AES inside) MUST be unrolled to expose each block's statically-known
-    // state shape to the inner-loop batcher. Kept rolled, the per-block state
-    // shape is unknown, so the inner SubBytes `.len()`-bound loops never unroll and
-    // every S-box multiply degrades to an unbatched scalar round (the CBC 10k
-    // singletons). The inner-unrolled estimate is pessimistic here: the re-queued
-    // copies keep their own round loops rolled by their own decision, so the real
-    // materialized cost is only `raw_duplication`. Gate small-trip unrolls on that
-    // realistic cost (still bounded by the global budget) instead of the cap.
-    let small_trip = (iterations as usize) <= SMALL_TRIP_UNROLL;
+    // Low-trip outer loops are allowed to expose their statically-known shape
+    // to the MPC batcher when their actual raw duplication still fits the
+    // global budget. This is the MPC profitability boost: reducing interactive
+    // rounds takes priority over code size.
+    let loop_carried = has_loop_carried_assignment(&body, &variables);
+    let small_trip =
+        (iterations as usize) <= SMALL_TRIP_UNROLL && (iterations <= 2 || !loop_carried);
     let fits = if small_trip {
         raw_duplication <= *budget
     } else {
@@ -7691,7 +8317,12 @@ fn try_unroll_for(stmt: AstNode, env: &LenEnv, budget: &mut usize) -> UnrollOutc
         // change the decision. Capping at this threshold keeps the estimator
         // linear in the useful evidence instead of walking huge inlined bodies
         // under large project budgets.
-        let threshold = unroll_max_expansion().min(*budget);
+        let expansion_cap = if loop_carried {
+            SERIAL_UNROLL_MAX_EXPANSION
+        } else {
+            unroll_max_expansion()
+        };
+        let threshold = expansion_cap.min(*budget);
         let estimate_limit = threshold
             .checked_div(iterations as usize)
             .unwrap_or(0)
@@ -7700,9 +8331,68 @@ fn try_unroll_for(stmt: AstNode, env: &LenEnv, budget: &mut usize) -> UnrollOutc
         let inner_unrolled_estimate = estimate_unrolled_size(body_stmts, &benv, estimate_limit);
         let decision_expansion =
             (iterations as usize).saturating_mul(inner_unrolled_estimate.max(1));
-        decision_expansion <= unroll_max_expansion() && decision_expansion <= *budget
+        decision_expansion <= expansion_cap && decision_expansion <= *budget
     };
     if !fits {
+        // A kept loop can begin with an imprecise header yet establish a stable
+        // exact shape after its first iteration (common for accumulator-style
+        // list transforms). Peel exactly that iteration when abstract transfer
+        // proves the gain. The residual loop is still governed by the ordinary
+        // unroll budget/serial-expansion policy; this is LLVM-style peeling to
+        // expose an invariant, not unrestricted unrolling.
+        let peel_cost = raw_body_count.max(1);
+        let established_shapes = if iterations > 1 && peel_cost <= *budget {
+            first_iteration_established_shapes(&body, env, loop_var, lo)
+        } else {
+            HashMap::new()
+        };
+        if !established_shapes.is_empty() {
+            let mut body_declared = HashSet::new();
+            for statement in body_stmts {
+                collect_declared_names(statement, &mut body_declared);
+            }
+            let suffix = INLINE_SUFFIX.fetch_add(1, Ordering::Relaxed);
+            let rename: HashMap<String, String> = body_declared
+                .iter()
+                .map(|name| (name.clone(), format!("{name}__peel{suffix}")))
+                .collect();
+            let mut peeled = Vec::with_capacity(body_stmts.len());
+            for statement in body_stmts {
+                let renamed = if rename.is_empty() {
+                    statement.clone()
+                } else {
+                    rename_in(statement.clone(), &rename)
+                };
+                peeled.push(substitute_ident_with_int(renamed, loop_var, lo));
+            }
+
+            let residual_iterable = match iterable.as_ref() {
+                AstNode::BinaryOperation {
+                    op,
+                    right,
+                    location: range_location,
+                    ..
+                } if op == ".." => AstNode::BinaryOperation {
+                    op: op.clone(),
+                    left: Box::new(make_int_literal(lo + 1, range_location)),
+                    right: right.clone(),
+                    location: range_location.clone(),
+                },
+                _ => unreachable!("range_bounds accepted a non-range iterable"),
+            };
+            let residual = AstNode::ForLoop {
+                variables,
+                iterable: Box::new(residual_iterable),
+                body,
+                location,
+            };
+            *budget = budget.saturating_sub(peel_cost);
+            return UnrollOutcome::Peeled {
+                statements: peeled,
+                established_shapes,
+                residual,
+            };
+        }
         return UnrollOutcome::Kept(AstNode::ForLoop {
             variables,
             iterable,
@@ -7710,9 +8400,9 @@ fn try_unroll_for(stmt: AstNode, env: &LenEnv, budget: &mut usize) -> UnrollOutc
             location,
         });
     }
-    // Charge only the *raw* duplication here; the flattened copies are re-queued
-    // and their inner loops draw from the same budget when they unroll, so
-    // charging the inner-unrolled estimate too would double-count.
+    // Charge only the raw duplication here; the flattened copies are re-queued and
+    // their inner loops draw from the same budget when they unroll, so charging
+    // the inner-unrolled estimate too would double-count.
     *budget = budget.saturating_sub(raw_duplication);
 
     // Names declared inside the body (locals + nested loop variables) get a
@@ -7744,6 +8434,31 @@ fn try_unroll_for(stmt: AstNode, env: &LenEnv, budget: &mut usize) -> UnrollOutc
     }
 
     UnrollOutcome::Flattened(flattened)
+}
+
+/// Whether a loop directly reassigns a binding from an outer scope that its
+/// body also reads. Such iterations are serial by construction: unrolling may
+/// expose constants inside each iteration, but it cannot batch MPC work across
+/// the recurrence (`state_{n+1}` depends on `state_n`). This deliberately
+/// ignores list-mutator receivers such as `out.append(x)`: ordered result
+/// assembly does not make the secret computations producing `x` dependent.
+fn has_loop_carried_assignment(body: &AstNode, loop_variables: &[String]) -> bool {
+    let mut assigned = HashSet::new();
+    collect_assigned_vars(body, &mut assigned);
+    for variable in loop_variables {
+        assigned.remove(variable);
+    }
+
+    let mut declared = HashSet::new();
+    collect_declared_names(body, &mut declared);
+    assigned.retain(|name| !declared.contains(name));
+    if assigned.is_empty() {
+        return false;
+    }
+
+    let mut referenced = HashSet::new();
+    collect_referenced_vars(body, &mut referenced);
+    assigned.iter().any(|name| referenced.contains(name))
 }
 
 /// Whether the loop body assigns to `var` (directly, as the target identifier of
@@ -8219,6 +8934,23 @@ fn expr_is_pure(node: &AstNode, pure_fns: &HashSet<String>) -> bool {
             _ => false,
         },
         _ => false,
+    }
+}
+
+/// Whether evaluating an expression exactly once may move within a dependency-
+/// ordered scheduling region.  This is deliberately a little broader than
+/// [`expr_is_pure`]: `copy` allocates a distinct list, so CSE/LICM must never
+/// merge or duplicate it, but moving that one allocation with all of its data
+/// dependencies preserved cannot change the copied value or its identity.
+/// Opens, randomness, I/O, client operations, and other effects remain pinned.
+fn expr_is_reorderable(node: &AstNode, pure_fns: &HashSet<String>) -> bool {
+    match node {
+        AstNode::FunctionCall { arguments, .. }
+            if call_name(node).is_some_and(|name| builtin_base_name(name) == "copy") =>
+        {
+            arguments.iter().all(|arg| expr_is_pure(arg, pure_fns))
+        }
+        _ => expr_is_pure(node, pure_fns),
     }
 }
 
@@ -9932,24 +10664,56 @@ impl Sroa {
         self.ints.remove(name);
     }
 
-    /// Conservative handling for a subtree we do not model (nested control
-    /// flow, closures, unknown statement kinds): demote every tracked list it
-    /// references, and treat every name it writes as rebound.
-    fn note_opaque(&mut self, node: &AstNode) {
-        let mut refs = HashSet::new();
-        collect_identifiers(node, &mut refs);
-        for r in &refs {
-            if let Some(st) = self.tracked(r) {
-                self.demote(&st, "opaque-ref");
-            }
-        }
+    /// Handle a subtree this block-local replay does not model. Aggregates
+    /// mutated by the subtree are demoted. Read-only scalar-backed aggregates
+    /// are instead materialized into faithful snapshots and references in the
+    /// subtree are redirected to those snapshots, preserving scalarization in
+    /// the owning block without leaking its empty backing handle.
+    fn rewrite_opaque(&mut self, node: &AstNode) -> AstNode {
         let mut written = HashSet::new();
         collect_written_vars(node, &mut written);
+
+        let mut refs = HashSet::new();
+        collect_identifiers(node, &mut refs);
+        let mut replacements = HashMap::new();
+        for name in &refs {
+            let Some(st) = self.tracked(name) else {
+                continue;
+            };
+            if written.contains(name) {
+                self.demote(&st, "opaque-write");
+                continue;
+            }
+            let (literal_backed, husk) = {
+                let state = st.borrow();
+                (state.literal_backed, state.husk)
+            };
+            if literal_backed {
+                if husk {
+                    self.demote(&st, "husk-escape");
+                }
+            } else {
+                let snapshot = self.snapshot(&st, &node.location());
+                replacements.insert(name.clone(), snapshot);
+            }
+        }
+
         for w in &written {
             if let Some(st) = self.tracked(w) {
                 self.demote(&st, "opaque-write");
             }
             self.rebind(w);
+        }
+
+        if replacements.is_empty() {
+            node.clone()
+        } else {
+            // `written` includes declarations, assignments, loop variables,
+            // and mutator receivers. Therefore a name admitted to
+            // `replacements` has no shadowing binding site or write in this
+            // subtree, making this use+binding alpha-renamer equivalent to a
+            // free-use rewrite for the selected names.
+            rename_in(node.clone(), &replacements)
         }
     }
 
@@ -9961,9 +10725,9 @@ impl Sroa {
     /// still evaluated exactly once, at the same program point.
     fn capture_elem(&mut self, st: &Rc<RefCell<SroaState>>, elem: AstNode, loc: &SourceLocation) {
         let captured = match elem {
-            AstNode::Identifier(ref name, _) => {
-                self.note_identifier_capture(st, name);
-                elem
+            AstNode::Identifier(name, location) => {
+                let captured = self.note_identifier_capture(st, &name, &location);
+                AstNode::Identifier(captured.unwrap_or(name), location)
             }
             AstNode::Literal { .. } => elem,
             other => {
@@ -9990,8 +10754,16 @@ impl Sroa {
         s.snapshot = None;
     }
 
-    /// Bookkeeping for capturing an identifier element into `st`.
-    fn note_identifier_capture(&mut self, st: &Rc<RefCell<SroaState>>, name: &str) {
+    /// Bookkeeping for capturing an identifier element into `st`. A fragile
+    /// scalar-backed aggregate is captured through a faithful snapshot; if it
+    /// is mutated later, the analysis replay demotes both sides so the rewrite
+    /// preserves the original shared handle instead.
+    fn note_identifier_capture(
+        &mut self,
+        st: &Rc<RefCell<SroaState>>,
+        name: &str,
+        location: &SourceLocation,
+    ) -> Option<String> {
         let st_id = st.borrow().id;
         self.captured_by
             .entry(name.to_string())
@@ -9999,40 +10771,35 @@ impl Sroa {
             .push(st_id);
         if let Some(other) = self.tracked(name) {
             if Rc::ptr_eq(&other, st) {
-                return; // self-alias: same object either way
+                return None; // self-alias: same object either way
             }
-            // Aliasing a tracked list into `st` is fine while `st` stays
-            // symbolic: every read/mutation path through `st` substitutes
-            // down to `name` and is handled there. But if `st` ends up
-            // demoted, its REAL array holds the alias, and unknown code could
-            // observe an empty husk or mutate the element behind our back —
-            // so the captured list must be demoted with it.
+            // A real aggregate cannot retain a scalar-backed list's empty
+            // runtime husk. Capture a faithful snapshot now; a later mutation
+            // of the source invalidates the capture during ANALYZE, causing
+            // the final rewrite to preserve the original shared handle.
             let fragile = {
                 let o = other.borrow();
                 !o.literal_backed || o.husk
             };
-            self.demote_edges.push((st_id, other.borrow().id));
             if fragile {
-                if st.borrow().literal_backed {
-                    // The capturer's emitted literal now holds a husk element.
-                    st.borrow_mut().husk = true;
-                } else {
-                    // Scalar-backed capturer: it is scalarized rather than kept
-                    // real, so the capture edge (which fires only if the
-                    // capturer is demoted) never restores the source, and the
-                    // husk flag guards only literal-backed capturers. A
-                    // constant-index read of the capturer hands out this
-                    // scalar-backed source's bare handle, which can escape into
-                    // a sibling block (e.g. an inlined callee body scalarized in
-                    // its own pass) and be dereferenced there as a length-0
-                    // array. Demote the source now (fail-closed): its real
-                    // array is rebuilt, so any escaping handle is non-empty.
-                    // This only turns extra array plumbing real; the MPC round
-                    // structure is untouched.
-                    self.demote(&other, "captured-fragile");
-                }
+                return Some(self.snapshot(&other, location));
             }
         }
+        None
+    }
+
+    fn invalidate_captured_source(&mut self, name: &str, st: &Rc<RefCell<SroaState>>) -> bool {
+        let Some(capturers) = self.captured_by.get(name).cloned() else {
+            return false;
+        };
+        if capturers.is_empty() {
+            return false;
+        }
+        self.demote(st, "captured-source-mutated");
+        for id in capturers {
+            self.demote_id(id, "captured-source-mutated");
+        }
+        true
     }
 
     // ---- snapshots --------------------------------------------------------
@@ -10292,10 +11059,7 @@ impl Sroa {
             },
             // Anything else (nested blocks/ifs used as expressions, command
             // calls, ...) is not modeled: fail closed.
-            other => {
-                self.note_opaque(other);
-                other.clone()
-            }
+            other => self.rewrite_opaque(other),
         }
     }
 
@@ -10395,8 +11159,8 @@ impl Sroa {
             // inner blocks were already scalarized independently by the
             // structural recursion; at this level they are opaque.
             other => {
-                self.note_opaque(other);
-                self.out.push(other.clone());
+                let other2 = self.rewrite_opaque(other);
+                self.out.push(other2);
             }
         }
     }
@@ -10425,18 +11189,6 @@ impl Sroa {
                     if st.borrow().literal_backed {
                         self.env.insert(name.to_string(), st);
                     } else {
-                        // Aliasing a scalar-backed (empty-husk-backed) list
-                        // under a new name lets that handle flow wherever the
-                        // alias goes. The inliner emits exactly this for a
-                        // list-returning callee (`var caller = callee_local`),
-                        // so the alias routinely crosses into a sibling block
-                        // that was scalarized in its own pass and reads the
-                        // handle as a real (length-0) array. The per-block model
-                        // cannot see that read, and neither the capture edge nor
-                        // the husk flag covers a bare alias, so demote the
-                        // source (fail-closed: its real array is kept). A
-                        // literal-backed list is already real and faithful, so
-                        // aliasing it stays safe.
                         self.demote(&st, "alias-escape");
                     }
                 }
@@ -10471,8 +11223,7 @@ impl Sroa {
                     // later hazards through `q` demote the whole group. A
                     // scalar-backed source, however, is an empty husk whose
                     // handle now escapes under `name` and can be read in a
-                    // sibling block (same cross-block hole as the bare-alias
-                    // arm above), so demote it instead of aliasing.
+                    // sibling block, so demote it instead of aliasing.
                     if let Some(st) = self.tracked(rhs) {
                         if st.borrow().literal_backed {
                             self.env.insert(name.to_string(), st);
@@ -10516,9 +11267,9 @@ impl Sroa {
         for e in elements {
             let e2 = self.subst_value(e);
             let e2 = match e2 {
-                AstNode::Identifier(ref n, _) if Some(n.as_str()) != avoid_name => {
-                    self.note_identifier_capture(&st, n);
-                    e2
+                AstNode::Identifier(n, ident_location) if Some(n.as_str()) != avoid_name => {
+                    let captured = self.note_identifier_capture(&st, &n, &ident_location);
+                    AstNode::Identifier(captured.unwrap_or(n), ident_location)
                 }
                 AstNode::Literal { .. } => e2,
                 other => {
@@ -10589,6 +11340,7 @@ impl Sroa {
                 let base2 = self.subst_value(base);
                 if let AstNode::Identifier(n, _) = &base2 {
                     if let Some(st) = self.tracked(n) {
+                        self.invalidate_captured_source(n, &st);
                         self.demote(&st, "store-target");
                     }
                 }
@@ -10606,6 +11358,7 @@ impl Sroa {
                 let object2 = self.subst_value(object);
                 if let AstNode::Identifier(n, _) = &object2 {
                     if let Some(st) = self.tracked(n) {
+                        self.invalidate_captured_source(n, &st);
                         self.demote(&st, "store-target");
                     }
                 }
@@ -10652,12 +11405,18 @@ impl Sroa {
                     self.demote(&st, "literal-mutated");
                     return false;
                 }
+                if self.invalidate_captured_source(recv, &st) {
+                    return false;
+                }
                 self.capture_operand(&st, &arguments[1], location);
                 true
             }
             "extend" => {
                 if st.borrow().literal_backed {
                     self.demote(&st, "literal-mutated");
+                    return false;
+                }
+                if self.invalidate_captured_source(recv, &st) {
                     return false;
                 }
                 match &arguments[1] {
@@ -10681,9 +11440,14 @@ impl Sroa {
                         let edge = (src.borrow().id, st.borrow().id);
                         self.demote_edges.push(edge);
                         for e in src_elems {
-                            if let AstNode::Identifier(n, _) = &e {
-                                self.note_identifier_capture(&st, n);
-                            }
+                            let e = match e {
+                                AstNode::Identifier(n, ident_location) => {
+                                    let captured =
+                                        self.note_identifier_capture(&st, &n, &ident_location);
+                                    AstNode::Identifier(captured.unwrap_or(n), ident_location)
+                                }
+                                other => other,
+                            };
                             let mut s = st.borrow_mut();
                             s.elems.push(Some(e));
                             s.snapshot = None;
@@ -10763,14 +11527,21 @@ fn scalarize_block(stmts: Vec<AstNode>) -> Vec<AstNode> {
     }
 }
 
-/// -O3 entry point: structurally recurse, scalarizing each block's local
-/// non-escaping arrays. Nested blocks are scalarized first and are then
-/// opaque to the enclosing block's walk.
+/// -O3 entry point: scalarize each block's local non-escaping arrays. Owning
+/// blocks are processed before nested blocks so an escape into nested control
+/// flow is observed before either block can delete the real aggregate build.
 pub fn scalarize_local_arrays(node: AstNode) -> AstNode {
     match node {
         AstNode::Block(stmts) => {
+            // Process the owning block before its nested blocks. An outer
+            // aggregate referenced by nested control flow must be classified
+            // while its original build statements are still present: writes
+            // demote it, while read-only uses receive a faithful snapshot. A
+            // bottom-up walk can delete the build first and leave the parent
+            // no way to repair an escaped empty backing handle.
+            let stmts = scalarize_block(stmts);
             let stmts: Vec<AstNode> = stmts.into_iter().map(scalarize_local_arrays).collect();
-            AstNode::Block(scalarize_block(stmts))
+            AstNode::Block(stmts)
         }
         AstNode::FunctionDefinition {
             name,
@@ -10846,11 +11617,308 @@ pub fn scalarize_local_arrays(node: AstNode) -> AstNode {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ast::AstNode;
+    use crate::ast::{AstNode, Parameter};
     use crate::errors::SourceLocation;
 
     fn make_loc() -> SourceLocation {
         SourceLocation::default()
+    }
+
+    #[test]
+    fn public_bit_gate_on_secret_parameter_uses_local_share_algebra() {
+        let loc = make_loc();
+        let ident = |name: &str| AstNode::Identifier(name.to_string(), loc.clone());
+        let from_clear = |bit: u128| AstNode::FunctionCall {
+            function: Box::new(ident("Share.from_clear_int")),
+            arguments: vec![
+                super::make_int_literal(bit, &loc),
+                super::make_int_literal(1, &loc),
+            ],
+            location: loc.clone(),
+            resolved_return_type: None,
+        };
+        let gate = |op: &str, rhs: u128| AstNode::BinaryOperation {
+            op: op.to_string(),
+            left: Box::new(ident("secret_input")),
+            right: Box::new(from_clear(rhs)),
+            location: loc.clone(),
+        };
+        let declaration = |name: &str, value: AstNode| AstNode::VariableDeclaration {
+            name: name.to_string(),
+            type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+            value: Some(Box::new(value)),
+            is_mutable: false,
+            is_secret: true,
+            location: loc.clone(),
+        };
+        let function = AstNode::FunctionDefinition {
+            name: Some("localize".to_string()),
+            type_params: Vec::new(),
+            parameters: vec![Parameter {
+                name: "secret_input".to_string(),
+                type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+                default_value: None,
+                is_secret: true,
+                is_variadic: false,
+            }],
+            return_type: None,
+            body: Box::new(AstNode::Block(vec![
+                declaration("and_zero", gate("and", 0)),
+                declaration("xor_one", gate("xor", 1)),
+                declaration("or_zero", gate("or", 0)),
+                declaration("or_one", gate("or", 1)),
+            ])),
+            is_secret: false,
+            pragmas: Vec::new(),
+            location: loc.clone(),
+            node_id: 0,
+        };
+
+        let AstNode::FunctionDefinition { body, .. } = fold_public_gates(function) else {
+            panic!("expected function");
+        };
+        let AstNode::Block(statements) = body.as_ref() else {
+            panic!("expected body block");
+        };
+        let value_call = |index: usize| match &statements[index] {
+            AstNode::VariableDeclaration {
+                value: Some(value), ..
+            } => call_name(value),
+            _ => None,
+        };
+        assert_eq!(value_call(0), Some("Share.mul_scalar"));
+        assert_eq!(value_call(1), Some("Share.add_constant"));
+        assert!(matches!(
+            &statements[2],
+            AstNode::VariableDeclaration {
+                value: Some(value), ..
+            } if matches!(value.as_ref(), AstNode::Identifier(name, _) if name == "secret_input")
+        ));
+        assert_eq!(value_call(3), Some("Share.add_constant"));
+        let AstNode::VariableDeclaration {
+            value: Some(or_one),
+            ..
+        } = &statements[3]
+        else {
+            panic!("expected or-one declaration");
+        };
+        let AstNode::FunctionCall { arguments, .. } = or_one.as_ref() else {
+            panic!("expected local add-constant");
+        };
+        assert!(matches!(
+            arguments.first(),
+            Some(node) if call_name(node) == Some("Share.mul_scalar")
+        ));
+    }
+
+    #[test]
+    fn public_gate_localization_does_not_retype_unknown_clear_values() {
+        let loc = make_loc();
+        let gate = AstNode::BinaryOperation {
+            op: "xor".to_string(),
+            left: Box::new(AstNode::Identifier(
+                "runtime_clear".to_string(),
+                loc.clone(),
+            )),
+            right: Box::new(make_from_clear_int_bit(1, &loc)),
+            location: loc.clone(),
+        };
+        let function = AstNode::FunctionDefinition {
+            name: Some("leave_clear".to_string()),
+            type_params: Vec::new(),
+            parameters: vec![Parameter {
+                name: "runtime_clear".to_string(),
+                type_annotation: Some(Box::new(AstNode::Identifier(
+                    "bool".to_string(),
+                    loc.clone(),
+                ))),
+                default_value: None,
+                is_secret: false,
+                is_variadic: false,
+            }],
+            return_type: None,
+            body: Box::new(AstNode::Block(vec![AstNode::VariableDeclaration {
+                name: "result".to_string(),
+                type_annotation: None,
+                value: Some(Box::new(gate)),
+                is_mutable: false,
+                is_secret: false,
+                location: loc.clone(),
+            }])),
+            is_secret: false,
+            pragmas: Vec::new(),
+            location: loc,
+            node_id: 0,
+        };
+
+        let AstNode::FunctionDefinition { body, .. } = fold_public_gates(function) else {
+            panic!("expected function");
+        };
+        let AstNode::Block(statements) = body.as_ref() else {
+            panic!("expected block");
+        };
+        assert!(matches!(
+            &statements[0],
+            AstNode::VariableDeclaration {
+                value: Some(value), ..
+            } if matches!(value.as_ref(), AstNode::BinaryOperation { op, .. } if op == "xor")
+        ));
+    }
+
+    #[test]
+    fn batching_fixpoint_fuses_newly_normalized_scalar_and_vector_multiplies() {
+        reset_temp_counter();
+        let loc = make_loc();
+        let ident = |name: &str| AstNode::Identifier(name.to_string(), loc.clone());
+        let scalar = AstNode::VariableDeclaration {
+            name: "scalar_product".to_string(),
+            type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+            value: Some(Box::new(AstNode::BinaryOperation {
+                op: "and".to_string(),
+                left: Box::new(ident("a")),
+                right: Box::new(ident("b")),
+                location: loc.clone(),
+            })),
+            is_mutable: false,
+            is_secret: true,
+            location: loc.clone(),
+        };
+        let vector = AstNode::VariableDeclaration {
+            name: "vector_products".to_string(),
+            type_annotation: None,
+            value: Some(Box::new(AstNode::FunctionCall {
+                function: Box::new(ident("Share.batch_mul")),
+                arguments: vec![ident("lefts"), ident("rights")],
+                location: loc.clone(),
+                resolved_return_type: None,
+            })),
+            is_mutable: false,
+            is_secret: false,
+            location: loc,
+        };
+        let input = AstNode::Block(vec![scalar, vector]);
+
+        let once = optimize_multiplies(schedule_for_batching(input.clone()));
+        let fixed = optimize_multiply_batches_to_fixpoint(input);
+        let count_batch_calls = |node: &AstNode| {
+            fn walk(node: &AstNode, count: &mut usize) {
+                if call_name(node).is_some_and(|name| builtin_base_name(name) == "batch_mul") {
+                    *count += 1;
+                }
+                for_each_child(node, &mut |child| walk(child, count));
+            }
+            let mut count = 0;
+            walk(node, &mut count);
+            count
+        };
+
+        assert_eq!(
+            count_batch_calls(&once),
+            2,
+            "first pass has incompatible forms"
+        );
+        assert_eq!(
+            count_batch_calls(&fixed),
+            1,
+            "fixpoint must fuse the normalized scalar batch with the vector batch"
+        );
+    }
+
+    #[test]
+    fn mixed_public_batch_keeps_one_reduced_interactive_batch() {
+        reset_temp_counter();
+        let loc = make_loc();
+        let ident = |name: &str| AstNode::Identifier(name.to_string(), loc.clone());
+        let secret_param = |name: &str| Parameter {
+            name: name.to_string(),
+            type_annotation: Some(Box::new(AstNode::SecretType(Box::new(ident("bool"))))),
+            default_value: None,
+            is_secret: true,
+            is_variadic: false,
+        };
+        let list_decl = |name: &str, elements: Vec<AstNode>| AstNode::VariableDeclaration {
+            name: name.to_string(),
+            type_annotation: None,
+            value: Some(Box::new(AstNode::ListLiteral {
+                elements,
+                location: loc.clone(),
+            })),
+            is_mutable: false,
+            is_secret: false,
+            location: loc.clone(),
+        };
+        let body = AstNode::Block(vec![
+            list_decl(
+                "lefts",
+                vec![ident("a"), make_from_clear_int_bit(1, &loc), ident("a")],
+            ),
+            list_decl(
+                "rights",
+                vec![ident("b"), ident("b"), make_from_clear_int_bit(0, &loc)],
+            ),
+            AstNode::VariableDeclaration {
+                name: "products".to_string(),
+                type_annotation: None,
+                value: Some(Box::new(make_batch_mul_call(
+                    ident("lefts"),
+                    ident("rights"),
+                    &loc,
+                ))),
+                is_mutable: false,
+                is_secret: false,
+                location: loc.clone(),
+            },
+        ]);
+        let function = AstNode::FunctionDefinition {
+            name: Some("main".to_string()),
+            type_params: Vec::new(),
+            parameters: vec![secret_param("a"), secret_param("b")],
+            return_type: None,
+            body: Box::new(body),
+            is_secret: false,
+            pragmas: Vec::new(),
+            location: loc,
+            node_id: 0,
+        };
+        let optimized = fold_public_gates(function);
+
+        let mut batch_sizes = Vec::new();
+        let mut local_muls = 0usize;
+        fn inspect(node: &AstNode, batch_sizes: &mut Vec<usize>, local_muls: &mut usize) {
+            if let AstNode::FunctionCall { arguments, .. } = node {
+                match call_name(node).map(builtin_base_name) {
+                    Some("batch_mul") => {
+                        let size = match arguments.first() {
+                            Some(AstNode::ListLiteral { elements, .. }) => elements.len(),
+                            _ => usize::MAX,
+                        };
+                        batch_sizes.push(size);
+                    }
+                    Some("mul_scalar") => *local_muls += 1,
+                    _ => {}
+                }
+            }
+            for_each_child(node, &mut |child| inspect(child, batch_sizes, local_muls));
+        }
+        let AstNode::FunctionDefinition { body, .. } = &optimized else {
+            panic!("expected function");
+        };
+        inspect(body, &mut batch_sizes, &mut local_muls);
+        assert_eq!(
+            batch_sizes,
+            vec![1],
+            "only secret×secret lane stays interactive"
+        );
+        assert_eq!(
+            local_muls, 2,
+            "two public lanes become local scalar products"
+        );
+        let demand = crate::preprocessing_planner::plan_preprocessing_demand(&optimized);
+        assert_eq!(demand.triples, 1, "only the reduced batch needs a triple");
+        assert!(
+            !demand.dynamic,
+            "the split batch length is statically exact"
+        );
     }
 
     /// SOUNDNESS regression (kept-loop guard folding): inside a while loop the
@@ -10937,6 +12005,93 @@ mod tests {
             count_ifs(st, &mut ifs2);
         }
         assert_eq!(ifs2, 0, "straight-line provable guard must still fold");
+    }
+
+    #[test]
+    fn copy_is_reorderable_but_not_cse_pure() {
+        let copy = make_call("copy", vec![make_identifier("source")]);
+        let open = make_call("Share.open", vec![make_identifier("secret")]);
+        let pure_functions = HashSet::new();
+
+        assert!(
+            expr_is_reorderable(&copy, &pure_functions),
+            "one copy may move with its dependencies"
+        );
+        assert!(
+            !expr_is_pure(&copy, &pure_functions),
+            "copy identity must prevent CSE/LICM duplication"
+        );
+        assert!(
+            !expr_is_reorderable(&open, &pure_functions),
+            "declassification remains a scheduling barrier"
+        );
+    }
+
+    #[test]
+    fn loop_shape_proof_preserves_only_inductive_facts() {
+        let mut entry = LenEnv::default();
+        entry.shapes.insert("state".into(), Shape::flat(2));
+        let mut mutated = HashSet::new();
+        mutated.insert("state".to_string());
+        let assignment = |len: usize| AstNode::Assignment {
+            target: Box::new(make_identifier("state")),
+            value: Box::new(AstNode::ListLiteral {
+                elements: (0..len).map(|_| make_int_literal(0)).collect(),
+                location: make_loc(),
+            }),
+            location: make_loc(),
+        };
+
+        let (same, _) = loop_invariant_facts(&assignment(2), &entry, &mutated);
+        assert_eq!(same.get("state").and_then(Shape::count), Some(2));
+
+        let (changed, _) = loop_invariant_facts(&assignment(3), &entry, &mutated);
+        assert!(
+            !changed.contains_key("state"),
+            "a changing shape is not an invariant"
+        );
+    }
+
+    #[test]
+    fn large_serial_loop_peels_once_to_establish_shape() {
+        let mut statements = vec![
+            // Make the assignment a real loop-carried recurrence while letting
+            // abstract transfer establish an exact post-iteration shape.
+            make_var_decl("previous", make_identifier("state")),
+            AstNode::Assignment {
+                target: Box::new(make_identifier("state")),
+                value: Box::new(make_int_list(&[1, 2])),
+                location: make_loc(),
+            },
+        ];
+        // Force ordinary full-unroll profitability over the serial threshold.
+        for index in 0..48 {
+            statements.push(make_var_decl(
+                &format!("padding_{index}"),
+                make_identifier("state"),
+            ));
+        }
+        let loop_node = make_for("round", make_range(0, 9), statements);
+        let mut env = LenEnv::default();
+        env.shapes.insert("state".into(), Shape::Unknown);
+        let mut budget = 1_000_000usize;
+
+        let UnrollOutcome::Peeled {
+            established_shapes,
+            residual,
+            ..
+        } = try_unroll_for(loop_node, &env, &mut budget)
+        else {
+            panic!("shape-establishing serial loop should peel once");
+        };
+        assert_eq!(
+            established_shapes.get("state").and_then(Shape::count),
+            Some(2)
+        );
+        let AstNode::ForLoop { iterable, .. } = residual else {
+            panic!("one residual loop must remain");
+        };
+        assert_eq!(range_bounds(&iterable, &env), Some((1, 9)));
     }
 
     #[test]
@@ -12187,6 +13342,23 @@ mod tests {
     }
 
     #[test]
+    fn heavy_loop_carried_recurrence_uses_serial_unroll_threshold() {
+        let mut body = Vec::new();
+        body.push(make_assignment("state", make_identifier("state")));
+        for i in 0..40 {
+            body.push(make_var_decl(&format!("t{i}"), make_identifier("state")));
+        }
+        let block = AstNode::Block(vec![make_for("round", make_range(1, 10), body)]);
+
+        let optimized = unroll_literal_loops(block);
+        assert_eq!(
+            count_for_loops(&optimized),
+            1,
+            "a large serial recurrence cannot gain cross-iteration MPC batching"
+        );
+    }
+
+    #[test]
     fn test_no_unroll_for_len_bound_loop() {
         // for i in 0..a.len(): out.append(a[i])  -- non-literal bound, unchanged.
         let iterable = AstNode::BinaryOperation {
@@ -13368,6 +14540,143 @@ mod tests {
                 Some(AstNode::IndexAccess { .. })
             ),
             "read of demoted list must stay an index access"
+        );
+    }
+
+    #[test]
+    fn sroa_keeps_alias_backing_array_when_handle_leaves_block() {
+        let inner = AstNode::Block(vec![
+            sroa_empty_list_decl("inner_out"),
+            make_append("inner_out", make_identifier("a")),
+            sroa_decl("escaped", make_identifier("inner_out")),
+        ]);
+        let block = AstNode::Block(vec![inner, sroa_decl("r", sroa_index_read("escaped", 0))]);
+
+        let out = scalarize_local_arrays(block);
+        let stmts = sroa_stmts(&out);
+
+        assert_eq!(
+            sroa_count_calls(stmts, "append"),
+            1,
+            "an append-built list escaping through an alias must remain real"
+        );
+    }
+
+    #[test]
+    fn sroa_still_scalarizes_aggregate_wholly_owned_by_nested_block() {
+        let inner = AstNode::Block(vec![
+            sroa_empty_list_decl("inner_out"),
+            make_append("inner_out", make_identifier("a")),
+            sroa_decl("inner_result", sroa_index_read("inner_out", 0)),
+        ]);
+
+        let out = scalarize_local_arrays(AstNode::Block(vec![inner]));
+
+        assert_eq!(
+            sroa_count_calls(sroa_stmts(&out), "append"),
+            0,
+            "a non-escaping nested aggregate should still be scalar-replaced"
+        );
+    }
+
+    #[test]
+    fn sroa_snapshots_read_only_inner_aggregate_captured_by_literal() {
+        let block = AstNode::Block(vec![
+            sroa_empty_list_decl("lane"),
+            make_append("lane", make_identifier("a")),
+            sroa_decl(
+                "lanes",
+                AstNode::ListLiteral {
+                    elements: vec![make_identifier("lane")],
+                    location: make_loc(),
+                },
+            ),
+        ]);
+
+        let out = scalarize_local_arrays(block);
+
+        assert_eq!(
+            sroa_count_calls(sroa_stmts(&out), "append"),
+            0,
+            "a read-only captured aggregate should remain scalar-replaced"
+        );
+    }
+
+    #[test]
+    fn sroa_preserves_shared_handle_when_captured_aggregate_mutates_later() {
+        let block = AstNode::Block(vec![
+            sroa_empty_list_decl("lane"),
+            make_append("lane", make_identifier("a")),
+            sroa_decl(
+                "lanes",
+                AstNode::ListLiteral {
+                    elements: vec![make_identifier("lane")],
+                    location: make_loc(),
+                },
+            ),
+            make_append("lane", make_identifier("b")),
+        ]);
+
+        let out = scalarize_local_arrays(block);
+
+        assert_eq!(
+            sroa_count_calls(sroa_stmts(&out), "append"),
+            2,
+            "later mutation must invalidate the snapshot and preserve alias semantics"
+        );
+    }
+
+    #[test]
+    fn sroa_materializes_read_only_outer_aggregate_for_nested_loop() {
+        let loop_read = AstNode::IndexAccess {
+            base: Box::new(make_identifier("out")),
+            index: Box::new(make_identifier("i")),
+            location: make_loc(),
+        };
+        let block = AstNode::Block(vec![
+            sroa_empty_list_decl("out"),
+            make_append("out", make_identifier("a")),
+            make_append("out", make_identifier("b")),
+            make_for(
+                "i",
+                make_range(0, 2),
+                vec![sroa_decl("observed", loop_read)],
+            ),
+        ]);
+
+        let out = scalarize_local_arrays(block);
+        let stmts = sroa_stmts(&out);
+
+        assert_eq!(sroa_count_calls(stmts, "append"), 0);
+        assert_eq!(
+            stmts
+                .iter()
+                .filter_map(get_var_decl_name)
+                .filter(|name| name.starts_with("__sroa_snap"))
+                .count(),
+            1,
+            "the nested loop should read one materialized snapshot"
+        );
+    }
+
+    #[test]
+    fn sroa_demotes_outer_aggregate_mutated_by_nested_loop() {
+        let block = AstNode::Block(vec![
+            sroa_empty_list_decl("out"),
+            make_append("out", make_identifier("a")),
+            make_for(
+                "i",
+                make_range(0, 2),
+                vec![make_append("out", make_identifier("b"))],
+            ),
+        ]);
+
+        let out = scalarize_local_arrays(block);
+
+        assert_eq!(
+            sroa_count_calls(sroa_stmts(&out), "append"),
+            2,
+            "a nested mutation must retain the real aggregate and all writes"
         );
     }
 

--- a/crates/stoffel-lang/src/optimizations.rs
+++ b/crates/stoffel-lang/src/optimizations.rs
@@ -1611,7 +1611,7 @@ fn is_share_open_call(node: &AstNode) -> Option<&AstNode> {
     } = node
     {
         if let AstNode::Identifier(name, _) = function.as_ref() {
-            if (name == "Share.open" || name == "open") && arguments.len() == 1 {
+            if matches!(builtin_base_name(name), "open" | "reveal") && arguments.len() == 1 {
                 return Some(&arguments[0]);
             }
         }
@@ -2027,8 +2027,8 @@ struct StatementInfo {
     index: usize,
     /// The AST node
     node: AstNode,
-    /// Is this an implicit reveal? (clear var = secret expr)
-    is_implicit_reveal: bool,
+    /// Is this an implicit secret-to-clear move or an explicit `Share.open`?
+    is_reveal: bool,
     /// Does this statement use a revealed variable in a computation (triggers flush)?
     uses_revealed_var: bool,
 }
@@ -2131,6 +2131,16 @@ fn reveal_dep_keys(node: &AstNode) -> (HashSet<String>, HashSet<String>) {
         }
         _ => {
             read_keys(node, &mut reads);
+            // Structured statements are atomic to this reorderer. Register
+            // every nested write conservatively on both scalar and heap keys,
+            // so hoisting an independent reveal across an `if` is legal while
+            // any consumer/mutation of the same location remains ordered.
+            let mut nested_writes = HashSet::new();
+            collect_written_vars(node, &mut nested_writes);
+            for name in nested_writes {
+                writes.insert(scalar_key(&name));
+                writes.insert(heap_key(&name));
+            }
         }
     }
 
@@ -2179,6 +2189,17 @@ fn is_implicit_reveal(node: &AstNode, secret_vars: &HashSet<String>) -> bool {
     }
 }
 
+fn is_explicit_reveal(node: &AstNode) -> bool {
+    match node {
+        AstNode::VariableDeclaration {
+            value: Some(value), ..
+        }
+        | AstNode::Assignment { value, .. } => is_share_open_call(value).is_some(),
+        AstNode::DiscardStatement { expression, .. } => is_share_open_call(expression).is_some(),
+        _ => false,
+    }
+}
+
 /// Checks if a statement uses a revealed variable in a way that triggers a flush
 /// This happens when a revealed (clear) variable is used in computation
 fn uses_revealed_in_computation(node: &AstNode, revealed_vars: &HashSet<String>) -> bool {
@@ -2217,7 +2238,16 @@ fn uses_revealed_in_computation(node: &AstNode, revealed_vars: &HashSet<String>)
         AstNode::DiscardStatement { expression, .. } => {
             uses_revealed_in_computation(expression, revealed_vars)
         }
-        _ => false,
+        // Structured control (most importantly `if revealed_bit`) and any
+        // future expression-bearing statement are flush triggers whenever
+        // they reference a pending clear result. Keeping this structural
+        // fallback prevents a newly supported AST node from silently
+        // fragmenting reveal batches.
+        _ => {
+            let mut refs = HashSet::new();
+            collect_referenced_vars(node, &mut refs);
+            refs.iter().any(|v| revealed_vars.contains(v))
+        }
     }
 }
 
@@ -2240,11 +2270,6 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
         }
     }
 
-    // If no secret variables, nothing to optimize
-    if secret_vars.is_empty() {
-        return statements;
-    }
-
     // Second pass: build statement info
     let mut revealed_vars: HashSet<String> = HashSet::new();
     let mut stmt_infos: Vec<StatementInfo> = Vec::with_capacity(statements.len());
@@ -2252,7 +2277,7 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
     for (index, node) in statements.into_iter().enumerate() {
         let defines = collect_defined_vars(&node);
 
-        let is_reveal = is_implicit_reveal(&node, &secret_vars);
+        let is_reveal = is_explicit_reveal(&node) || is_implicit_reveal(&node, &secret_vars);
 
         // Track revealed variables
         if is_reveal {
@@ -2266,13 +2291,13 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
         stmt_infos.push(StatementInfo {
             index,
             node,
-            is_implicit_reveal: is_reveal,
+            is_reveal,
             uses_revealed_var: uses_revealed,
         });
     }
 
     // Check if reordering is beneficial
-    let has_reveals = stmt_infos.iter().any(|s| s.is_implicit_reveal);
+    let has_reveals = stmt_infos.iter().any(|s| s.is_reveal);
     let has_flush_triggers = stmt_infos.iter().any(|s| s.uses_revealed_var);
 
     if !has_reveals || !has_flush_triggers {
@@ -2387,7 +2412,7 @@ fn reorder_block_for_reveals(statements: Vec<AstNode>) -> Vec<AstNode> {
                     2
                 }
                 // Flush triggers last
-                else if info.is_implicit_reveal {
+                else if info.is_reveal {
                     1
                 }
                 // Reveals second
@@ -3377,19 +3402,17 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     let node = timed_pass("inline_multiply_wrappers", || {
         inline_multiply_wrappers(node)
     });
-    // Round-minimizing list scheduler (-O3): within each side-effect-free region,
-    // reorder statements so that all mutually-independent multiplies at the same
-    // dependency depth become consecutive. The greedy multiply batcher that runs
-    // next then collapses each depth into a single `Share.batch_mul` — one MPC
-    // round instead of one per chain. This trades register pressure (a whole
-    // round's shares are live at once) for fewer communication rounds, so it is
-    // gated to -O3 alongside inlining/unrolling.
+    // Round-minimizing interactive scheduler (-O3): model singular multiplies
+    // and reveals as distinct protocol nodes in one dependency DAG, then make
+    // every dependency-ready group consecutive. The lowering passes collapse
+    // those groups into `Share.batch_mul` / `Share.batch_open`. This trades
+    // register pressure (a whole round's shares are live at once) for fewer
+    // communication rounds, so it is gated to -O3 alongside inlining/unrolling.
     let node = if optimization_level >= 3 {
         timed_pass("schedule_for_batching", || schedule_for_batching(node))
     } else {
         node
     };
-    let node = timed_pass("optimize_reveals", || optimize_reveals(node));
     let node = timed_pass("optimize_multiplies", || optimize_multiplies(node));
     // Batching materializes accumulator setup and result-slice statements around
     // every fused call. Those new statements can expose another legal merge that
@@ -3407,6 +3430,10 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
     let node = timed_pass("reorder_for_reveal_batching", || {
         reorder_for_reveal_batching(node)
     });
+    // Reordering can make formerly interleaved explicit opens consecutive.
+    // Materialize those newly exposed groups as native batch opens now; the
+    // earlier reveal pass could not see across their clear consumers.
+    let node = timed_pass("optimize_reveals_after_reorder", || optimize_reveals(node));
     // SROA / scalarization (-O3): after the batchers settled the block shape,
     // replace constant-index reads of locally-built lists with direct element
     // references and delete the corresponding build calls, rematerializing a
@@ -3431,13 +3458,13 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
 }
 
 // ===========================================================================
-// Round-minimizing list scheduler
+// Round-minimizing interactive scheduler
 //
 // Reorders analyzable statements within a straight-line region of a block so that all
-// mutually-independent multiplies at the same dependency depth become
-// consecutive — letting the greedy multiply batcher coalesce them into one
-// `Share.batch_mul` (one MPC round). The reorder is a topological schedule of a
-// precise dependency graph, so it preserves every observed value:
+// mutually-independent operations of one protocol kind become consecutive —
+// letting the lowering passes coalesce scalar multiplies/reveals into native
+// `Share.batch_mul` / `Share.batch_open` calls. The reorder is a topological
+// schedule of a precise dependency graph, so it preserves every observed value:
 //
 //   * Data deps: RAW / WAR / WAW over scalar and heap keys. Assignments write
 //     their target key, and known mutators write/read their receiver heap key.
@@ -3447,8 +3474,8 @@ fn optimize_all_inner(node: AstNode, optimization_level: u8) -> AstNode {
 //   * Effects: observable mutators are ordered per receiver/effect key; unknown
 //     calls, reveals, control flow, and unresolved aliasing split the block.
 //
-// Multiplies are clustered by a list scheduler: drain all ready non-multiply
-// statements, then fire every currently-ready multiply as one round, repeat.
+// Interactive nodes are clustered by a list scheduler: drain ready local work,
+// then fire every currently-ready node of one protocol kind as one round.
 // ===========================================================================
 
 /// The "root" variable of an lvalue/receiver expression (`a` for `a`, `a[i]`,
@@ -3515,6 +3542,22 @@ fn value_is_multiply(value: &AstNode) -> bool {
 }
 
 /// Per-statement scheduling facts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InteractiveKind {
+    Multiply,
+    Reveal,
+}
+
+fn interactive_kind(value: &AstNode) -> Option<InteractiveKind> {
+    if value_is_multiply(value) {
+        Some(InteractiveKind::Multiply)
+    } else if is_share_open_call(value).is_some() {
+        Some(InteractiveKind::Reveal)
+    } else {
+        None
+    }
+}
+
 struct SchedInfo {
     direct_reads: HashSet<u32>,
     /// Materialized logical-read keys (loop aggregates; see `loop_sched_info`).
@@ -3525,7 +3568,7 @@ struct SchedInfo {
     logical_nodes: Vec<Rc<DepNode>>,
     writes: HashSet<u32>,
     effects: HashSet<u32>,
-    is_multiply: bool,
+    interactive: Option<InteractiveKind>,
 }
 
 fn scalar_key(name: &str) -> String {
@@ -3694,8 +3737,8 @@ fn loop_body_is_schedulable(body: &AstNode, pure_fns: &HashSet<String>) -> bool 
 /// the union over the iterable and every body statement (computed in body order
 /// so logical-dep tracking inside the loop is faithful), minus the loop-local
 /// induction variables. The over-approximation only ever ADDS dependency edges,
-/// so the resulting schedule preserves every observed value; `is_multiply` is
-/// false because a loop is not a single fusable multiply.
+/// so the resulting schedule preserves every observed value; `interactive` is
+/// `None` because a loop is not one directly fusable protocol operation.
 fn loop_sched_info(
     variables: &[String],
     iterable: &AstNode,
@@ -3754,24 +3797,30 @@ fn loop_sched_info(
         logical_nodes: Vec::new(),
         writes,
         effects,
-        is_multiply: false,
+        interactive: None,
     }
 }
 
-/// Whether a statement can participate in reordering. Anything else is a barrier
-/// (control flow, returns, reveals, unknown/user calls) that pins the schedule.
+/// Whether a statement can participate in reordering. Scalar multiply/reveal
+/// calls are first-class interactive nodes; anything else effectful or unknown
+/// remains a barrier.
 fn stmt_is_schedulable(stmt: &AstNode, pure_fns: &HashSet<String>) -> bool {
     match stmt {
-        AstNode::VariableDeclaration { value, .. } => value
-            .as_deref()
-            .is_none_or(|v| expr_is_reorderable(v, pure_fns)),
+        AstNode::VariableDeclaration { value, .. } => value.as_deref().is_none_or(|v| {
+            expr_is_reorderable(v, pure_fns)
+                || is_share_open_call(v).is_some_and(|share| expr_is_pure(share, pure_fns))
+        }),
         AstNode::Assignment { target, value, .. } => {
             (matches!(target.as_ref(), AstNode::Identifier(_, _)) || root_var(target).is_some())
                 && expr_is_pure(target, pure_fns)
-                && expr_is_reorderable(value, pure_fns)
+                && (expr_is_reorderable(value, pure_fns)
+                    || is_share_open_call(value).is_some_and(|share| expr_is_pure(share, pure_fns)))
         }
         AstNode::FunctionCall { arguments, .. } => call_name(stmt).is_some_and(|name| {
-            is_mutator_call_name(name) && arguments.iter().all(|arg| expr_is_pure(arg, pure_fns))
+            (is_mutator_call_name(name)
+                || is_share_open_call(stmt).is_some()
+                || is_readonly_observable_call(name))
+                && arguments.iter().all(|arg| expr_is_pure(arg, pure_fns))
         }),
         AstNode::DiscardStatement { expression, .. } => match expression.as_ref() {
             AstNode::FunctionCall { .. } => stmt_is_schedulable(expression, pure_fns),
@@ -3791,6 +3840,20 @@ fn stmt_is_schedulable(stmt: &AstNode, pure_fns: &HashSet<String>) -> bool {
         AstNode::ForLoop { iterable, body, .. } => {
             expr_is_pure(iterable, pure_fns) && loop_body_is_schedulable(body, pure_fns)
         }
+        // Pure structured control can move as one atomic region. We never
+        // speculate a branch: the condition and branch semantics remain intact;
+        // only the whole region participates in the surrounding dependency DAG.
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            expr_is_pure(condition, pure_fns)
+                && loop_body_is_schedulable(then_branch, pure_fns)
+                && else_branch
+                    .as_deref()
+                    .is_none_or(|branch| loop_body_is_schedulable(branch, pure_fns))
+        }
         _ => false,
     }
 }
@@ -3805,23 +3868,23 @@ fn stmt_is_schedulable(stmt: &AstNode, pure_fns: &HashSet<String>) -> bool {
 /// it — see the note on `statement_reads_and_writes`.
 fn sched_info(stmt: &AstNode, env: &SchedEnv, interner: &mut KeyInterner) -> SchedInfo {
     let mut direct_reads = HashSet::new();
-    let logical_reads = HashSet::new();
+    let mut logical_reads = HashSet::new();
     let mut logical_nodes = Vec::new();
     let mut writes = HashSet::new();
     let mut effects = HashSet::new();
-    let mut is_multiply = false;
+    let mut interactive = None;
 
     match stmt {
         AstNode::VariableDeclaration { name, value, .. } => {
             writes.insert(interner.scalar(name));
             if let Some(v) = value.as_deref() {
                 collect_direct_read_keys(v, &mut direct_reads, interner);
-                is_multiply = value_is_multiply(v);
+                interactive = interactive_kind(v);
             }
         }
         AstNode::Assignment { target, value, .. } => {
             collect_direct_read_keys(value, &mut direct_reads, interner);
-            is_multiply = value_is_multiply(value);
+            interactive = interactive_kind(value);
             match target.as_ref() {
                 AstNode::Identifier(name, _) => {
                     writes.insert(interner.scalar(name));
@@ -3852,7 +3915,60 @@ fn sched_info(stmt: &AstNode, env: &SchedEnv, interner: &mut KeyInterner) -> Sch
         } => {
             return loop_sched_info(variables, iterable, body, env, interner);
         }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => {
+            collect_direct_read_keys(condition, &mut direct_reads, interner);
+            for branch in
+                std::iter::once(then_branch.as_ref()).chain(else_branch.as_deref().into_iter())
+            {
+                let mut branch_env = env.clone();
+                for statement in loop_body_statements(branch) {
+                    let branch_info = sched_info(statement, &branch_env, interner);
+                    update_sched_env(statement, &mut branch_env, &branch_info, interner);
+                    direct_reads.extend(branch_info.direct_reads);
+                    logical_reads.extend(branch_info.logical_reads);
+                    logical_nodes.extend(branch_info.logical_nodes);
+                    writes.extend(branch_info.writes);
+                    effects.extend(branch_info.effects);
+                }
+            }
+        }
         AstNode::FunctionCall { arguments, .. } => {
+            if is_share_open_call(stmt).is_some() {
+                for argument in arguments {
+                    collect_direct_read_keys(argument, &mut direct_reads, interner);
+                    logical_nodes.push(logical_reads_node(argument, env, interner));
+                }
+                interactive = Some(InteractiveKind::Reveal);
+                return SchedInfo {
+                    direct_reads,
+                    logical_reads,
+                    logical_nodes,
+                    writes,
+                    effects,
+                    interactive,
+                };
+            }
+            if call_name(stmt).is_some_and(is_readonly_observable_call) {
+                for argument in arguments {
+                    collect_direct_read_keys(argument, &mut direct_reads, interner);
+                    logical_nodes.push(logical_reads_node(argument, env, interner));
+                }
+                // A dedicated effect-only key keeps print order without
+                // pretending the call writes or aliases program storage.
+                effects.insert(interner.scalar("__effect:print"));
+                return SchedInfo {
+                    direct_reads,
+                    logical_reads,
+                    logical_nodes,
+                    writes,
+                    effects,
+                    interactive,
+                };
+            }
             // A recognized mutator: first argument is the receiver (read+written),
             // the rest are read.
             if let Some(receiver) = arguments.first() {
@@ -3883,7 +3999,7 @@ fn sched_info(stmt: &AstNode, env: &SchedEnv, interner: &mut KeyInterner) -> Sch
         logical_nodes,
         writes,
         effects,
-        is_multiply,
+        interactive,
     }
 }
 
@@ -3951,6 +4067,30 @@ fn update_sched_env(
                 env.remove(var);
             }
         }
+        AstNode::IfExpression { .. } => {
+            // A branch join may select either definition. Preserve the complete
+            // input-dependency cone for every possibly-written root; exact
+            // branch value identity is intentionally not guessed.
+            let mut deps: HashSet<u32> = info
+                .direct_reads
+                .iter()
+                .chain(info.logical_reads.iter())
+                .copied()
+                .collect();
+            let mut visited = HashSet::new();
+            for node in &info.logical_nodes {
+                flatten_dep_node(node, &mut deps, &mut visited);
+            }
+            let dep_node = Rc::new(DepNode {
+                own: deps.into_iter().collect(),
+                parents: Vec::new(),
+            });
+            for &write in &info.writes {
+                if let Some(root) = interner.key_root(write) {
+                    env.insert(root.to_string(), Rc::clone(&dep_node));
+                }
+            }
+        }
         AstNode::FunctionCall { arguments, .. } => {
             if let Some(receiver) = arguments.first().and_then(root_var) {
                 env.remove(&receiver);
@@ -3981,7 +4121,8 @@ fn schedule_in_node(node: AstNode, pure_fns: &HashSet<String>) -> AstNode {
                 .into_iter()
                 .map(|s| schedule_in_node(s, pure_fns))
                 .collect();
-            AstNode::Block(schedule_statement_list(stmts, pure_fns))
+            let scheduled = schedule_statement_list(stmts, pure_fns);
+            AstNode::Block(fuse_independent_loops(scheduled, pure_fns))
         }
         AstNode::FunctionDefinition {
             name,
@@ -4069,6 +4210,164 @@ fn flatten_statement_blocks(stmts: Vec<AstNode>) -> Vec<AstNode> {
     out
 }
 
+/// Fuse counted loops when their complete read/write footprints are independent
+/// and intervening statements admit a dependence-preserving partition around
+/// the fused loop. This preserves code size while exposing same-iteration
+/// interactive operations to batching.
+fn fuse_independent_loops(statements: Vec<AstNode>, pure_fns: &HashSet<String>) -> Vec<AstNode> {
+    fn conflicts(writes: &HashSet<String>, observed: &HashSet<String>) -> bool {
+        writes
+            .iter()
+            .any(|write| observed.iter().any(|key| keys_conflict(write, key)))
+    }
+
+    fn independent(first: &AstNode, second: &AstNode) -> bool {
+        let (first_reads, first_writes) = statement_reads_and_writes(first);
+        let (second_reads, second_writes) = statement_reads_and_writes(second);
+        let mut first_observed = first_reads;
+        first_observed.extend(first_writes.iter().cloned());
+        let mut second_observed = second_reads;
+        second_observed.extend(second_writes.iter().cloned());
+        !conflicts(&first_writes, &second_observed) && !conflicts(&second_writes, &first_observed)
+    }
+
+    fn footprints_independent(
+        first_reads: &HashSet<String>,
+        first_writes: &HashSet<String>,
+        second_reads: &HashSet<String>,
+        second_writes: &HashSet<String>,
+    ) -> bool {
+        let mut first_observed = first_reads.clone();
+        first_observed.extend(first_writes.iter().cloned());
+        let mut second_observed = second_reads.clone();
+        second_observed.extend(second_writes.iter().cloned());
+        !conflicts(first_writes, &second_observed) && !conflicts(second_writes, &first_observed)
+    }
+
+    fn fuse(first: &AstNode, second: &AstNode, pure_fns: &HashSet<String>) -> Option<AstNode> {
+        let (
+            AstNode::ForLoop {
+                variables: first_vars,
+                iterable: first_iter,
+                body: first_body,
+                location,
+            },
+            AstNode::ForLoop {
+                variables: second_vars,
+                iterable: second_iter,
+                body: second_body,
+                ..
+            },
+        ) = (first, second)
+        else {
+            return None;
+        };
+        if first_vars.len() != 1
+            || second_vars.len() != 1
+            || first_iter != second_iter
+            || !loop_body_is_schedulable(first_body, pure_fns)
+            || !loop_body_is_schedulable(second_body, pure_fns)
+            || !independent(first, second)
+        {
+            return None;
+        }
+
+        let first_var = &first_vars[0];
+        let second_var = &second_vars[0];
+        let mut second_declared = HashSet::new();
+        collect_declared_names(second_body, &mut second_declared);
+        let mut second_referenced = HashSet::new();
+        collect_referenced_vars(second_body, &mut second_referenced);
+        if second_declared.contains(second_var)
+            || (first_var != second_var
+                && (second_declared.contains(first_var) || second_referenced.contains(first_var)))
+        {
+            return None;
+        }
+
+        let second_body = if first_var == second_var {
+            (**second_body).clone()
+        } else {
+            rename_in(
+                (**second_body).clone(),
+                &HashMap::from([(second_var.clone(), first_var.clone())]),
+            )
+        };
+        let mut merged = branch_into_stmts((**first_body).clone());
+        merged.extend(branch_into_stmts(second_body));
+        let merged = schedule_statement_list(flatten_statement_blocks(merged), pure_fns);
+        Some(AstNode::ForLoop {
+            variables: first_vars.clone(),
+            iterable: first_iter.clone(),
+            body: Box::new(AstNode::Block(merged)),
+            location: location.clone(),
+        })
+    }
+
+    let mut out: Vec<AstNode> = Vec::with_capacity(statements.len());
+    for statement in statements {
+        let mut replacement = None;
+        if matches!(statement, AstNode::ForLoop { .. }) {
+            for position in (0..out.len()).rev() {
+                let Some(fused) = fuse(&out[position], &statement, pure_fns) else {
+                    continue;
+                };
+                let middle = &out[position + 1..];
+                if !middle
+                    .iter()
+                    .all(|node| stmt_is_schedulable(node, pure_fns))
+                {
+                    continue;
+                }
+
+                // Compute the transitive A-dependent suffix partition in one
+                // forward pass. Once a statement observes A or any prior member
+                // of the suffix, it too must remain after the fused loop.
+                let (first_reads, first_writes) = statement_reads_and_writes(&out[position]);
+                let mut after_reads = HashSet::new();
+                let mut after_writes = HashSet::new();
+                let mut before = Vec::new();
+                let mut after = Vec::new();
+                for node in middle {
+                    let (reads, writes) = statement_reads_and_writes(node);
+                    let depends_on_first =
+                        !footprints_independent(&first_reads, &first_writes, &reads, &writes);
+                    let depends_on_suffix =
+                        !footprints_independent(&after_reads, &after_writes, &reads, &writes);
+                    if depends_on_first || depends_on_suffix {
+                        after_reads.extend(reads);
+                        after_writes.extend(writes);
+                        after.push(node.clone());
+                    } else {
+                        before.push(node.clone());
+                    }
+                }
+
+                let (second_reads, second_writes) = statement_reads_and_writes(&statement);
+                if !footprints_independent(
+                    &after_reads,
+                    &after_writes,
+                    &second_reads,
+                    &second_writes,
+                ) {
+                    continue;
+                }
+                replacement = Some((position, before, fused, after));
+                break;
+            }
+        }
+        if let Some((position, before, fused, after)) = replacement {
+            out.truncate(position);
+            out.extend(before);
+            out.push(fused);
+            out.extend(after);
+        } else {
+            out.push(statement);
+        }
+    }
+    out
+}
+
 /// Split a statement list into maximal schedulable runs separated by barriers,
 /// reorder each run, and emit barriers in place.
 fn schedule_statement_list(stmts: Vec<AstNode>, pure_fns: &HashSet<String>) -> Vec<AstNode> {
@@ -4104,8 +4403,8 @@ fn sched_cone_ab_check() -> bool {
 }
 
 /// Reorder one analyzable straight-line run via dependency-graph list scheduling,
-/// clustering same-depth multiplies. Falls back to the original order if a
-/// dependency cycle is somehow present (never expected).
+/// clustering dependency-ready multiplies and reveals by protocol kind. Falls
+/// back to source order if a dependency cycle is somehow present.
 fn schedule_run(stmts: Vec<AstNode>) -> Vec<AstNode> {
     let n = stmts.len();
     if n < 2 {
@@ -4356,19 +4655,22 @@ fn build_schedule_order(
         }
     }
 
-    // List-schedule: drain ready non-multiplies, then fire one round of all
-    // currently-ready multiplies, repeat. Ready buckets are min-heaps on the
-    // original index so the output is a stable topological order.
+    // List-schedule: drain ready local work, then fire all currently-ready
+    // operations of one interactive protocol kind. Multiply and reveal nodes
+    // never share a batch, but each kind automatically coalesces its independent
+    // scalar operations. Ready buckets are min-heaps on source index for stable,
+    // deterministic output.
     use std::cmp::Reverse;
     use std::collections::BinaryHeap;
     let mut ready_free: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
     let mut ready_mult: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
+    let mut ready_reveal: BinaryHeap<Reverse<usize>> = BinaryHeap::new();
     for i in 0..n {
         if indeg[i] == 0 {
-            if infos[i].is_multiply {
-                ready_mult.push(Reverse(i));
-            } else {
-                ready_free.push(Reverse(i));
+            match infos[i].interactive {
+                Some(InteractiveKind::Multiply) => ready_mult.push(Reverse(i)),
+                Some(InteractiveKind::Reveal) => ready_reveal.push(Reverse(i)),
+                None => ready_free.push(Reverse(i)),
             }
         }
     }
@@ -4380,8 +4682,19 @@ fn build_schedule_order(
             // Emit one ready free statement.
             vec![ready_free.pop().map(|Reverse(i)| i).unwrap()]
         } else if !ready_mult.is_empty() {
-            // Fire one multiply round: all currently-ready multiplies at once.
-            std::iter::from_fn(|| ready_mult.pop().map(|Reverse(i)| i)).collect()
+            // If both protocols are ready, preserve the source order of their
+            // earliest node. The chosen kind then fires as one batch.
+            let reveal_first = matches!(
+                (ready_reveal.peek(), ready_mult.peek()),
+                (Some(Reverse(reveal)), Some(Reverse(mul))) if reveal < mul
+            );
+            if reveal_first {
+                std::iter::from_fn(|| ready_reveal.pop().map(|Reverse(i)| i)).collect()
+            } else {
+                std::iter::from_fn(|| ready_mult.pop().map(|Reverse(i)| i)).collect()
+            }
+        } else if !ready_reveal.is_empty() {
+            std::iter::from_fn(|| ready_reveal.pop().map(|Reverse(i)| i)).collect()
         } else {
             break; // cycle (unexpected) — fall back below.
         };
@@ -4390,10 +4703,10 @@ fn build_schedule_order(
             for &s in &succ[i] {
                 indeg[s] -= 1;
                 if indeg[s] == 0 {
-                    if infos[s].is_multiply {
-                        ready_mult.push(Reverse(s));
-                    } else {
-                        ready_free.push(Reverse(s));
+                    match infos[s].interactive {
+                        Some(InteractiveKind::Multiply) => ready_mult.push(Reverse(s)),
+                        Some(InteractiveKind::Reveal) => ready_reveal.push(Reverse(s)),
+                        None => ready_free.push(Reverse(s)),
                     }
                 }
             }
@@ -6773,7 +7086,7 @@ fn fold_branches_in_stmts(stmts: Vec<AstNode>) -> Vec<AstNode> {
 
 /// A flow-sensitive provenance fact for a value. `Top` is the conservative
 /// unknown (possibly secret) default.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 enum ConstVal {
     Top,
     /// A value proven by semantic typing to be secret, but whose clear value is
@@ -6795,6 +7108,253 @@ enum ConstVal {
 }
 
 type GateEnv = std::collections::HashMap<String, ConstVal>;
+
+fn gate_value_is_concrete(value: &ConstVal) -> bool {
+    match value {
+        ConstVal::Int(_) | ConstVal::Bit { .. } => true,
+        ConstVal::List(elements) => elements.iter().all(gate_value_is_concrete),
+        ConstVal::Top | ConstVal::Secret => false,
+    }
+}
+
+fn gate_const_to_ast(value: &ConstVal, location: &SourceLocation) -> Option<AstNode> {
+    match value {
+        ConstVal::Int(value) if *value >= 0 => Some(make_int_literal(*value as u128, location)),
+        ConstVal::Bit { val, .. } => Some(make_from_clear_int_bit(*val, location)),
+        ConstVal::List(elements) => Some(AstNode::ListLiteral {
+            elements: elements
+                .iter()
+                .map(|element| gate_const_to_ast(element, location))
+                .collect::<Option<Vec<_>>>()?,
+            location: location.clone(),
+        }),
+        _ => None,
+    }
+}
+
+fn gate_range_bounds(iterable: &AstNode, env: &GateEnv) -> Option<(i128, i128)> {
+    let AstNode::BinaryOperation {
+        op, left, right, ..
+    } = iterable
+    else {
+        return None;
+    };
+    if op != ".." {
+        return None;
+    }
+    let ConstVal::Int(lo) = gate_eval(left, env) else {
+        return None;
+    };
+    let ConstVal::Int(hi) = gate_eval(right, env) else {
+        return None;
+    };
+    (hi >= lo).then_some((lo, hi))
+}
+
+/// Abstractly execute an exact, effect-free public region. This interpreter is
+/// intentionally small and fail-closed: unsupported control/effects return
+/// false, causing the original loop to remain untouched.
+fn gate_simulate_public_node(node: &AstNode, env: &mut GateEnv, fuel: &mut usize) -> bool {
+    if *fuel == 0 {
+        return false;
+    }
+    *fuel -= 1;
+    match node {
+        AstNode::Block(statements) => statements
+            .iter()
+            .all(|statement| gate_simulate_public_node(statement, env, fuel)),
+        AstNode::ForLoop {
+            variables,
+            iterable,
+            body,
+            ..
+        } => {
+            let [variable] = variables.as_slice() else {
+                return false;
+            };
+            let Some((lo, hi)) = gate_range_bounds(iterable, env) else {
+                return false;
+            };
+            if (hi - lo) as u128 > UNROLL_MAX_ITERATIONS {
+                return false;
+            }
+            let mut locals = HashSet::new();
+            collect_declared_names(body, &mut locals);
+            for value in lo..hi {
+                for local in &locals {
+                    env.remove(local);
+                }
+                env.insert(variable.clone(), ConstVal::Int(value));
+                if !gate_simulate_public_node(body, env, fuel) {
+                    return false;
+                }
+            }
+            for local in locals {
+                env.remove(&local);
+            }
+            env.remove(variable);
+            true
+        }
+        AstNode::IfExpression {
+            condition,
+            then_branch,
+            else_branch,
+        } => match gate_eval(condition, env) {
+            ConstVal::Bit { val: 0, .. } => else_branch
+                .as_deref()
+                .is_none_or(|branch| gate_simulate_public_node(branch, env, fuel)),
+            ConstVal::Bit { .. } => gate_simulate_public_node(then_branch, env, fuel),
+            _ => false,
+        },
+        AstNode::WhileLoop { .. }
+        | AstNode::TryCatch { .. }
+        | AstNode::Return { .. }
+        | AstNode::Yield(_)
+        | AstNode::Break
+        | AstNode::Continue
+        | AstNode::FunctionDefinition { .. }
+        | AstNode::CommandCall { .. } => false,
+        AstNode::FunctionCall { .. } | AstNode::DiscardStatement { .. } => {
+            let expression = match node {
+                AstNode::FunctionCall { .. } => node,
+                AstNode::DiscardStatement { expression, .. } => expression.as_ref(),
+                _ => unreachable!("matched call/discard above"),
+            };
+            let Some(call) = call_name(expression) else {
+                return false;
+            };
+            if !is_pure_builtin(call) && !is_mutator_call_name(call) {
+                return false;
+            }
+            let AstNode::FunctionCall { arguments, .. } = expression else {
+                return false;
+            };
+            if !arguments
+                .iter()
+                .all(|argument| expr_is_pure(argument, &HashSet::new()))
+            {
+                return false;
+            }
+            let _ = gate_process_stmt(node.clone(), env);
+            true
+        }
+        AstNode::VariableDeclaration { value, .. } => {
+            if !value
+                .as_deref()
+                .is_none_or(|value| expr_is_pure(value, &HashSet::new()))
+            {
+                return false;
+            }
+            let _ = gate_process_stmt(node.clone(), env);
+            true
+        }
+        AstNode::Assignment { target, value, .. } => {
+            if !expr_is_pure(target, &HashSet::new()) || !expr_is_pure(value, &HashSet::new()) {
+                return false;
+            }
+            let _ = gate_process_stmt(node.clone(), env);
+            true
+        }
+        _ => false,
+    }
+}
+
+/// Replace a statically-bounded public loop with its final concrete mutations.
+/// List identity is preserved: only an initially-empty list is materialized via
+/// appends to the original receiver; arbitrary rebinding is rejected.
+fn try_partial_evaluate_public_for(
+    variables: &[String],
+    iterable: &AstNode,
+    body: &AstNode,
+    location: &SourceLocation,
+    env: &mut GateEnv,
+) -> Option<AstNode> {
+    let [variable] = variables else {
+        return None;
+    };
+    let (lo, hi) = gate_range_bounds(iterable, env)?;
+    if hi <= lo || (hi - lo) as u128 > UNROLL_MAX_ITERATIONS {
+        return None;
+    }
+
+    let mut written = HashSet::new();
+    collect_written_vars(body, &mut written);
+    let mut locals = HashSet::new();
+    collect_declared_names(body, &mut locals);
+    let mut outer: Vec<String> = written
+        .into_iter()
+        .filter(|name| name != variable && !locals.contains(name))
+        .collect();
+    outer.sort();
+    if outer.is_empty()
+        || outer.iter().any(|name| {
+            env.get(name)
+                .is_none_or(|value| !gate_value_is_concrete(value))
+        })
+    {
+        return None;
+    }
+    let initial: HashMap<String, ConstVal> = outer
+        .iter()
+        .map(|name| (name.clone(), env[name].clone()))
+        .collect();
+
+    let mut simulated = env.clone();
+    let mut fuel = 500_000usize;
+    for value in lo..hi {
+        for local in &locals {
+            simulated.remove(local);
+        }
+        simulated.insert(variable.clone(), ConstVal::Int(value));
+        if !gate_simulate_public_node(body, &mut simulated, &mut fuel) {
+            return None;
+        }
+    }
+    if outer.iter().any(|name| {
+        simulated
+            .get(name)
+            .is_none_or(|value| !gate_value_is_concrete(value))
+    }) {
+        return None;
+    }
+
+    let mut replacement = Vec::new();
+    for name in outer {
+        let before = &initial[&name];
+        let after = simulated.get(&name)?;
+        if before == after {
+            continue;
+        }
+        match (before, after) {
+            (ConstVal::List(before), ConstVal::List(after)) if before.is_empty() => {
+                for element in after {
+                    replacement.push(AstNode::FunctionCall {
+                        function: Box::new(AstNode::Identifier(
+                            "append".to_string(),
+                            location.clone(),
+                        )),
+                        arguments: vec![
+                            AstNode::Identifier(name.clone(), location.clone()),
+                            gate_const_to_ast(element, location)?,
+                        ],
+                        location: location.clone(),
+                        resolved_return_type: None,
+                    });
+                }
+            }
+            (ConstVal::Int(_) | ConstVal::Bit { .. }, _) => {
+                replacement.push(AstNode::Assignment {
+                    target: Box::new(AstNode::Identifier(name.clone(), location.clone())),
+                    value: Box::new(gate_const_to_ast(after, location)?),
+                    location: location.clone(),
+                });
+            }
+            _ => return None,
+        }
+        env.insert(name, after.clone());
+    }
+    Some(AstNode::Block(replacement))
+}
 
 fn annotation_contains_secret_type(annotation: Option<&AstNode>) -> bool {
     fn contains(node: &AstNode) -> bool {
@@ -7045,16 +7605,24 @@ fn gate_process_stmt(stmt: AstNode, env: &mut GateEnv) -> AstNode {
             iterable,
             body,
             location,
-        } => gate_process_loop_body(
-            |body| AstNode::ForLoop {
-                variables,
-                iterable,
-                body,
-                location,
-            },
-            *body,
-            env,
-        ),
+        } => {
+            if let Some(replacement) =
+                try_partial_evaluate_public_for(&variables, &iterable, &body, &location, env)
+            {
+                replacement
+            } else {
+                gate_process_loop_body(
+                    |body| AstNode::ForLoop {
+                        variables,
+                        iterable,
+                        body,
+                        location,
+                    },
+                    *body,
+                    env,
+                )
+            }
+        }
         other => other,
     }
 }
@@ -7627,6 +8195,24 @@ fn gate_eval(node: &AstNode, env: &GateEnv) -> ConstVal {
                         {
                             return ConstVal::Bit {
                                 val: (a ^ b) & 1,
+                                from_list: *fa || *fb,
+                            };
+                        }
+                    }
+                    Some("mul") => {
+                        if let (
+                            ConstVal::Bit {
+                                val: a,
+                                from_list: fa,
+                            },
+                            ConstVal::Bit {
+                                val: b,
+                                from_list: fb,
+                            },
+                        ) = (&lhs, &rhs)
+                        {
+                            return ConstVal::Bit {
+                                val: (a & b) & 1,
                                 from_list: *fa || *fb,
                             };
                         }
@@ -8643,6 +9229,15 @@ fn is_mutator_call_name(name: &str) -> bool {
 /// communication — so it is pure too.)
 fn is_pure_builtin(name: &str) -> bool {
     builtin_effect(name).pure
+}
+
+/// Observable calls whose arguments are read but which cannot mutate program
+/// data. They may participate in the dependency scheduler as effect nodes:
+/// same-kind effects retain source order, while independent MPC operations can
+/// be hoisted ahead. Calls that can abort (`assert`) or touch external state in
+/// less transparent ways remain barriers.
+fn is_readonly_observable_call(name: &str) -> bool {
+    builtin_base_name(name) == "print"
 }
 
 fn call_name(node: &AstNode) -> Option<&str> {
@@ -11921,6 +12516,108 @@ mod tests {
         );
     }
 
+    #[test]
+    fn exact_public_loop_is_partially_evaluated_without_rebinding_lists() {
+        let loc = make_loc();
+        let body = AstNode::Block(vec![
+            make_append("out", make_identifier("carry")),
+            AstNode::Assignment {
+                target: Box::new(make_identifier("carry")),
+                value: Box::new(AstNode::UnaryOperation {
+                    op: "not".to_string(),
+                    operand: Box::new(make_identifier("carry")),
+                    location: loc.clone(),
+                }),
+                location: loc.clone(),
+            },
+        ]);
+        let mut env = GateEnv::from([
+            ("out".to_string(), ConstVal::List(Vec::new())),
+            (
+                "carry".to_string(),
+                ConstVal::Bit {
+                    val: 1,
+                    from_list: false,
+                },
+            ),
+        ]);
+
+        let replacement = try_partial_evaluate_public_for(
+            &["i".to_string()],
+            &make_range(0, 3),
+            &body,
+            &loc,
+            &mut env,
+        )
+        .expect("exact public loop should evaluate");
+        let AstNode::Block(statements) = replacement else {
+            panic!("partial evaluation should emit a statement block");
+        };
+        assert_eq!(statements.len(), 4, "three appends plus final carry");
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| call_name(statement).is_some_and(|name| name == "append"))
+                .count(),
+            3
+        );
+        assert_eq!(
+            statements
+                .iter()
+                .filter(|statement| matches!(statement, AstNode::Assignment { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            env.get("out"),
+            Some(&ConstVal::List(vec![
+                ConstVal::Bit {
+                    val: 1,
+                    from_list: false,
+                },
+                ConstVal::Bit {
+                    val: 0,
+                    from_list: false,
+                },
+                ConstVal::Bit {
+                    val: 1,
+                    from_list: false,
+                },
+            ]))
+        );
+    }
+
+    #[test]
+    fn public_loop_partial_evaluation_rejects_observable_effects() {
+        let loc = make_loc();
+        let body = AstNode::Block(vec![
+            make_call("print", vec![make_identifier("carry")]),
+            AstNode::Assignment {
+                target: Box::new(make_identifier("carry")),
+                value: Box::new(make_identifier("carry")),
+                location: loc.clone(),
+            },
+        ]);
+        let mut env = GateEnv::from([(
+            "carry".to_string(),
+            ConstVal::Bit {
+                val: 1,
+                from_list: false,
+            },
+        )]);
+        assert!(
+            try_partial_evaluate_public_for(
+                &["i".to_string()],
+                &make_range(0, 3),
+                &body,
+                &loc,
+                &mut env,
+            )
+            .is_none(),
+            "observable effects must keep the original loop"
+        );
+    }
+
     /// SOUNDNESS regression (kept-loop guard folding): inside a while loop the
     /// unroller CANNOT flatten (unknown bound), a guard over a loop-mutated
     /// variable must NOT be folded with the variable's pre-loop entry value —
@@ -12176,6 +12873,58 @@ mod tests {
             .map(|s| order.iter().position(|i| i == s).unwrap())
             .collect();
         assert!(append_pos.windows(2).all(|w| w[0] < w[1]));
+    }
+
+    #[test]
+    fn loop_fusion_requires_whole_loop_independence() {
+        let and = |left: &str, right: &str| AstNode::BinaryOperation {
+            op: "and".to_string(),
+            left: Box::new(make_identifier(left)),
+            right: Box::new(make_identifier(right)),
+            location: make_loc(),
+        };
+        let first = make_for(
+            "i",
+            make_range(0, 4),
+            vec![make_var_decl("lane_a", and("x", "y"))],
+        );
+        let second = make_for(
+            "j",
+            make_range(0, 4),
+            vec![make_var_decl("lane_b", and("p", "q"))],
+        );
+        let fused = fuse_independent_loops(vec![first.clone(), second], &HashSet::new());
+        assert_eq!(
+            fused
+                .iter()
+                .filter(|node| matches!(node, AstNode::ForLoop { .. }))
+                .count(),
+            1,
+            "independent equal-range loops should fuse"
+        );
+
+        let dependent = make_for(
+            "j",
+            make_range(0, 4),
+            vec![make_var_decl("lane_b", and("state", "q"))],
+        );
+        let writer = make_for(
+            "i",
+            make_range(0, 4),
+            vec![AstNode::Assignment {
+                target: Box::new(make_identifier("state")),
+                value: Box::new(and("x", "y")),
+                location: make_loc(),
+            }],
+        );
+        let kept = fuse_independent_loops(vec![writer, dependent], &HashSet::new());
+        assert_eq!(
+            kept.iter()
+                .filter(|node| matches!(node, AstNode::ForLoop { .. }))
+                .count(),
+            2,
+            "a cross-loop RAW dependency must reject fusion"
+        );
     }
 
     #[test]
@@ -12549,6 +13298,14 @@ mod tests {
         let detected = is_share_open_call(&open_call);
         assert!(detected.is_some());
         assert_eq!(detected.unwrap(), &share_expr);
+
+        let reveal_call = AstNode::FunctionCall {
+            function: Box::new(make_identifier("reveal")),
+            arguments: vec![share_expr.clone()],
+            location: make_loc(),
+            resolved_return_type: None,
+        };
+        assert_eq!(is_share_open_call(&reveal_call), Some(&share_expr));
     }
 
     #[test]
@@ -12692,6 +13449,73 @@ mod tests {
         } else {
             panic!("Expected Block");
         }
+    }
+
+    #[test]
+    fn interactive_scheduler_hoists_singular_reveals_then_batches() {
+        reset_temp_counter();
+        let clear_use = AstNode::IfExpression {
+            condition: Box::new(make_identifier("a")),
+            then_branch: Box::new(AstNode::Block(Vec::new())),
+            else_branch: None,
+        };
+        let reordered = schedule_statement_list(
+            vec![
+                make_var_decl("a", make_share_open(make_identifier("s1"))),
+                clear_use,
+                make_var_decl("b", make_share_open(make_identifier("s2"))),
+            ],
+            &HashSet::new(),
+        );
+        let names: Vec<&str> = reordered
+            .iter()
+            .filter_map(|statement| match statement {
+                AstNode::VariableDeclaration { name, .. } => Some(name.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(names, ["a", "b"]);
+
+        let AstNode::Block(batched) = optimize_reveals(AstNode::Block(reordered)) else {
+            panic!("expected block");
+        };
+        assert_eq!(batched.len(), 4, "one batch, two extracts, clear use");
+        assert!(matches!(
+            &batched[0],
+            AstNode::VariableDeclaration { value: Some(value), .. }
+                if call_name(value) == Some("Share.batch_open")
+        ));
+    }
+
+    #[test]
+    fn interactive_scheduler_crosses_print_but_preserves_print_order() {
+        let print = |name: &str| AstNode::FunctionCall {
+            function: Box::new(make_identifier("print")),
+            arguments: vec![make_identifier(name)],
+            location: make_loc(),
+            resolved_return_type: None,
+        };
+        let scheduled = schedule_statement_list(
+            vec![
+                make_var_decl("a", make_share_open(make_identifier("s1"))),
+                print("a"),
+                make_var_decl("b", make_share_open(make_identifier("s2"))),
+                print("b"),
+            ],
+            &HashSet::new(),
+        );
+        assert!(matches!(
+            &scheduled[..],
+            [
+                AstNode::VariableDeclaration { name: a, .. },
+                AstNode::VariableDeclaration { name: b, .. },
+                AstNode::FunctionCall { arguments: first, .. },
+                AstNode::FunctionCall { arguments: second, .. },
+            ] if a == "a"
+                && b == "b"
+                && matches!(&first[..], [AstNode::Identifier(name, _)] if name == "a")
+                && matches!(&second[..], [AstNode::Identifier(name, _)] if name == "b")
+        ));
     }
 
     #[test]

--- a/crates/stoffel-lang/src/preprocessing_planner.rs
+++ b/crates/stoffel-lang/src/preprocessing_planner.rs
@@ -22,11 +22,23 @@
 //! data-dependent loops) the analysis sets `dynamic = true` rather than silently
 //! undercounting.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use crate::ast::{AstNode, Parameter, Value};
+use crate::errors::SourceLocation;
+use crate::symbol_table::SymbolType;
 use stoffel_vm_types::compiled_binary::{MpcBackend, PreprocessingDemand};
-use stoffel_vm_types::core_types::DEFAULT_FIXED_POINT_FRACTIONAL_BITS;
+use stoffel_vm_types::core_types::{
+    DEFAULT_FIXED_POINT_FRACTIONAL_BITS, DEFAULT_FIXED_POINT_TOTAL_BITS,
+};
+
+fn preprocessing_diagnostic(message: std::fmt::Arguments<'_>) {
+    if std::env::var_os("STOFFEL_PREPROCESSING_DIAGNOSTICS").is_some() {
+        eprintln!("preprocessing planner: {message}");
+    }
+}
 
 /// Statically known list shape of a value: its length and, recursively, the
 /// shape of its elements (so nested lists like `list[list[secret bool]]` can be
@@ -100,16 +112,72 @@ impl std::hash::Hash for Secrecy {
     }
 }
 
+static NEXT_EXACT_ELEMENTS_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Exact aggregate contents shared by abstract values.
+///
+/// `id` identifies one immutable logical snapshot. Cloning the `Arc` preserves
+/// the snapshot identity, while every mutation rotates the id first. Call-cache
+/// keys can therefore distinguish changed lane provenance in O(1) without
+/// recursively rebuilding a key for every element on every call.
+#[derive(Debug, Clone)]
+struct ExactElements {
+    id: u64,
+    values: Vec<AbstractValue>,
+}
+
+impl ExactElements {
+    fn shared(values: Vec<AbstractValue>) -> Arc<Self> {
+        Arc::new(Self {
+            id: Self::next_id(),
+            values,
+        })
+    }
+
+    fn values_mut(elements: &mut Arc<Self>) -> &mut Vec<AbstractValue> {
+        let elements = Arc::make_mut(elements);
+        elements.id = Self::next_id();
+        &mut elements.values
+    }
+
+    fn next_id() -> u64 {
+        let id = NEXT_EXACT_ELEMENTS_ID.fetch_add(1, Ordering::Relaxed);
+        assert_ne!(id, u64::MAX, "exhausted exact aggregate snapshot ids");
+        id
+    }
+}
+
+impl std::ops::Deref for ExactElements {
+    type Target = [AbstractValue];
+
+    fn deref(&self) -> &Self::Target {
+        &self.values
+    }
+}
+
 /// The abstract value an expression evaluates to: its list shape, its secrecy,
 /// and — for clear integers — its constant value (used for loop bounds).
 #[derive(Debug, Clone)]
 struct AbstractValue {
     len: Len,
     secrecy: Secrecy,
+    /// The value is known to all parties while still inhabiting a secret-share
+    /// type (for example the result of `Share.from_clear_int`). Such values can
+    /// participate in integer/boolean multiplication without a Beaver triple.
+    public_share: bool,
     /// Statically known clear integer value, if any.
     int: Option<u64>,
     /// Fractional bits of a secret fixed-point value, for `/` truncation cost.
     frac_bits: Option<usize>,
+    /// Integer share width when known (one bit identifies the boolean domain).
+    bit_length: Option<usize>,
+    /// Exact integral value of a public share. Kept separate from `int`, which
+    /// denotes an ordinary clear integer usable as a loop bound/index.
+    public_integer: Option<i64>,
+    /// Exact elements of a statically materialized list. This preserves
+    /// per-lane public-share provenance for mixed `batch_mul` operands instead
+    /// of collapsing the whole aggregate to one all-public bit.
+    elements: Option<Arc<ExactElements>>,
 }
 
 impl AbstractValue {
@@ -117,8 +185,12 @@ impl AbstractValue {
         AbstractValue {
             len: Len::Unknown,
             secrecy: Secrecy::Unknown,
+            public_share: false,
             int: None,
             frac_bits: None,
+            bit_length: None,
+            public_integer: None,
+            elements: None,
         }
     }
 
@@ -126,8 +198,12 @@ impl AbstractValue {
         AbstractValue {
             len: Len::Unknown,
             secrecy: Secrecy::Clear,
+            public_share: false,
             int: Some(value),
             frac_bits: None,
+            bit_length: None,
+            public_integer: None,
+            elements: None,
         }
     }
 
@@ -135,8 +211,12 @@ impl AbstractValue {
         AbstractValue {
             len: Len::Unknown,
             secrecy: Secrecy::Clear,
+            public_share: false,
             int: None,
             frac_bits: None,
+            bit_length: None,
+            public_integer: None,
+            elements: None,
         }
     }
 
@@ -144,9 +224,42 @@ impl AbstractValue {
         AbstractValue {
             len: Len::Unknown,
             secrecy: Secrecy::Secret,
+            public_share: false,
             int: None,
             frac_bits: None,
+            bit_length: None,
+            public_integer: None,
+            elements: None,
         }
+    }
+
+    fn public_share(frac_bits: Option<usize>) -> Self {
+        AbstractValue {
+            len: Len::Unknown,
+            secrecy: Secrecy::Secret,
+            public_share: true,
+            int: None,
+            frac_bits,
+            bit_length: None,
+            public_integer: None,
+            elements: None,
+        }
+    }
+
+    fn secret_with_bit_length(bit_length: Option<usize>) -> Self {
+        let mut value = Self::secret();
+        value.bit_length = bit_length;
+        value
+    }
+
+    fn public_integral_share(bit_length: Option<usize>, value: i64) -> Option<Self> {
+        if bit_length == Some(1) && !matches!(value, 0 | 1) {
+            return None;
+        }
+        let mut result = Self::public_share(None);
+        result.bit_length = bit_length;
+        result.public_integer = Some(value);
+        Some(result)
     }
 }
 
@@ -180,14 +293,40 @@ impl From<&Len> for LenKey {
     }
 }
 
-/// A memoisation / call-stack key: the function plus the abstract shape of its
-/// arguments. Two calls with the same name, argument lengths, and argument
-/// secrecy incur identical demand, so we analyse each shape only once.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AbstractValueKey {
+    len: LenKey,
+    secrecy: Secrecy,
+    public_share: bool,
+    int: Option<u64>,
+    frac_bits: Option<usize>,
+    bit_length: Option<usize>,
+    public_integer: Option<i64>,
+    elements_id: Option<u64>,
+}
+
+impl From<&AbstractValue> for AbstractValueKey {
+    fn from(value: &AbstractValue) -> Self {
+        Self {
+            len: LenKey::from(&value.len),
+            secrecy: value.secrecy,
+            public_share: value.public_share,
+            int: value.int,
+            frac_bits: value.frac_bits,
+            bit_length: value.bit_length,
+            public_integer: value.public_integer,
+            elements_id: value.elements.as_ref().map(|elements| elements.id),
+        }
+    }
+}
+
+/// A memoisation / call-stack key: the function plus the complete abstract
+/// values of its arguments. Lane provenance and clear constants affect demand,
+/// so omitting either can reuse an estimate from an inequivalent call site.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct CallKey {
     name: String,
-    arg_lens: Vec<LenKey>,
-    arg_secrecy: Vec<Secrecy>,
+    arguments: Vec<AbstractValueKey>,
 }
 
 /// A user-defined function the planner can analyse.
@@ -202,6 +341,30 @@ struct Planner<'a> {
     functions: HashMap<String, &'a FunctionInfo<'a>>,
     memo: HashMap<CallKey, CallResult>,
     mpc_backend: MpcBackend,
+    work: PlannerWork,
+    loop_profiles: HashMap<SourceLocation, LoopProfile>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct LoopProfile {
+    invocations: u64,
+    iterations: u64,
+    expression_visits: u64,
+}
+
+/// Deterministic units of planner work used by scaling regression tests. These
+/// counters describe algorithmic work rather than machine-dependent elapsed
+/// time, so they are stable enough to gate CI.
+#[derive(Debug, Clone, Copy, Default)]
+struct PlannerWork {
+    expression_visits: u64,
+    exact_loop_iterations: u64,
+    summarized_loop_iterations: u64,
+    uniform_append_summaries: u64,
+    aggregate_mutations: u64,
+    aggregate_lanes_appended: u64,
+    aggregate_lanes_copied: u64,
+    call_keys_built: u64,
 }
 
 /// Compute the total preprocessing demand of `program` (the top-level AST, a
@@ -243,6 +406,13 @@ fn plan_preprocessing_demand_inner(
     program: &AstNode,
     mpc_backend: MpcBackend,
 ) -> PreprocessingDemand {
+    plan_preprocessing_demand_inner_with_work(program, mpc_backend).0
+}
+
+fn plan_preprocessing_demand_inner_with_work(
+    program: &AstNode,
+    mpc_backend: MpcBackend,
+) -> (PreprocessingDemand, PlannerWork) {
     let mut infos: Vec<(String, FunctionInfo)> = Vec::new();
     collect_functions(program, &mut infos);
 
@@ -255,6 +425,8 @@ fn plan_preprocessing_demand_inner(
         functions,
         memo: HashMap::new(),
         mpc_backend,
+        work: PlannerWork::default(),
+        loop_profiles: HashMap::new(),
     };
 
     // Program entries are the functions the runtime can actually invoke as a
@@ -284,7 +456,28 @@ fn plan_preprocessing_demand_inner(
         let result = planner.analyze_entry(name, info);
         total = max_demand(total, result.demand);
     }
-    total
+    if std::env::var("STOFFEL_OPT_TIMING").is_ok_and(|value| value != "0" && !value.is_empty()) {
+        eprintln!(
+            "[planner-work] expressions={} loop_iterations={} summarized_loop_iterations={} uniform_append_summaries={} aggregate_mutations={} lanes_appended={} lanes_copied={} call_keys={}",
+            planner.work.expression_visits,
+            planner.work.exact_loop_iterations,
+            planner.work.summarized_loop_iterations,
+            planner.work.uniform_append_summaries,
+            planner.work.aggregate_mutations,
+            planner.work.aggregate_lanes_appended,
+            planner.work.aggregate_lanes_copied,
+            planner.work.call_keys_built,
+        );
+        let mut loops: Vec<_> = planner.loop_profiles.iter().collect();
+        loops.sort_unstable_by_key(|(_, profile)| std::cmp::Reverse(profile.expression_visits));
+        for (location, profile) in loops.into_iter().take(12) {
+            eprintln!(
+                "[planner-loop] location={location} invocations={} iterations={} expressions={}",
+                profile.invocations, profile.iterations, profile.expression_visits,
+            );
+        }
+    }
+    (total, planner.work)
 }
 
 /// Walk `node` collecting every top-level function definition (recursing into
@@ -330,6 +523,7 @@ fn max_demand(a: PreprocessingDemand, b: PreprocessingDemand) -> PreprocessingDe
         randoms: a.randoms.max(b.randoms),
         prandbits: a.prandbits.max(b.prandbits),
         prandints: a.prandints.max(b.prandints),
+        prandint_bits: a.prandint_bits.max(b.prandint_bits),
         dynamic: a.dynamic || b.dynamic,
     }
 }
@@ -339,10 +533,22 @@ impl<'a> Planner<'a> {
     /// are unknown (a caller would supply them) but their secrecy follows their
     /// type annotation.
     fn analyze_entry(&mut self, name: &str, info: &FunctionInfo<'a>) -> CallResult {
-        let arg_lens: Vec<Len> = info.parameters.iter().map(|_| Len::Unknown).collect();
-        let arg_secrecy: Vec<Secrecy> = info.parameters.iter().map(param_element_secrecy).collect();
+        let arguments: Vec<AbstractValue> = info
+            .parameters
+            .iter()
+            .map(|parameter| AbstractValue {
+                len: Len::Unknown,
+                secrecy: param_element_secrecy(parameter),
+                public_share: false,
+                int: None,
+                frac_bits: param_frac_bits(parameter),
+                bit_length: None,
+                public_integer: None,
+                elements: None,
+            })
+            .collect();
         let mut call_stack = Vec::new();
-        self.analyze_call(name, info, &arg_lens, &arg_secrecy, &mut call_stack)
+        self.analyze_call(name, info, &arguments, &mut call_stack)
     }
 
     /// Analyse one call of `name` with the given argument shapes, memoised on
@@ -352,14 +558,13 @@ impl<'a> Planner<'a> {
         &mut self,
         name: &str,
         info: &FunctionInfo<'a>,
-        arg_lens: &[Len],
-        arg_secrecy: &[Secrecy],
+        arguments: &[AbstractValue],
         call_stack: &mut Vec<String>,
     ) -> CallResult {
+        self.work.call_keys_built = self.work.call_keys_built.saturating_add(1);
         let key = CallKey {
             name: name.to_string(),
-            arg_lens: arg_lens.iter().map(LenKey::from).collect(),
-            arg_secrecy: arg_secrecy.to_vec(),
+            arguments: arguments.iter().map(AbstractValueKey::from).collect(),
         };
         if let Some(cached) = self.memo.get(&key) {
             return cached.clone();
@@ -367,6 +572,10 @@ impl<'a> Planner<'a> {
 
         // Recursion: we cannot bound the depth statically, so flag dynamic.
         if call_stack.iter().any(|frame| frame == name) {
+            preprocessing_diagnostic(format_args!(
+                "dynamic recursion: {} -> {name}",
+                call_stack.join(" -> ")
+            ));
             return CallResult {
                 demand: PreprocessingDemand {
                     dynamic: true,
@@ -380,20 +589,12 @@ impl<'a> Planner<'a> {
         // the parameters' declared element secrecy.
         let mut env = Env::new();
         for (index, param) in info.parameters.iter().enumerate() {
-            let len = arg_lens.get(index).cloned().unwrap_or(Len::Unknown);
-            let secrecy = arg_secrecy
+            let mut value = arguments
                 .get(index)
-                .copied()
-                .unwrap_or_else(|| param_element_secrecy(param));
-            env.insert(
-                param.name.clone(),
-                AbstractValue {
-                    len,
-                    secrecy,
-                    int: None,
-                    frac_bits: param_frac_bits(param),
-                },
-            );
+                .cloned()
+                .unwrap_or_else(AbstractValue::unknown);
+            value.frac_bits = param_frac_bits(param).or(value.frac_bits);
+            env.insert(param.name.clone(), value);
         }
 
         call_stack.push(name.to_string());
@@ -455,16 +656,31 @@ impl<'a> Planner<'a> {
                     env.insert(name.clone(), value);
                 } else {
                     // Index/field assignment: evaluate the target for any
-                    // embedded calls, but it does not rebind a simple name.
+                    // embedded calls. It also mutates the aggregate rooted at a
+                    // simple name: once a non-public share is stored anywhere
+                    // in a list/object, the aggregate is no longer provably an
+                    // all-public operand for a later batch multiplication.
                     self.eval_expr(target, env, demand, call_stack);
+                    let updated_exact_lane = update_exact_aggregate_assignment(env, target, &value);
+                    if !updated_exact_lane {
+                        if let Some(root) = assignment_root(target) {
+                            if let Some(aggregate) = env.get_mut(root) {
+                                aggregate.secrecy = aggregate.secrecy.join_arith(value.secrecy);
+                                aggregate.public_share &= value.public_share;
+                                aggregate.elements = None;
+                            }
+                        }
+                    }
                 }
             }
             AstNode::ForLoop {
                 variables,
                 iterable,
                 body,
-                ..
-            } => self.eval_for_loop(variables, iterable, body, env, demand, ret, call_stack),
+                location,
+            } => self.eval_for_loop(
+                variables, iterable, body, location, env, demand, ret, call_stack,
+            ),
             AstNode::WhileLoop {
                 condition, body, ..
             } => self.eval_while_loop(condition, body, env, demand, ret, call_stack),
@@ -514,7 +730,7 @@ impl<'a> Planner<'a> {
             call_stack,
         );
 
-        let (else_demand, else_ret) = match else_branch {
+        let (else_demand, else_ret, else_env) = match else_branch {
             Some(else_branch) => {
                 let mut else_env = env.clone();
                 let mut else_demand = PreprocessingDemand::default();
@@ -526,9 +742,9 @@ impl<'a> Planner<'a> {
                     &mut else_ret,
                     call_stack,
                 );
-                (else_demand, else_ret)
+                (else_demand, else_ret, else_env)
             }
-            None => (PreprocessingDemand::default(), ret.clone()),
+            None => (PreprocessingDemand::default(), ret.clone(), env.clone()),
         };
 
         // Demand of a conditional is the per-element maximum of its branches.
@@ -537,9 +753,18 @@ impl<'a> Planner<'a> {
         // The function return value may come from either branch.
         *ret = merge_opt_ret(then_ret, else_ret);
 
-        // Branch-local bindings cannot be reconciled, so leave `env` unchanged
-        // for names whose value diverges; subsequent uses fall back to the
-        // pre-`if` binding (conservative).
+        // Preserve facts only when both branches agree. In particular, a value
+        // that is public before the conditional must not remain classified as
+        // public if either branch replaces it with a secret share.
+        for name in env.keys().cloned().collect::<Vec<_>>() {
+            let Some(then_value) = then_env.get(&name).cloned() else {
+                continue;
+            };
+            let Some(else_value) = else_env.get(&name).cloned() else {
+                continue;
+            };
+            env.insert(name, merge_value(then_value, else_value));
+        }
     }
 
     /// Evaluate a `while` loop. The counted shape codegen emits everywhere —
@@ -595,6 +820,12 @@ impl<'a> Planner<'a> {
             None => {
                 add_demand(demand, &body_demand);
                 if has_any_material(&body_demand) {
+                    preprocessing_diagnostic(format_args!(
+                        "dynamic while loop in {} at {:?}: body demand {:?}",
+                        call_stack.join(" -> "),
+                        condition.location(),
+                        body_demand
+                    ));
                     demand.dynamic = true;
                 }
                 apply_loop_length_growth_unknown(env, &body_env);
@@ -659,13 +890,21 @@ impl<'a> Planner<'a> {
         variables: &[String],
         iterable: &AstNode,
         body: &AstNode,
+        location: &SourceLocation,
         env: &mut Env,
         demand: &mut PreprocessingDemand,
         ret: &mut Option<AbstractValue>,
         call_stack: &mut Vec<String>,
     ) {
+        const EXACT_LOOP_INTERPRETATION_LIMIT: u64 = 10_000;
+
         // Determine iteration count and the loop variable's abstract value.
-        let (count, loop_var_value): (Option<u64>, AbstractValue) = match iterable {
+        let (count, loop_var_value, range_start, exact_loop_elements): (
+            Option<u64>,
+            AbstractValue,
+            Option<u64>,
+            Option<Arc<ExactElements>>,
+        ) = match iterable {
             AstNode::BinaryOperation {
                 op, left, right, ..
             } if op == ".." => {
@@ -676,8 +915,9 @@ impl<'a> Planner<'a> {
                     (Some(a), Some(b)) if b >= a => Some(b - a),
                     _ => None,
                 };
-                // Range loop variable is a clear int (value unknown in general).
-                (count, AbstractValue::clear())
+                // Exact counted loops are interpreted iteration by iteration,
+                // so preserve the initial induction value when it is known.
+                (count, AbstractValue::clear(), start.int, None)
             }
             _ => {
                 // `for x in <list>`: the count is the list length; bind `x` to
@@ -687,12 +927,101 @@ impl<'a> Planner<'a> {
                 let element = AbstractValue {
                     len: collection.len.element(),
                     secrecy: collection.secrecy,
+                    public_share: collection.public_share,
                     int: None,
                     frac_bits: None,
+                    bit_length: collection.bit_length,
+                    public_integer: None,
+                    elements: None,
                 };
-                (count, element)
+                (count, element, None, collection.elements)
             }
         };
+
+        // Scaling a body analysed only in its first-iteration environment is
+        // unsound for loop-carried MPC state: a public accumulator can make the
+        // first product local, then become secret so every later product needs
+        // a triple. Interpret ordinary statically-bounded loops exactly so each
+        // iteration observes the preceding iteration's abstract state. The cap
+        // protects compiler latency for pathological literal bounds; those keep
+        // the conservative dynamic fallback below instead of claiming an exact
+        // (potentially under-provisioned) manifest.
+        if let Some(count) = count.filter(|count| *count <= EXACT_LOOP_INTERPRETATION_LIMIT) {
+            let expressions_before = self.work.expression_visits;
+            if self.try_summarize_uniform_append_loop(
+                variables,
+                body,
+                count,
+                range_start,
+                env,
+                demand,
+                call_stack,
+            ) {
+                let profile = self.loop_profiles.entry(location.clone()).or_default();
+                profile.invocations = profile.invocations.saturating_add(1);
+                profile.iterations = profile.iterations.saturating_add(count);
+                profile.expression_visits = profile.expression_visits.saturating_add(
+                    self.work
+                        .expression_visits
+                        .saturating_sub(expressions_before),
+                );
+                return;
+            }
+            let visible_names: HashSet<String> = env.keys().cloned().collect();
+            let mut body_local_names = Vec::new();
+            collect_declared_names(body, &mut body_local_names);
+            body_local_names.sort_unstable();
+            body_local_names.dedup();
+            for iteration in 0..count {
+                self.work.exact_loop_iterations = self.work.exact_loop_iterations.saturating_add(1);
+                if let Some(first) = variables.first() {
+                    let value = range_start
+                        .and_then(|start| start.checked_add(iteration))
+                        .map(AbstractValue::clear_int)
+                        .or_else(|| {
+                            exact_loop_elements
+                                .as_ref()
+                                .and_then(|elements| elements.get(iteration as usize))
+                                .cloned()
+                        })
+                        .unwrap_or_else(|| loop_var_value.clone());
+                    env.insert(first.clone(), value);
+                }
+                for extra in variables.iter().skip(1) {
+                    env.insert(extra.clone(), AbstractValue::unknown());
+                }
+
+                let mut iteration_demand = PreprocessingDemand::default();
+                let mut iteration_ret = None;
+                self.eval_block_like(
+                    body,
+                    env,
+                    &mut iteration_demand,
+                    &mut iteration_ret,
+                    call_stack,
+                );
+                add_demand(demand, &iteration_demand);
+                merge_into_ret(ret, iteration_ret);
+
+                // Body-local declarations and newly introduced loop variables
+                // do not escape an iteration. Remove only names that the AST
+                // can introduce instead of cloning/scanning the entire env.
+                for name in body_local_names.iter().chain(variables) {
+                    if !visible_names.contains(name) {
+                        env.remove(name);
+                    }
+                }
+            }
+            let profile = self.loop_profiles.entry(location.clone()).or_default();
+            profile.invocations = profile.invocations.saturating_add(1);
+            profile.iterations = profile.iterations.saturating_add(count);
+            profile.expression_visits = profile.expression_visits.saturating_add(
+                self.work
+                    .expression_visits
+                    .saturating_sub(expressions_before),
+            );
+            return;
+        }
 
         // Bind the loop variable(s) before analysing the body. (Only single-var
         // loops are supported by codegen; bind the first, leave the rest
@@ -721,6 +1050,10 @@ impl<'a> Planner<'a> {
         match count {
             Some(count) => {
                 add_demand(demand, &scale_demand(&body_demand, count));
+                // Reaching this arm means the known bound exceeded the exact
+                // interpretation budget above. The scaled first-iteration
+                // demand is only a floor for possible loop-carried state.
+                demand.dynamic = true;
                 // Apply the per-iteration list-length growth `count` times. A
                 // list appended to once per iteration ends at `start + count`.
                 // (This composes across nested loops: the inner loop writes its
@@ -734,11 +1067,106 @@ impl<'a> Planner<'a> {
                 // by an unbounded loop now has an unknown length.
                 add_demand(demand, &body_demand);
                 if has_any_material(&body_demand) {
+                    preprocessing_diagnostic(format_args!(
+                        "dynamic for loop in {} at {:?}: body demand {:?}",
+                        call_stack.join(" -> "),
+                        iterable.location(),
+                        body_demand
+                    ));
                     demand.dynamic = true;
                 }
                 apply_loop_length_growth_unknown(env, &body_env);
             }
         }
+    }
+
+    /// Summarize a uniform append-only map loop in closed form.
+    ///
+    /// The accepted shape is one `append(out, value)` statement over an exact
+    /// integer range. `value` may use the induction variable only to index exact
+    /// aggregates whose selected lanes all have the same abstract value. That
+    /// is a proof that every iteration has identical preprocessing demand and
+    /// appends identical abstract provenance. Evaluating the value once, scaling
+    /// its demand, and growing the exact aggregate by `count` therefore produces
+    /// the same manifest and post-loop environment as scalar interpretation.
+    #[allow(clippy::too_many_arguments)]
+    fn try_summarize_uniform_append_loop(
+        &mut self,
+        variables: &[String],
+        body: &AstNode,
+        count: u64,
+        range_start: Option<u64>,
+        env: &mut Env,
+        demand: &mut PreprocessingDemand,
+        call_stack: &mut Vec<String>,
+    ) -> bool {
+        let [loop_var] = variables else {
+            return false;
+        };
+        let Some(start) = range_start else {
+            return false;
+        };
+        let Some((receiver, value)) = single_append_loop_body(body) else {
+            return false;
+        };
+        let AstNode::Identifier(receiver_name, _) = receiver else {
+            return false;
+        };
+        if node_references_identifier(value, receiver_name)
+            || !expression_is_uniform_over_range(value, loop_var, start, count, env)
+        {
+            return false;
+        }
+        let Ok(count_usize) = usize::try_from(count) else {
+            return false;
+        };
+        if count == 0 {
+            self.work.uniform_append_summaries =
+                self.work.uniform_append_summaries.saturating_add(1);
+            return true;
+        }
+
+        let previous_loop_var = env.insert(loop_var.clone(), AbstractValue::clear_int(start));
+        let mut iteration_demand = PreprocessingDemand::default();
+        let element = self.eval_expr(value, env, &mut iteration_demand, call_stack);
+        // Keep the compact summary on scalar lanes. Repeating a nested exact
+        // aggregate would expand a large tree that branch merging must later
+        // rebuild recursively; those loops retain ordinary exact interpretation
+        // until the abstract domain has an explicit run-length representation.
+        if element.elements.is_some() || element.len.count().is_some() {
+            if let Some(previous) = previous_loop_var {
+                env.insert(loop_var.clone(), previous);
+            } else {
+                env.remove(loop_var);
+            }
+            return false;
+        }
+        add_demand(demand, &scale_demand(&iteration_demand, count));
+
+        self.list_grow(
+            Some(receiver),
+            count_usize,
+            Some(element.secrecy),
+            Some(element.public_share),
+            Some(element.len.clone()),
+            Some(ExactElements::shared(vec![element; count_usize])),
+            env,
+        );
+
+        if let Some(previous) = previous_loop_var {
+            let last = start.saturating_add(count.saturating_sub(1));
+            let mut final_value = AbstractValue::clear_int(last);
+            // Preserve the existing binding's declared abstract category when
+            // its concrete induction value is not otherwise observable.
+            final_value.secrecy = previous.secrecy;
+            env.insert(loop_var.clone(), final_value);
+        } else {
+            env.remove(loop_var);
+        }
+        self.work.summarized_loop_iterations =
+            self.work.summarized_loop_iterations.saturating_add(count);
+        self.work.uniform_append_summaries = self.work.uniform_append_summaries.saturating_add(1);
+        true
     }
 
     /// Evaluate an expression for its abstract value, accumulating any demand it
@@ -750,6 +1178,7 @@ impl<'a> Planner<'a> {
         demand: &mut PreprocessingDemand,
         call_stack: &mut Vec<String>,
     ) -> AbstractValue {
+        self.work.expression_visits = self.work.expression_visits.saturating_add(1);
         match node {
             AstNode::Literal { value, .. } => match value {
                 Value::Int { value, .. } => u64::try_from(*value)
@@ -763,9 +1192,12 @@ impl<'a> Planner<'a> {
                 .unwrap_or_else(AbstractValue::unknown),
             AstNode::ListLiteral { elements, .. } => {
                 let mut secrecy = Secrecy::Clear;
+                let mut public_share = !elements.is_empty();
                 let mut element_shape: Option<Len> = None;
+                let mut exact_elements = Vec::with_capacity(elements.len());
                 for element in elements {
                     let value = self.eval_expr(element, env, demand, call_stack);
+                    public_share &= value.public_share;
                     if value.secrecy == Secrecy::Secret {
                         secrecy = Secrecy::Secret;
                     } else if value.secrecy == Secrecy::Unknown && secrecy != Secrecy::Secret {
@@ -775,8 +1207,9 @@ impl<'a> Planner<'a> {
                     element_shape = Some(match element_shape {
                         Some(existing) if existing == value.len => existing,
                         Some(_) => Len::Unknown,
-                        None => value.len,
+                        None => value.len.clone(),
                     });
+                    exact_elements.push(value);
                 }
                 AbstractValue {
                     len: Len::Known {
@@ -784,8 +1217,12 @@ impl<'a> Planner<'a> {
                         elem: Box::new(element_shape.unwrap_or(Len::Unknown)),
                     },
                     secrecy,
+                    public_share,
                     int: None,
                     frac_bits: None,
+                    bit_length: None,
+                    public_integer: None,
+                    elements: Some(ExactElements::shared(exact_elements)),
                 }
             }
             AstNode::BinaryOperation {
@@ -794,29 +1231,55 @@ impl<'a> Planner<'a> {
             AstNode::UnaryOperation { operand, .. } => {
                 // `not` and other unary ops are free; propagate operand secrecy.
                 let value = self.eval_expr(operand, env, demand, call_stack);
+                let public_integer = value
+                    .public_integer
+                    .and_then(|value| (value == 0 || value == 1).then_some(1 - value));
                 AbstractValue {
                     len: Len::Unknown,
                     secrecy: value.secrecy,
+                    public_share: value.public_share,
                     int: None,
                     frac_bits: value.frac_bits,
+                    bit_length: value.bit_length,
+                    public_integer,
+                    elements: None,
                 }
             }
             AstNode::FunctionCall {
                 function,
                 arguments,
+                resolved_return_type,
                 ..
-            } => self.eval_function_call(function, arguments, env, demand, call_stack),
+            } => self.eval_function_call(
+                function,
+                arguments,
+                resolved_return_type.as_ref(),
+                env,
+                demand,
+                call_stack,
+            ),
             AstNode::IndexAccess { base, index, .. } => {
                 let base = self.eval_expr(base, env, demand, call_stack);
-                self.eval_expr(index, env, demand, call_stack);
+                let index = self.eval_expr(index, env, demand, call_stack);
+                if let Some(value) = index
+                    .int
+                    .and_then(|index| usize::try_from(index).ok())
+                    .and_then(|index| base.elements.as_ref()?.get(index))
+                {
+                    return value.clone();
+                }
                 // An element of a list inherits the list's element shape and
                 // secrecy (so `state[i]` on a list of 8-bit bytes is a byte of
                 // length 8).
                 AbstractValue {
                     len: base.len.element(),
                     secrecy: base.secrecy,
+                    public_share: base.public_share,
                     int: None,
                     frac_bits: None,
+                    bit_length: base.bit_length,
+                    public_integer: None,
+                    elements: None,
                 }
             }
             AstNode::FieldAccess { object, .. } => {
@@ -899,7 +1362,9 @@ impl<'a> Planner<'a> {
             // prime field (`a xor b = a + b - 2ab`), so they cost one triple too.
             "*" | "and" | "or" | "xor"
                 if left_value.secrecy == Secrecy::Secret
-                    && right_value.secrecy == Secrecy::Secret =>
+                    && right_value.secrecy == Secrecy::Secret
+                    && !(left_value.public_share && left_value.frac_bits.is_none())
+                    && !(right_value.public_share && right_value.frac_bits.is_none()) =>
             {
                 demand.add(1, 0, 0, 0);
             }
@@ -911,6 +1376,7 @@ impl<'a> Planner<'a> {
                     .frac_bits
                     .unwrap_or(DEFAULT_FIXED_POINT_FRACTIONAL_BITS) as u64;
                 demand.add(0, 0, f, 1);
+                demand.require_prandint_bits(DEFAULT_FIXED_POINT_TOTAL_BITS);
             }
             _ => {}
         }
@@ -925,11 +1391,30 @@ impl<'a> Planner<'a> {
             _ => None,
         };
 
+        let public_integer = if left_value.public_share && right_value.public_share {
+            match (op, left_value.public_integer, right_value.public_integer) {
+                ("*", Some(left), Some(right)) => left.checked_mul(right),
+                ("and", Some(left), Some(right)) => Some(i64::from(left != 0 && right != 0)),
+                ("or", Some(left), Some(right)) => Some(i64::from(left != 0 || right != 0)),
+                ("xor", Some(left), Some(right)) => Some(i64::from((left != 0) ^ (right != 0))),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
         AbstractValue {
             len: Len::Unknown,
             secrecy: left_value.secrecy.join_arith(right_value.secrecy),
+            public_share: left_value.public_share
+                && right_value.public_share
+                && left_value.frac_bits.is_none()
+                && right_value.frac_bits.is_none(),
             int,
             frac_bits: left_value.frac_bits.or(right_value.frac_bits),
+            bit_length: left_value.bit_length.or(right_value.bit_length),
+            public_integer,
+            elements: None,
         }
     }
 
@@ -937,6 +1422,7 @@ impl<'a> Planner<'a> {
         &mut self,
         function: &AstNode,
         arguments: &[AstNode],
+        resolved_return_type: Option<&SymbolType>,
         env: &mut Env,
         demand: &mut PreprocessingDemand,
         call_stack: &mut Vec<String>,
@@ -951,11 +1437,29 @@ impl<'a> Planner<'a> {
             return AbstractValue::unknown();
         };
 
-        // Map source-level builtin aliases to their VM symbol, mirroring codegen.
-        let name = crate::builtin_registry::builtin_registry()
+        // Map source-level builtin aliases to their VM symbol, mirroring
+        // codegen. UFCS lowers some builtin-object calls to an unqualified
+        // method name (`Share.add(...)` -> `add(...)`); resolve that form by
+        // its semantic return type when it does not name a user function.
+        let registry = crate::builtin_registry::builtin_registry();
+        let name = registry
             .vm_symbol_for_call(raw_name)
-            .unwrap_or(raw_name.as_str())
-            .to_string();
+            .map(str::to_string)
+            .or_else(|| {
+                if self.functions.contains_key(raw_name) {
+                    return None;
+                }
+                let expected = resolved_return_type?;
+                let mut candidates = registry
+                    .objects
+                    .values()
+                    .filter_map(|object| object.methods.get(raw_name))
+                    .filter(|method| &method.return_type == expected)
+                    .map(|method| method.qualified_name.as_str());
+                let candidate = candidates.next()?;
+                candidates.next().is_none().then(|| candidate.to_string())
+            })
+            .unwrap_or_else(|| raw_name.to_string());
 
         // Pre-evaluate argument abstract values (also accumulates embedded
         // demand from nested calls/ops).
@@ -967,28 +1471,117 @@ impl<'a> Planner<'a> {
         match name.as_str() {
             // --- Operations that consume preprocessing material ---------------
             "Share.mul" => {
-                demand.add(1, 0, 0, 0);
-                AbstractValue::secret()
+                let left = arg_values.first();
+                let right = arg_values.get(1);
+                let left_is_local_constant =
+                    left.is_some_and(|value| value.public_share && value.frac_bits.is_none());
+                let right_is_local_constant =
+                    right.is_some_and(|value| value.public_share && value.frac_bits.is_none());
+                if !left_is_local_constant && !right_is_local_constant {
+                    preprocessing_diagnostic(format_args!(
+                        "interactive Share.mul in {}: left={left:?}, right={right:?}",
+                        call_stack.join(" -> ")
+                    ));
+                    demand.add(1, 0, 0, 0);
+                }
+                let bit_length = left
+                    .and_then(|value| value.bit_length)
+                    .or_else(|| right.and_then(|value| value.bit_length));
+                if left_is_local_constant && right_is_local_constant {
+                    match left
+                        .and_then(|value| value.public_integer)
+                        .zip(right.and_then(|value| value.public_integer))
+                        .and_then(|(left, right)| left.checked_mul(right))
+                        .and_then(|value| AbstractValue::public_integral_share(bit_length, value))
+                    {
+                        Some(value) => value,
+                        None => {
+                            let mut value = AbstractValue::public_share(None);
+                            value.bit_length = bit_length;
+                            value
+                        }
+                    }
+                } else {
+                    AbstractValue::secret_with_bit_length(bit_length)
+                }
             }
             "Share.batch_mul" => {
                 let input_len = arg_values
                     .first()
                     .map(|value| value.len.clone())
                     .unwrap_or(Len::Unknown);
-                match input_len.count() {
-                    Some(len) => demand.add(len as u64, 0, 0, 0),
-                    None => {
-                        // Runtime-sized batch: provision one and flag dynamic.
-                        demand.add(1, 0, 0, 0);
-                        demand.dynamic = true;
+                let left = arg_values.first();
+                let right = arg_values.get(1);
+                let left_is_local_constant =
+                    left.is_some_and(|value| value.public_share && value.frac_bits.is_none());
+                let right_is_local_constant =
+                    right.is_some_and(|value| value.public_share && value.frac_bits.is_none());
+                let exact_products = left
+                    .and_then(|value| value.elements.as_ref())
+                    .zip(right.and_then(|value| value.elements.as_ref()))
+                    .filter(|(left, right)| left.len() == right.len())
+                    .map(|(left, right)| {
+                        left.iter()
+                            .zip(right.iter())
+                            .map(|(left, right)| {
+                                let left_local = left.public_share && left.frac_bits.is_none();
+                                let right_local = right.public_share && right.frac_bits.is_none();
+                                let bit_length = left.bit_length.or(right.bit_length);
+                                let mut value = if left_local && right_local {
+                                    left.public_integer
+                                        .zip(right.public_integer)
+                                        .and_then(|(left, right)| left.checked_mul(right))
+                                        .and_then(|value| {
+                                            AbstractValue::public_integral_share(bit_length, value)
+                                        })
+                                        .unwrap_or_else(|| {
+                                            let mut value = AbstractValue::public_share(None);
+                                            value.bit_length = bit_length;
+                                            value
+                                        })
+                                } else {
+                                    AbstractValue::secret_with_bit_length(bit_length)
+                                };
+                                value.len = Len::Unknown;
+                                (u64::from(!left_local && !right_local), value)
+                            })
+                            .collect::<Vec<_>>()
+                    });
+                if let Some(products) = &exact_products {
+                    demand.add(products.iter().map(|(cost, _)| *cost).sum(), 0, 0, 0);
+                } else if !left_is_local_constant && !right_is_local_constant {
+                    match input_len.count() {
+                        Some(len) => demand.add(len as u64, 0, 0, 0),
+                        None => {
+                            // Runtime-sized batch: provision one and flag dynamic.
+                            preprocessing_diagnostic(format_args!(
+                                "dynamic Share.batch_mul in {}: left={:?}, right={:?}",
+                                call_stack.join(" -> "),
+                                arg_values.first(),
+                                arg_values.get(1)
+                            ));
+                            demand.add(1, 0, 0, 0);
+                            demand.dynamic = true;
+                        }
                     }
                 }
                 // Result is a list of secret shares, same length as the inputs.
                 AbstractValue {
                     len: input_len,
                     secrecy: Secrecy::Secret,
+                    public_share: exact_products.as_ref().map_or(
+                        left_is_local_constant && right_is_local_constant,
+                        |products| products.iter().all(|(_, value)| value.public_share),
+                    ),
                     int: None,
                     frac_bits: None,
+                    bit_length: None,
+                    public_integer: None,
+                    elements: exact_products.map(|products| {
+                        ExactElements::shared(
+                            products.into_iter().map(|(_, value)| value).collect(),
+                        )
+                    }),
                 }
             }
 
@@ -1004,20 +1597,43 @@ impl<'a> Planner<'a> {
             // The appended/inserted element is the call's last argument; its
             // shape and secrecy are folded into the receiver list.
             "append" | "array_push" | "insert" => {
-                let element = arg_values.last();
-                let element_secrecy = element.map(|value| value.secrecy);
-                let element_shape = element.map(|value| value.len.clone());
-                self.list_grow(arguments.first(), 1, element_secrecy, element_shape, env);
+                let element = arg_values.last().cloned();
+                let element_secrecy = element.as_ref().map(|value| value.secrecy);
+                let element_public_share = element.as_ref().map(|value| value.public_share);
+                let element_shape = element.as_ref().map(|value| value.len.clone());
+                // `arg_values[0]` is a clone of the receiver. Keeping it alive
+                // across the mutation would make every append copy the entire
+                // accumulated vector through `Arc::make_mut`.
+                drop(arg_values);
+                self.list_grow(
+                    arguments.first(),
+                    1,
+                    element_secrecy,
+                    element_public_share,
+                    element_shape,
+                    element.map(|element| ExactElements::shared(vec![element])),
+                    env,
+                );
                 AbstractValue::clear()
             }
             "extend" => {
-                let element_secrecy = arg_values.get(1).map(|value| value.secrecy);
-                match arg_values.get(1).and_then(|value| value.len.count()) {
+                let source = arg_values.get(1).cloned();
+                let element_secrecy = source.as_ref().map(|value| value.secrecy);
+                let element_public_share = source.as_ref().map(|value| value.public_share);
+                let count = source.as_ref().and_then(|value| value.len.count());
+                let element_shape = source.as_ref().map(|value| value.len.element());
+                let exact_elements = source.and_then(|value| value.elements);
+                // Release the separately evaluated receiver snapshot before
+                // mutating it; the source snapshot remains alive by necessity.
+                drop(arg_values);
+                match count {
                     Some(n) => self.list_grow(
                         arguments.first(),
                         n,
                         element_secrecy,
-                        arg_values.get(1).map(|value| value.len.element()),
+                        element_public_share,
+                        element_shape,
+                        exact_elements,
                         env,
                     ),
                     None => self.list_make_unknown(arguments.first(), env),
@@ -1039,8 +1655,12 @@ impl<'a> Planner<'a> {
             "create_array" => AbstractValue {
                 len: Len::flat(0),
                 secrecy: Secrecy::Unknown,
+                public_share: false,
                 int: None,
                 frac_bits: None,
+                bit_length: None,
+                public_integer: None,
+                elements: Some(ExactElements::shared(Vec::new())),
             },
             "create_object"
             | "set_field"
@@ -1049,15 +1669,29 @@ impl<'a> Planner<'a> {
             | "assert"
             | "MpcOutput.send_to_client"
             | "Share.send_to_client" => AbstractValue::clear(),
-            "get_field" => arg_values
-                .first()
-                .map(|collection| AbstractValue {
-                    len: collection.len.element(),
-                    secrecy: collection.secrecy,
-                    int: None,
-                    frac_bits: collection.frac_bits,
-                })
-                .unwrap_or_else(AbstractValue::unknown),
+            "get_field" => {
+                if let Some(value) = arg_values
+                    .get(1)
+                    .and_then(|index| index.int)
+                    .and_then(|index| usize::try_from(index).ok())
+                    .and_then(|index| arg_values.first()?.elements.as_ref()?.get(index))
+                {
+                    return value.clone();
+                }
+                arg_values
+                    .first()
+                    .map(|collection| AbstractValue {
+                        len: collection.len.element(),
+                        secrecy: collection.secrecy,
+                        public_share: collection.public_share,
+                        int: None,
+                        frac_bits: collection.frac_bits,
+                        bit_length: collection.bit_length,
+                        public_integer: None,
+                        elements: None,
+                    })
+                    .unwrap_or_else(AbstractValue::unknown)
+            }
             "slice" => {
                 let source = arg_values.first();
                 let len = match (
@@ -1079,16 +1713,29 @@ impl<'a> Planner<'a> {
                     secrecy: source
                         .map(|value| value.secrecy)
                         .unwrap_or(Secrecy::Unknown),
+                    public_share: source.is_some_and(|value| value.public_share),
                     int: None,
                     frac_bits: source.and_then(|value| value.frac_bits),
+                    bit_length: None,
+                    public_integer: None,
+                    elements: source
+                        .and_then(|value| value.elements.as_ref())
+                        .zip(arg_values.get(1).and_then(|value| value.int))
+                        .zip(arg_values.get(2).and_then(|value| value.int))
+                        .and_then(|((elements, start), end)| {
+                            let start = usize::try_from(start).ok()?;
+                            let end = usize::try_from(end).ok()?;
+                            elements
+                                .get(start..end)
+                                .map(|elements| ExactElements::shared(elements.to_vec()))
+                        }),
                 }
             }
             "contains" => AbstractValue::clear(),
 
             // --- Client input: a secret scalar share -------------------------
-            "ClientStore.take_share"
-            | "ClientStore.take_share_bool"
-            | "ClientStore.take_share_fixed" => AbstractValue::secret(),
+            "ClientStore.take_share" | "ClientStore.take_share_fixed" => AbstractValue::secret(),
+            "ClientStore.take_share_bool" => AbstractValue::secret_with_bit_length(Some(1)),
 
             // --- Operations that consume random preprocessing material -------
             // random_field always uses the random-share pool. A typed
@@ -1098,38 +1745,156 @@ impl<'a> Planner<'a> {
                 demand.add(0, 1, 0, 0);
                 AbstractValue::secret()
             }
-            "Share.random" | "Share.random_int" => {
+            "Share.random" => {
                 match self.mpc_backend {
-                    MpcBackend::HoneyBadger => demand.add(0, 0, 0, 1),
+                    MpcBackend::HoneyBadger => {
+                        demand.add(0, 0, 0, 1);
+                        let bit_width = resolved_return_type
+                            .and_then(secret_scalar_bit_width)
+                            .unwrap_or(DEFAULT_FIXED_POINT_TOTAL_BITS);
+                        demand.require_prandint_bits(bit_width);
+                    }
+                    MpcBackend::Avss => demand.add(0, 1, 0, 0),
+                }
+                AbstractValue::secret()
+            }
+            "Share.random_int" => {
+                match self.mpc_backend {
+                    MpcBackend::HoneyBadger => {
+                        demand.add(0, 0, 0, 1);
+                        let bit_width = arg_values
+                            .first()
+                            .and_then(|value| value.int)
+                            .and_then(|value| usize::try_from(value).ok());
+                        match bit_width {
+                            Some(bit_width) => demand.require_prandint_bits(bit_width),
+                            None => {
+                                preprocessing_diagnostic(format_args!(
+                                    "dynamic Share.random_int width in {}",
+                                    call_stack.join(" -> ")
+                                ));
+                                demand.require_prandint_bits(DEFAULT_FIXED_POINT_TOTAL_BITS);
+                                demand.dynamic = true;
+                            }
+                        }
+                    }
                     MpcBackend::Avss => demand.add(0, 1, 0, 0),
                 }
                 AbstractValue::secret()
             }
 
             // --- Free MPC builtins (secrecy effects only, no demand) ---------
-            "Share.add" | "Share.sub" | "Share.mul_scalar" | "Share.add_constant"
-            | "Share.add_scalar" => AbstractValue::secret(),
+            "Share.add" | "Share.sub" => {
+                let left = arg_values.first();
+                let right = arg_values.get(1);
+                let bit_length = left
+                    .and_then(|value| value.bit_length)
+                    .or_else(|| right.and_then(|value| value.bit_length));
+                let result = left
+                    .filter(|value| value.public_share)
+                    .and_then(|value| value.public_integer)
+                    .zip(
+                        right
+                            .filter(|value| value.public_share)
+                            .and_then(|value| value.public_integer),
+                    )
+                    .and_then(|(left, right)| match name.as_str() {
+                        "Share.add" => left.checked_add(right),
+                        "Share.sub" => left.checked_sub(right),
+                        _ => unreachable!(),
+                    })
+                    .and_then(|value| AbstractValue::public_integral_share(bit_length, value));
+                result.unwrap_or_else(|| AbstractValue::secret_with_bit_length(bit_length))
+            }
+            "Share.mul_scalar" | "Share.add_constant" | "Share.add_scalar" => {
+                let share = arg_values.first();
+                let scalar = arg_values
+                    .get(1)
+                    .and_then(|value| value.int)
+                    .and_then(|value| i64::try_from(value).ok());
+                let bit_length = share.and_then(|value| value.bit_length);
+                let result = share
+                    .filter(|value| value.public_share)
+                    .and_then(|value| value.public_integer)
+                    .zip(scalar)
+                    .and_then(|(share, scalar)| match name.as_str() {
+                        "Share.mul_scalar" => share.checked_mul(scalar),
+                        "Share.add_constant" | "Share.add_scalar" => share.checked_add(scalar),
+                        _ => unreachable!(),
+                    })
+                    .and_then(|value| AbstractValue::public_integral_share(bit_length, value));
+                result.unwrap_or_else(|| AbstractValue::secret_with_bit_length(bit_length))
+            }
+            "Share.neg" => {
+                let share = arg_values.first();
+                let bit_length = share.and_then(|value| value.bit_length);
+                share
+                    .filter(|value| value.public_share)
+                    .and_then(|value| value.public_integer)
+                    .and_then(i64::checked_neg)
+                    .and_then(|value| AbstractValue::public_integral_share(bit_length, value))
+                    .unwrap_or_else(|| AbstractValue::secret_with_bit_length(bit_length))
+            }
             "Share.from_clear"
             | "Share.from_clear_int"
             | "Share.from_clear_uint"
-            | "Share.from_clear_fixed" => AbstractValue::secret(),
+            | "Share.from_clear_fixed" => {
+                let frac_bits = if name == "Share.from_clear_fixed" {
+                    arg_values
+                        .get(2)
+                        .and_then(|value| value.int)
+                        .and_then(|value| usize::try_from(value).ok())
+                        .or(Some(DEFAULT_FIXED_POINT_FRACTIONAL_BITS))
+                } else if resolved_return_type
+                    .is_some_and(|ty| matches!(ty.underlying_type(), SymbolType::Fixed { .. }))
+                {
+                    Some(DEFAULT_FIXED_POINT_FRACTIONAL_BITS)
+                } else {
+                    None
+                };
+                let bit_length =
+                    if name == "Share.from_clear_int" || name == "Share.from_clear_uint" {
+                        arg_values
+                            .get(1)
+                            .and_then(|value| value.int)
+                            .and_then(|value| usize::try_from(value).ok())
+                    } else if name == "Share.from_clear" {
+                        Some(64)
+                    } else {
+                        None
+                    };
+                let public_integer = (frac_bits.is_none())
+                    .then(|| arg_values.first().and_then(|value| value.int))
+                    .flatten()
+                    .and_then(|value| i64::try_from(value).ok())
+                    .map(|value| {
+                        if bit_length == Some(1) {
+                            i64::from(value != 0)
+                        } else {
+                            value
+                        }
+                    });
+                let mut value = AbstractValue::public_share(frac_bits);
+                value.bit_length = bit_length;
+                value.public_integer = public_integer;
+                value
+            }
             "Share.open" => AbstractValue::clear(),
 
             // --- User functions: recurse with the call's argument shapes -----
             _ => {
                 if let Some(info) = self.functions.get(name.as_str()).copied() {
-                    let arg_lens: Vec<Len> =
-                        arg_values.iter().map(|value| value.len.clone()).collect();
-                    let arg_secrecy: Vec<Secrecy> =
-                        arg_values.iter().map(|value| value.secrecy).collect();
-                    let result =
-                        self.analyze_call(&name, info, &arg_lens, &arg_secrecy, call_stack);
+                    let result = self.analyze_call(&name, info, &arg_values, call_stack);
                     add_demand(demand, &result.demand);
                     result.ret
                 } else {
                     // Unknown function with no analysable body. We have already
                     // counted demand inside its arguments; its own body is
                     // opaque, so report unknown (do not over-count).
+                    preprocessing_diagnostic(format_args!(
+                        "unknown call {name} in {}",
+                        call_stack.join(" -> ")
+                    ));
                     AbstractValue::unknown()
                 }
             }
@@ -1141,15 +1906,18 @@ impl<'a> Planner<'a> {
     /// element's shape (so the receiver becomes a list-of-known-shape) and
     /// folding the element's secrecy into the list's element secrecy.
     fn list_grow(
-        &self,
+        &mut self,
         receiver: Option<&AstNode>,
         n: usize,
         element_secrecy: Option<Secrecy>,
+        element_public_share: Option<bool>,
         element_shape: Option<Len>,
+        exact_elements: Option<Arc<ExactElements>>,
         env: &mut Env,
     ) {
         if let Some(AstNode::Identifier(name, _)) = receiver {
             if let Some(value) = env.get_mut(name) {
+                let was_empty = matches!(&value.len, Len::Known { len: 0, .. });
                 value.len = match &value.len {
                     Len::Known { len, elem } => {
                         // Keep the element shape if it agrees with the appended
@@ -1175,6 +1943,33 @@ impl<'a> Planner<'a> {
                         _ => Secrecy::Unknown,
                     };
                 }
+                if let Some(element_public_share) = element_public_share {
+                    value.public_share = if was_empty {
+                        element_public_share
+                    } else {
+                        value.public_share && element_public_share
+                    };
+                } else {
+                    value.public_share = false;
+                }
+                match (&mut value.elements, exact_elements) {
+                    (Some(elements), Some(appended)) if appended.len() == n => {
+                        self.work.aggregate_mutations =
+                            self.work.aggregate_mutations.saturating_add(1);
+                        self.work.aggregate_lanes_appended = self
+                            .work
+                            .aggregate_lanes_appended
+                            .saturating_add(appended.len() as u64);
+                        if Arc::strong_count(elements) > 1 {
+                            self.work.aggregate_lanes_copied = self
+                                .work
+                                .aggregate_lanes_copied
+                                .saturating_add(elements.len() as u64);
+                        }
+                        ExactElements::values_mut(elements).extend(appended.iter().cloned());
+                    }
+                    (elements, _) => *elements = None,
+                }
             }
         }
     }
@@ -1184,9 +1979,143 @@ impl<'a> Planner<'a> {
         if let Some(AstNode::Identifier(name, _)) = receiver {
             if let Some(value) = env.get_mut(name) {
                 value.len = Len::Unknown;
+                value.elements = None;
             }
         }
     }
+}
+
+fn single_append_loop_body(body: &AstNode) -> Option<(&AstNode, &AstNode)> {
+    let statement = match body {
+        AstNode::Block(statements) if statements.len() == 1 => &statements[0],
+        AstNode::Block(_) => return None,
+        statement => statement,
+    };
+    let statement = match statement {
+        AstNode::DiscardStatement { expression, .. } => expression.as_ref(),
+        statement => statement,
+    };
+    let AstNode::FunctionCall {
+        function,
+        arguments,
+        ..
+    } = statement
+    else {
+        return None;
+    };
+    let AstNode::Identifier(name, _) = function.as_ref() else {
+        return None;
+    };
+    if !matches!(name.as_str(), "append" | "array_push") || arguments.len() != 2 {
+        return None;
+    }
+    Some((&arguments[0], &arguments[1]))
+}
+
+fn node_references_identifier(node: &AstNode, target: &str) -> bool {
+    if matches!(node, AstNode::Identifier(name, _) if name == target) {
+        return true;
+    }
+    let mut found = false;
+    crate::optimizations::for_each_child(node, &mut |child| {
+        if !found {
+            found = node_references_identifier(child, target);
+        }
+    });
+    found
+}
+
+/// Semantic equality for exact lane facts. Snapshot ids deliberately make call
+/// cache keys distinguish independently-created aggregates; this proof instead
+/// needs value equality, so nested exact aggregates are compared recursively.
+fn abstract_values_equivalent(left: &AbstractValue, right: &AbstractValue) -> bool {
+    left.len == right.len
+        && left.secrecy == right.secrecy
+        && left.public_share == right.public_share
+        && left.int == right.int
+        && left.frac_bits == right.frac_bits
+        && left.bit_length == right.bit_length
+        && left.public_integer == right.public_integer
+        && match (&left.elements, &right.elements) {
+            (None, None) => true,
+            (Some(left), Some(right)) => {
+                Arc::ptr_eq(left, right)
+                    || (left.len() == right.len()
+                        && left
+                            .iter()
+                            .zip(right.iter())
+                            .all(|(left, right)| abstract_values_equivalent(left, right)))
+            }
+            _ => false,
+        }
+}
+
+/// Prove that `expression` has one abstract value for every induction value in
+/// `[start, start + count)`. Direct induction-variable indexing is uniform only
+/// when every selected exact lane is semantically equal. Any other use of the
+/// induction variable fails closed. Mutating calls are excluded because their
+/// caller environment would not be iteration-invariant.
+fn expression_is_uniform_over_range(
+    expression: &AstNode,
+    loop_var: &str,
+    start: u64,
+    count: u64,
+    env: &Env,
+) -> bool {
+    if count == 0 {
+        return true;
+    }
+    if let AstNode::IndexAccess { base, index, .. } = expression {
+        if matches!(index.as_ref(), AstNode::Identifier(name, _) if name == loop_var) {
+            let AstNode::Identifier(base_name, _) = base.as_ref() else {
+                return false;
+            };
+            let Some(elements) = env.get(base_name).and_then(|value| value.elements.as_ref())
+            else {
+                return false;
+            };
+            let Some(end) = start.checked_add(count) else {
+                return false;
+            };
+            let (Ok(start), Ok(end)) = (usize::try_from(start), usize::try_from(end)) else {
+                return false;
+            };
+            let Some(selected) = elements.get(start..end) else {
+                return false;
+            };
+            return selected.split_first().is_none_or(|(first, rest)| {
+                rest.iter()
+                    .all(|element| abstract_values_equivalent(first, element))
+            });
+        }
+    }
+    if matches!(expression, AstNode::Identifier(name, _) if name == loop_var) {
+        return count == 1;
+    }
+    if let AstNode::FunctionCall {
+        function,
+        arguments: _,
+        ..
+    } = expression
+    {
+        if matches!(
+            function.as_ref(),
+            AstNode::Identifier(name, _)
+                if matches!(
+                    name.as_str(),
+                    "append" | "array_push" | "insert" | "extend" | "pop" | "remove"
+                )
+        ) {
+            return false;
+        }
+    }
+    let mut uniform = true;
+    crate::optimizations::for_each_child(expression, &mut |child| {
+        if uniform {
+            uniform = expression_is_uniform_over_range(child, loop_var, start, count, env);
+        }
+    });
+    uniform
 }
 
 /// Fold a freshly observed return value into a function's accumulating return
@@ -1213,16 +2142,120 @@ fn merge_value(a: AbstractValue, b: AbstractValue) -> AbstractValue {
         (Some(x), Some(y)) if x == y => Some(x),
         _ => None,
     };
+    let elements = match (a.elements.clone(), b.elements.clone()) {
+        (Some(left), Some(right)) if left.len() == right.len() => Some(ExactElements::shared(
+            left.iter()
+                .zip(right.iter())
+                .map(|(left, right)| merge_value(left.clone(), right.clone()))
+                .collect(),
+        )),
+        _ => None,
+    };
     AbstractValue {
         len,
         secrecy: a.secrecy.merge_branch(b.secrecy),
+        public_share: a.public_share && b.public_share,
         int,
         frac_bits: if a.frac_bits == b.frac_bits {
             a.frac_bits
         } else {
             None
         },
+        bit_length: if a.bit_length == b.bit_length {
+            a.bit_length
+        } else {
+            None
+        },
+        public_integer: if a.public_integer == b.public_integer {
+            a.public_integer
+        } else {
+            None
+        },
+        elements,
     }
+}
+
+fn assignment_root(node: &AstNode) -> Option<&str> {
+    match node {
+        AstNode::Identifier(name, _) => Some(name),
+        AstNode::IndexAccess { base, .. } => assignment_root(base),
+        AstNode::FieldAccess { object, .. } => assignment_root(object),
+        _ => None,
+    }
+}
+
+fn update_exact_aggregate_assignment(
+    env: &mut Env,
+    target: &AstNode,
+    assigned: &AbstractValue,
+) -> bool {
+    fn collect_path(node: &AstNode, env: &Env, indices: &mut Vec<usize>) -> Option<String> {
+        match node {
+            AstNode::Identifier(name, _) => Some(name.clone()),
+            AstNode::IndexAccess { base, index, .. } => {
+                let root = collect_path(base, env, indices)?;
+                let index = match index.as_ref() {
+                    AstNode::Literal {
+                        value: Value::Int { value, .. },
+                        ..
+                    } => usize::try_from(*value).ok()?,
+                    AstNode::Identifier(name, _) => env
+                        .get(name)
+                        .and_then(|value| value.int)
+                        .and_then(|value| usize::try_from(value).ok())?,
+                    _ => return None,
+                };
+                indices.push(index);
+                Some(root)
+            }
+            // Object-field aliasing is not represented lane-by-lane.
+            AstNode::FieldAccess { .. } => None,
+            _ => None,
+        }
+    }
+
+    fn refresh_aggregate(value: &mut AbstractValue) {
+        let Some(elements) = value.elements.as_ref() else {
+            return;
+        };
+        value.public_share = !elements.is_empty() && elements.iter().all(|item| item.public_share);
+        value.secrecy = elements.iter().fold(Secrecy::Clear, |secrecy, item| {
+            secrecy.join_arith(item.secrecy)
+        });
+    }
+
+    fn replace_at_path(
+        aggregate: &mut AbstractValue,
+        indices: &[usize],
+        assigned: &AbstractValue,
+    ) -> bool {
+        let Some((&index, rest)) = indices.split_first() else {
+            *aggregate = assigned.clone();
+            return true;
+        };
+        let Some(element) = aggregate
+            .elements
+            .as_mut()
+            .and_then(|elements| ExactElements::values_mut(elements).get_mut(index))
+        else {
+            return false;
+        };
+        if !replace_at_path(element, rest, assigned) {
+            return false;
+        }
+        refresh_aggregate(aggregate);
+        true
+    }
+
+    let mut indices = Vec::new();
+    let Some(root) = collect_path(target, env, &mut indices) else {
+        return false;
+    };
+    if indices.is_empty() {
+        return false;
+    }
+    env.get_mut(&root)
+        .is_some_and(|aggregate| replace_at_path(aggregate, &indices, assigned))
 }
 
 /// One canonical `while` counter step, extracted from the body's top level.
@@ -1322,6 +2355,7 @@ fn add_demand(target: &mut PreprocessingDemand, addend: &PreprocessingDemand) {
         addend.prandints,
     );
     target.dynamic |= addend.dynamic;
+    target.prandint_bits = target.prandint_bits.max(addend.prandint_bits);
 }
 
 /// Multiply a demand by an iteration count (saturating).
@@ -1331,6 +2365,7 @@ fn scale_demand(demand: &PreprocessingDemand, count: u64) -> PreprocessingDemand
         randoms: demand.randoms.saturating_mul(count),
         prandbits: demand.prandbits.saturating_mul(count),
         prandints: demand.prandints.saturating_mul(count),
+        prandint_bits: demand.prandint_bits,
         dynamic: demand.dynamic,
     }
 }
@@ -1345,35 +2380,68 @@ fn apply_loop_length_growth(env: &mut Env, body_env: &Env, count: u64) {
         let Some(after) = body_env.get(name) else {
             continue;
         };
-        let new_len = match (&before.len, &after.len) {
-            (
-                Len::Known { len: start, .. },
-                Len::Known {
-                    len: end,
-                    elem: end_elem,
-                },
-            ) => {
-                let delta = *end as i128 - *start as i128;
-                let total = *start as i128 + delta * count as i128;
-                if total >= 0 {
-                    // Preserve the per-iteration element shape (e.g. each
-                    // appended byte stays length 8).
+        let new_len = if count == 0 {
+            before.len.clone()
+        } else {
+            match (&before.len, &after.len) {
+                (
+                    Len::Known { len: start, .. },
                     Len::Known {
-                        len: total as usize,
-                        elem: end_elem.clone(),
+                        len: end,
+                        elem: end_elem,
+                    },
+                ) => {
+                    let delta = *end as i128 - *start as i128;
+                    let total = *start as i128 + delta * count as i128;
+                    if total >= 0 {
+                        // Preserve the per-iteration element shape (e.g. each
+                        // appended byte stays length 8).
+                        Len::Known {
+                            len: total as usize,
+                            elem: end_elem.clone(),
+                        }
+                    } else {
+                        Len::Unknown
                     }
-                } else {
-                    Len::Unknown
                 }
+                // The body made the length unknown (or it always was): stays unknown.
+                (_, Len::Unknown) => Len::Unknown,
+                // The list did not exist with a known length before but does now:
+                // we cannot scale it reliably, so treat as unknown.
+                (Len::Unknown, Len::Known { .. }) => Len::Unknown,
             }
-            // The body made the length unknown (or it always was): stays unknown.
-            (_, Len::Unknown) => Len::Unknown,
-            // The list did not exist with a known length before but does now:
-            // we cannot scale it reliably, so treat as unknown.
-            (Len::Unknown, Len::Known { .. }) => Len::Unknown,
         };
         if let Some(slot) = env.get_mut(name) {
             slot.len = new_len;
+            if count > 0 {
+                slot.secrecy = after.secrecy;
+                slot.public_share = after.public_share;
+                slot.frac_bits = after.frac_bits;
+                // The scalable loop summary knows the final length and uniform
+                // element facts, but not an exact lane vector for repeated
+                // mutations. Dropping the stale pre-loop vector makes later
+                // batches use the proven length instead of seeing (for example)
+                // the original empty list as an exact zero-lane operand.
+                slot.elements = if count == 1 {
+                    after.elements.clone()
+                } else {
+                    None
+                };
+                // A scalar constant that the symbolic iteration did not change
+                // is a loop invariant and remains foldable after any number of
+                // iterations. This matters for consecutive counted loops: a
+                // known `n` used by the first loop must still size the second.
+                // For a value changed by the body, one iteration is exact; two
+                // or more require a recurrence model we deliberately do not
+                // guess at.
+                slot.int = if before.int == after.int {
+                    before.int
+                } else if count == 1 {
+                    after.int
+                } else {
+                    None
+                };
+            }
         }
     }
 }
@@ -1385,10 +2453,19 @@ fn apply_loop_length_growth_unknown(env: &mut Env, body_env: &Env) {
         let Some(after) = body_env.get(name) else {
             continue;
         };
-        if before.len != after.len {
-            if let Some(slot) = env.get_mut(name) {
+        if let Some(slot) = env.get_mut(name) {
+            if before.len != after.len {
                 slot.len = Len::Unknown;
             }
+            slot.elements = None;
+            slot.secrecy = before.secrecy.merge_branch(after.secrecy);
+            slot.public_share = before.public_share && after.public_share;
+            slot.frac_bits = if before.frac_bits == after.frac_bits {
+                before.frac_bits
+            } else {
+                None
+            };
+            slot.int = None;
         }
     }
 }
@@ -1396,6 +2473,21 @@ fn apply_loop_length_growth_unknown(env: &mut Env, body_env: &Env) {
 /// Whether a demand carries any preprocessing material at all.
 fn has_any_material(demand: &PreprocessingDemand) -> bool {
     demand.triples > 0 || demand.randoms > 0 || demand.prandbits > 0 || demand.prandints > 0
+}
+
+/// Collect names that evaluation of `node` can introduce into the current
+/// environment. Exact loop interpretation uses this small, syntax-derived set
+/// to discard iteration-local bindings without scanning or cloning every
+/// binding visible at the loop site.
+fn collect_declared_names(node: &AstNode, names: &mut Vec<String>) {
+    match node {
+        AstNode::VariableDeclaration { name, .. } => names.push(name.clone()),
+        // A nested function owns a separate environment and is not executed as
+        // part of the containing block.
+        AstNode::FunctionDefinition { .. } => return,
+        _ => {}
+    }
+    crate::optimizations::for_each_child(node, &mut |child| collect_declared_names(child, names));
 }
 
 /// Element secrecy of a parameter, derived from its type annotation. A
@@ -1424,6 +2516,20 @@ fn annotation_contains_secret(annotation: &AstNode) -> bool {
         AstNode::SecretType(_) => true,
         AstNode::ListType(inner) => annotation_contains_secret(inner),
         _ => false,
+    }
+}
+
+/// Bit width used when a contextual `Share.random()` is lowered to
+/// `Share.random_int(width)`. This mirrors codegen so preprocessing and runtime
+/// agree on the PRandInt distribution instead of provisioning a fixed width.
+fn secret_scalar_bit_width(ty: &SymbolType) -> Option<usize> {
+    if !ty.is_secret() {
+        return None;
+    }
+    match ty.underlying_type() {
+        SymbolType::Bool => Some(1),
+        SymbolType::Fixed { bits } => Some(usize::from(*bits)),
+        _ => ty.bit_width().map(usize::from),
     }
 }
 
@@ -1471,6 +2577,11 @@ fn child_expressions(node: &AstNode) -> Vec<&AstNode> {
 mod tests {
     use super::*;
     use crate::compiler::{compile, CompilerOptions};
+    use crate::errors::ErrorReporter;
+    use crate::lexer::tokenize;
+    use crate::parser::parse;
+    use crate::semantic::analyze;
+    use crate::ufcs::transform_ufcs;
     use stoffel_vm_types::compiled_binary::MpcBackend;
 
     fn demand_for(src: &str) -> PreprocessingDemand {
@@ -1501,6 +2612,178 @@ mod tests {
             .expect("failed to spawn compile thread")
             .join()
             .expect("compile thread panicked")
+    }
+
+    fn list_loop_work(iterations: usize) -> (PreprocessingDemand, PlannerWork) {
+        let src = format!(
+            r#"
+def main() -> int64:
+  var xs: list[secret bool] = []
+  var ys: list[secret bool] = []
+  for i in 0..{iterations}:
+    xs.append(ClientStore.take_share_bool(0, i))
+    ys.append(ClientStore.take_share_bool(1, i))
+  var products = Share.batch_mul(xs, ys)
+  return 0
+"#
+        );
+        let tokens = tokenize(&src, "scaling.stfl").expect("synthetic source should lex");
+        let ast = parse(&tokens, "scaling.stfl").expect("synthetic source should parse");
+        let mut reporter = ErrorReporter::new();
+        let ast = analyze(transform_ufcs(ast), &mut reporter, "scaling.stfl")
+            .expect("synthetic source should pass semantic analysis");
+        plan_preprocessing_demand_inner_with_work(&ast, MpcBackend::HoneyBadger)
+    }
+
+    #[test]
+    fn exact_aggregate_loop_work_scales_linearly() {
+        let (small_demand, small) = list_loop_work(64);
+        let (medium_demand, medium) = list_loop_work(128);
+        let (large_demand, large) = list_loop_work(256);
+
+        assert_eq!(small_demand.triples, 64);
+        assert_eq!(medium_demand.triples, 128);
+        assert_eq!(large_demand.triples, 256);
+        assert!(!small_demand.dynamic && !medium_demand.dynamic && !large_demand.dynamic);
+
+        for (iterations, work) in [(64, small), (128, medium), (256, large)] {
+            assert_eq!(work.exact_loop_iterations, iterations);
+            assert_eq!(work.aggregate_mutations, iterations * 2);
+            assert_eq!(work.aggregate_lanes_appended, iterations * 2);
+            assert_eq!(
+                work.aggregate_lanes_copied, 0,
+                "growing a uniquely owned exact aggregate must not copy prior lanes"
+            );
+            assert_eq!(work.call_keys_built, 1);
+        }
+
+        // For a fixed loop body, expression visits have the exact form a+bN.
+        // The second finite difference therefore doubles as a deterministic
+        // scaling gate without relying on noisy wall-clock measurements.
+        assert_eq!(
+            large.expression_visits - medium.expression_visits,
+            2 * (medium.expression_visits - small.expression_visits)
+        );
+    }
+
+    #[test]
+    fn public_share_products_cross_loops_and_calls_without_triples() {
+        let src = r#"
+def scale(value: secret int64, factor: secret int64) -> secret int64:
+  return Share.mul(value, factor)
+
+def main(value: secret int64) -> int64:
+  var factor = Share.from_clear_int(1, 64)
+  var two = Share.from_clear_int(2, 64)
+  for i in 0..3:
+    factor = Share.mul(factor, two)
+  return Share.open(scale(value, factor))
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 0);
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn loop_carried_public_share_transition_is_counted_per_iteration() {
+        let src = r#"
+def main() -> int64:
+  var acc: secret bool = Share.from_clear_int(1, 1)
+  var input: secret bool = ClientStore.take_share_bool(0, 0)
+  for i in 0..3:
+    acc = acc and input
+  return 0
+"#;
+        let demand = demand_for(src);
+        assert_eq!(
+            demand.triples, 2,
+            "the first public×secret product is local; the next two consume triples"
+        );
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn mixed_public_secret_batch_counts_interactive_lanes_exactly() {
+        let src = r#"
+def main() -> int64:
+  var left = [Share.from_clear_int(1, 1), ClientStore.take_share_bool(0, 0)]
+  var right = [ClientStore.take_share_bool(0, 1), ClientStore.take_share_bool(0, 2)]
+  var products = Share.batch_mul(left, right)
+  return 0
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 1);
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn public_boolean_reconstruction_tracks_materialization_boundaries() {
+        let src = r#"
+def main() -> int64:
+  var zero = Share.from_clear_int(0, 1)
+  var one = Share.from_clear_int(1, 1)
+  var p0 = Share.mul(zero, one)
+  var still_public = Share.sub(Share.add(zero, one), Share.mul_scalar(p0, 2))
+  var input = ClientStore.take_share_bool(0, 0)
+  var local_product = Share.mul(still_public, input)
+
+  var p1 = Share.mul(one, one)
+  var materialized = Share.sub(Share.add(one, one), Share.mul_scalar(p1, 2))
+  var interactive_product = Share.mul(materialized, input)
+  return 0
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 1);
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn counted_loop_preserves_unmodified_scalar_bounds() {
+        let src = r#"
+def main() -> int64:
+  var n = 4
+  var first: list[secret bool] = []
+  for i in 0..n:
+    first.append(ClientStore.take_share_bool(0, i))
+
+  var left: list[secret bool] = []
+  var right: list[secret bool] = []
+  for j in 0..n:
+    left.append(first[j])
+    right.append(ClientStore.take_share_bool(1, j))
+
+  var products = Share.batch_mul(left, right)
+  return 0
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 4);
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn fixed_public_share_multiplication_retains_protocol_demand() {
+        let src = r#"
+def main(value: secret fix64) -> secret fix64:
+  var factor = Share.from_clear_fixed(1.5, 64, 16)
+  return Share.mul(value, factor)
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 1);
+        assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn branch_replacement_cannot_leave_stale_public_provenance() {
+        let src = r#"
+def main(value: secret int64, replace: bool) -> secret int64:
+  var maybe_public = Share.from_clear_int(3, 64)
+  if replace:
+    maybe_public = value
+  return Share.mul(maybe_public, value)
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 1);
+        assert!(!demand.dynamic);
     }
 
     /// Counted `while` loops (the only loop shape StoffelDB's codegen emits)

--- a/crates/stoffel-lang/src/preprocessing_planner.rs
+++ b/crates/stoffel-lang/src/preprocessing_planner.rs
@@ -25,7 +25,7 @@
 use std::collections::HashMap;
 
 use crate::ast::{AstNode, Parameter, Value};
-use stoffel_vm_types::compiled_binary::PreprocessingDemand;
+use stoffel_vm_types::compiled_binary::{MpcBackend, PreprocessingDemand};
 use stoffel_vm_types::core_types::DEFAULT_FIXED_POINT_FRACTIONAL_BITS;
 
 /// Statically known list shape of a value: its length and, recursively, the
@@ -201,6 +201,7 @@ struct FunctionInfo<'a> {
 struct Planner<'a> {
     functions: HashMap<String, &'a FunctionInfo<'a>>,
     memo: HashMap<CallKey, CallResult>,
+    mpc_backend: MpcBackend,
 }
 
 /// Compute the total preprocessing demand of `program` (the top-level AST, a
@@ -208,6 +209,17 @@ struct Planner<'a> {
 /// top-level function's demand, so whichever entry the runtime selects is
 /// covered.
 pub fn plan_preprocessing_demand(program: &AstNode) -> PreprocessingDemand {
+    plan_preprocessing_demand_for_backend(program, MpcBackend::default())
+}
+
+/// Compute preprocessing demand using the material pools consumed by
+/// `mpc_backend`. Random integer generation is backed by PRandInt under
+/// HoneyBadger, while AVSS currently implements it using ordinary random field
+/// shares.
+pub fn plan_preprocessing_demand_for_backend(
+    program: &AstNode,
+    mpc_backend: MpcBackend,
+) -> PreprocessingDemand {
     // The analysis recurses through the program's call graph, which for large
     // straight-line circuits (e.g. the AES S-box and its callers) can nest many
     // frames deep. Run it on a dedicated thread with a generous stack so the
@@ -218,14 +230,19 @@ pub fn plan_preprocessing_demand(program: &AstNode) -> PreprocessingDemand {
         std::thread::Builder::new()
             .name("preprocessing-demand-analysis".to_string())
             .stack_size(ANALYSIS_STACK_SIZE)
-            .spawn_scoped(scope, || plan_preprocessing_demand_inner(program))
+            .spawn_scoped(scope, || {
+                plan_preprocessing_demand_inner(program, mpc_backend)
+            })
             .expect("failed to spawn preprocessing-demand analysis thread")
             .join()
             .expect("preprocessing-demand analysis thread panicked")
     })
 }
 
-fn plan_preprocessing_demand_inner(program: &AstNode) -> PreprocessingDemand {
+fn plan_preprocessing_demand_inner(
+    program: &AstNode,
+    mpc_backend: MpcBackend,
+) -> PreprocessingDemand {
     let mut infos: Vec<(String, FunctionInfo)> = Vec::new();
     collect_functions(program, &mut infos);
 
@@ -237,6 +254,7 @@ fn plan_preprocessing_demand_inner(program: &AstNode) -> PreprocessingDemand {
     let mut planner = Planner {
         functions,
         memo: HashMap::new(),
+        mpc_backend,
     };
 
     // Program entries are the functions the runtime can actually invoke as a
@@ -1007,6 +1025,16 @@ impl<'a> Planner<'a> {
                 AbstractValue::clear()
             }
 
+            // `copy` creates a distinct list object but preserves the complete
+            // abstract value shape. The O3 multiply batcher seeds each fused
+            // operand accumulator with `copy(first_operand)` and then extends
+            // it; losing the seed length here makes an otherwise fully static
+            // `Share.batch_mul` appear runtime-sized, forcing online top-ups.
+            "copy" => arg_values
+                .first()
+                .cloned()
+                .unwrap_or_else(AbstractValue::unknown),
+
             // --- List/object constructors ------------------------------------
             "create_array" => AbstractValue {
                 len: Len::flat(0),
@@ -1021,13 +1049,62 @@ impl<'a> Planner<'a> {
             | "assert"
             | "MpcOutput.send_to_client"
             | "Share.send_to_client" => AbstractValue::clear(),
-            "get_field" | "slice" => AbstractValue::unknown(),
+            "get_field" => arg_values
+                .first()
+                .map(|collection| AbstractValue {
+                    len: collection.len.element(),
+                    secrecy: collection.secrecy,
+                    int: None,
+                    frac_bits: collection.frac_bits,
+                })
+                .unwrap_or_else(AbstractValue::unknown),
+            "slice" => {
+                let source = arg_values.first();
+                let len = match (
+                    arg_values.get(1).and_then(|value| value.int),
+                    arg_values.get(2).and_then(|value| value.int),
+                ) {
+                    (Some(start), Some(end)) if end >= start => Len::Known {
+                        len: (end - start) as usize,
+                        elem: Box::new(
+                            source
+                                .map(|value| value.len.element())
+                                .unwrap_or(Len::Unknown),
+                        ),
+                    },
+                    _ => Len::Unknown,
+                };
+                AbstractValue {
+                    len,
+                    secrecy: source
+                        .map(|value| value.secrecy)
+                        .unwrap_or(Secrecy::Unknown),
+                    int: None,
+                    frac_bits: source.and_then(|value| value.frac_bits),
+                }
+            }
             "contains" => AbstractValue::clear(),
 
             // --- Client input: a secret scalar share -------------------------
             "ClientStore.take_share"
             | "ClientStore.take_share_bool"
             | "ClientStore.take_share_fixed" => AbstractValue::secret(),
+
+            // --- Operations that consume random preprocessing material -------
+            // random_field always uses the random-share pool. A typed
+            // `Share.random()` is lowered to random_int(bit_length), whose
+            // backing pool depends on the selected runtime backend.
+            "Share.random_field" => {
+                demand.add(0, 1, 0, 0);
+                AbstractValue::secret()
+            }
+            "Share.random" | "Share.random_int" => {
+                match self.mpc_backend {
+                    MpcBackend::HoneyBadger => demand.add(0, 0, 0, 1),
+                    MpcBackend::Avss => demand.add(0, 1, 0, 0),
+                }
+                AbstractValue::secret()
+            }
 
             // --- Free MPC builtins (secrecy effects only, no demand) ---------
             "Share.add" | "Share.sub" | "Share.mul_scalar" | "Share.add_constant"
@@ -1037,7 +1114,6 @@ impl<'a> Planner<'a> {
             | "Share.from_clear_uint"
             | "Share.from_clear_fixed" => AbstractValue::secret(),
             "Share.open" => AbstractValue::clear(),
-            "Share.random" | "Share.random_field" | "Share.random_int" => AbstractValue::secret(),
 
             // --- User functions: recurse with the call's argument shapes -----
             _ => {
@@ -1517,6 +1593,33 @@ def main() -> int64:
         let demand = demand_for(src);
         assert_eq!(demand.triples, 5);
         assert!(!demand.dynamic);
+    }
+
+    #[test]
+    fn copy_extend_and_slice_preserve_static_batch_lengths() {
+        let src = r#"
+def main() -> int64:
+  var xs: list[secret bool] = []
+  var ys: list[secret bool] = []
+  for i in 0..4:
+    xs.append(ClientStore.take_share_bool(0, i))
+    ys.append(ClientStore.take_share_bool(1, i))
+  var lefts = copy(xs)
+  var rights = copy(ys)
+  lefts.extend(xs)
+  rights.extend(ys)
+  var products = Share.batch_mul(lefts, rights)
+  var first = slice(products, 0, 4)
+  var first_copy = copy(first)
+  var products2 = Share.batch_mul(first_copy, first)
+  return 0
+"#;
+        let demand = demand_for(src);
+        assert_eq!(demand.triples, 12, "8-element batch plus 4-element batch");
+        assert!(
+            !demand.dynamic,
+            "shape-preserving list plumbing must not force online top-ups"
+        );
     }
 
     #[test]

--- a/crates/stoffel-lang/src/semantic.rs
+++ b/crates/stoffel-lang/src/semantic.rs
@@ -4509,7 +4509,16 @@ impl<'a> SemanticAnalyzer<'a> {
                                     .symbol_table
                                     .lookup_builtin_method(obj_name, method_name)
                                 {
-                                    let call_name = if crate::builtin_registry::builtin_registry()
+                                    let is_scheduler_interactive = method_info.qualified_name
+                                        == "Share.mul"
+                                        || (method_info.qualified_name == "Share.open"
+                                            && matches!(method_name, "open" | "reveal"));
+                                    let call_name = if is_scheduler_interactive {
+                                        // Preserve the resolved identity of interactive calls so
+                                        // scheduling never has to infer it from an overloaded base
+                                        // name such as `mul` or `open`.
+                                        method_info.qualified_name.clone()
+                                    } else if crate::builtin_registry::builtin_registry()
                                         .is_receiver_bound_method(obj_name, method_name)
                                     {
                                         method_name.to_string()
@@ -4566,8 +4575,17 @@ impl<'a> SemanticAnalyzer<'a> {
                                     .symbol_table
                                     .lookup_builtin_method_for_receiver(receiver_type, name)
                                 {
+                                    let is_scheduler_interactive = method_info.qualified_name
+                                        == "Share.mul"
+                                        || (method_info.qualified_name == "Share.open"
+                                            && matches!(name.as_str(), "open" | "reveal"));
+                                    let call_name = if is_scheduler_interactive {
+                                        method_info.qualified_name.clone()
+                                    } else {
+                                        name.clone()
+                                    };
                                     (
-                                        name.clone(),
+                                        call_name,
                                         method_info.parameters.clone(),
                                         method_info.return_type.clone(),
                                         true,

--- a/crates/stoffel-lang/tests/rust/compiler_phase_tests.rs
+++ b/crates/stoffel-lang/tests/rust/compiler_phase_tests.rs
@@ -4640,7 +4640,16 @@ def main() -> fix64:
 
 /// Compile `source` and return the preprocessing demand the planner reads.
 fn demand_of(source: &str) -> stoffel_vm_types::compiled_binary::PreprocessingDemand {
-    let program = compile(source, "test.stfl", &default_options()).expect("program compiles");
+    demand_of_for_backend(source, MpcBackend::HoneyBadger)
+}
+
+fn demand_of_for_backend(
+    source: &str,
+    mpc_backend: MpcBackend,
+) -> stoffel_vm_types::compiled_binary::PreprocessingDemand {
+    let mut options = default_options();
+    options.mpc_backend = mpc_backend;
+    let program = compile(source, "test.stfl", &options).expect("program compiles");
     convert_to_binary(&program)
         .client_io_manifest
         .preprocessing_demand
@@ -4660,6 +4669,79 @@ def main() -> int64:
     assert_eq!(demand.randoms, 0);
     assert_eq!(demand.prandbits, 0);
     assert_eq!(demand.prandints, 0);
+    assert!(!demand.dynamic);
+}
+
+#[test]
+fn direct_random_builtins_emit_their_backing_pool_demand() {
+    let demand = demand_of(
+        r#"
+def main() -> int64:
+  var field_random = Share.random_field()
+  var explicit_int = Share.random_int(31)
+  var contextual_int: secret int64 = Share.random()
+  return 0
+"#,
+    );
+    assert_eq!(demand.randoms, 1);
+    assert_eq!(demand.prandints, 2);
+    assert_eq!(demand.triples, 0);
+    assert_eq!(demand.prandbits, 0);
+    assert!(!demand.dynamic);
+}
+
+#[test]
+fn literal_loop_scales_direct_random_share_demand() {
+    let demand = demand_of(
+        r#"
+def main() -> int64:
+  for i in 0..4:
+    var field_random = Share.random_field()
+  return 0
+"#,
+    );
+    assert_eq!(demand.randoms, 4);
+    assert_eq!(demand.prandints, 0);
+    assert!(!demand.dynamic);
+}
+
+#[test]
+fn avss_random_methods_all_use_random_share_preprocessing() {
+    let demand = demand_of_for_backend(
+        r#"
+def main() -> int64:
+  for i in 0..4:
+    var field_random = Share.random_field()
+    var explicit_int = Share.random_int(31)
+    var contextual_int: secret int64 = Share.random()
+  return 0
+"#,
+        MpcBackend::Avss,
+    );
+    assert_eq!(demand.randoms, 12);
+    assert_eq!(demand.prandints, 0);
+    assert_eq!(demand.triples, 0);
+    assert_eq!(demand.prandbits, 0);
+    assert!(!demand.dynamic);
+}
+
+#[test]
+fn honey_badger_random_methods_use_their_distinct_pools() {
+    let demand = demand_of_for_backend(
+        r#"
+def main() -> int64:
+  for i in 0..4:
+    var field_random = Share.random_field()
+    var explicit_int = Share.random_int(31)
+    var contextual_int: secret int64 = Share.random()
+  return 0
+"#,
+        MpcBackend::HoneyBadger,
+    );
+    assert_eq!(demand.randoms, 4);
+    assert_eq!(demand.prandints, 8);
+    assert_eq!(demand.triples, 0);
+    assert_eq!(demand.prandbits, 0);
     assert!(!demand.dynamic);
 }
 

--- a/crates/stoffel-lang/tests/rust/compiler_phase_tests.rs
+++ b/crates/stoffel-lang/tests/rust/compiler_phase_tests.rs
@@ -4685,8 +4685,24 @@ def main() -> int64:
     );
     assert_eq!(demand.randoms, 1);
     assert_eq!(demand.prandints, 2);
+    assert_eq!(demand.prandint_bits, 64);
     assert_eq!(demand.triples, 0);
     assert_eq!(demand.prandbits, 0);
+    assert!(!demand.dynamic);
+}
+
+#[test]
+fn contextual_random_bool_records_one_bit_prandint_width() {
+    let demand = demand_of_for_backend(
+        r#"
+def main() -> bool:
+  var bit: secret bool = Share.random()
+  return bit.reveal()
+"#,
+        MpcBackend::HoneyBadger,
+    );
+    assert_eq!(demand.prandints, 1);
+    assert_eq!(demand.prandint_bits, 1);
     assert!(!demand.dynamic);
 }
 
@@ -4740,6 +4756,7 @@ def main() -> int64:
     );
     assert_eq!(demand.randoms, 4);
     assert_eq!(demand.prandints, 8);
+    assert_eq!(demand.prandint_bits, 64);
     assert_eq!(demand.triples, 0);
     assert_eq!(demand.prandbits, 0);
     assert!(!demand.dynamic);
@@ -4750,8 +4767,8 @@ fn secret_multiplication_emits_one_triple() {
     let demand = demand_of(
         r#"
 def main() -> int64:
-  var a: secret int64 = Share.from_clear(3)
-  var b: secret int64 = Share.from_clear(4)
+  var a: secret int64 = ClientStore.take_share(0, 0)
+  var b: secret int64 = ClientStore.take_share(1, 0)
   var c: secret int64 = a * b
   return c.reveal()
 "#,
@@ -4777,6 +4794,7 @@ def main() -> fix64:
     assert_eq!(demand.triples, 0);
     assert_eq!(demand.prandbits, 16);
     assert_eq!(demand.prandints, 1);
+    assert_eq!(demand.prandint_bits, 64);
     assert!(!demand.dynamic);
 }
 
@@ -4796,6 +4814,7 @@ def main() -> fix64:
     );
     assert_eq!(demand.prandbits, 64);
     assert_eq!(demand.prandints, 4);
+    assert_eq!(demand.prandint_bits, 64);
     assert_eq!(demand.triples, 0);
     assert!(!demand.dynamic);
 }

--- a/crates/stoffel-lang/tests/rust/fixture_and_example_tests.rs
+++ b/crates/stoffel-lang/tests/rust/fixture_and_example_tests.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use stoffel_vm_types::compiled_binary::{
     utils::{load_from_file, try_to_vm_functions},
-    MpcBackend,
+    MpcBackend, MpcCurve,
 };
 use stoffel_vm_types::instructions::Instruction;
 use stoffellang::{compile_file, convert_to_binary, save_to_file, CompilerOptions};
@@ -187,6 +187,145 @@ fn secp256k1_ecdsa_keeps_preprocessing_minimal_and_batched() {
     assert_eq!(call_count("Share.mul"), 0);
     assert_eq!(call_count("Share.open_exp"), 0);
     assert_eq!(call_count("open_exp"), 0);
+}
+
+#[test]
+fn optimized_threshold_signatures_hit_avss_material_and_mul_reveal_round_floors() {
+    struct Case {
+        directory: &'static str,
+        curve: MpcCurve,
+        triples: u64,
+        randoms: u64,
+        batch_mul_sessions: usize,
+        mandatory_field_open_sessions: usize,
+        exponent_open_sessions: usize,
+        mul_reveal_round_floor: usize,
+    }
+
+    let cases = [
+        Case {
+            directory: "threshold_bls_bls12381",
+            curve: MpcCurve::Bls12_381,
+            triples: 0,
+            randoms: 1,
+            batch_mul_sessions: 0,
+            mandatory_field_open_sessions: 0,
+            exponent_open_sessions: 2,
+            mul_reveal_round_floor: 0,
+        },
+        Case {
+            directory: "threshold_ecdsa_p256",
+            curve: MpcCurve::Secp256r1,
+            triples: 2,
+            randoms: 3,
+            batch_mul_sessions: 2,
+            mandatory_field_open_sessions: 2,
+            exponent_open_sessions: 1,
+            mul_reveal_round_floor: 4,
+        },
+        Case {
+            directory: "threshold_ecdsa_secp256k1",
+            curve: MpcCurve::Secp256k1,
+            triples: 2,
+            randoms: 3,
+            batch_mul_sessions: 1,
+            mandatory_field_open_sessions: 2,
+            exponent_open_sessions: 0,
+            mul_reveal_round_floor: 3,
+        },
+        Case {
+            directory: "threshold_eddsa_ed25519",
+            curve: MpcCurve::Ed25519,
+            triples: 0,
+            randoms: 2,
+            batch_mul_sessions: 0,
+            mandatory_field_open_sessions: 1,
+            exponent_open_sessions: 0,
+            mul_reveal_round_floor: 1,
+        },
+        Case {
+            directory: "threshold_schnorr_ed25519",
+            curve: MpcCurve::Ed25519,
+            triples: 0,
+            randoms: 2,
+            batch_mul_sessions: 0,
+            mandatory_field_open_sessions: 1,
+            exponent_open_sessions: 0,
+            mul_reveal_round_floor: 1,
+        },
+    ];
+
+    for case in cases {
+        let path = manifest_dir()
+            .join("examples/threshold_signatures")
+            .join(case.directory)
+            .join("main.stfl");
+        let source = fs::read_to_string(&path).expect("read threshold signature example");
+        let options = CompilerOptions {
+            optimize: true,
+            optimization_level: 3,
+            mpc_backend: MpcBackend::Avss,
+            mpc_curve: case.curve,
+            ..CompilerOptions::default()
+        };
+        let program = compile_file(&path, &source, &options)
+            .unwrap_or_else(|errors| panic!("{}: {errors:#?}", case.directory));
+        let demand = program.client_io_manifest.preprocessing_demand;
+        assert_eq!(demand.triples, case.triples, "{} triples", case.directory);
+        assert_eq!(demand.randoms, case.randoms, "{} randoms", case.directory);
+        assert_eq!(demand.prandbits, 0, "{} prandbits", case.directory);
+        assert_eq!(demand.prandints, 0, "{} prandints", case.directory);
+        assert!(!demand.dynamic, "{} demand must be exact", case.directory);
+
+        let calls = |symbol: &str| {
+            program
+                .main_chunk
+                .instructions
+                .iter()
+                .filter(
+                    |instruction| matches!(instruction, Instruction::CALL(name) if name == symbol),
+                )
+                .count()
+        };
+        assert_eq!(
+            calls("Share.mul") + calls("mul"),
+            0,
+            "{} must not leave singular interactive products",
+            case.directory
+        );
+        assert_eq!(
+            calls("Share.batch_mul"),
+            case.batch_mul_sessions,
+            "{} multiplication sessions",
+            case.directory
+        );
+
+        // Every example has one client-conditional field open. With no client
+        // inputs (the benchmark path), that branch is skipped; all other field
+        // opens are mandatory protocol sessions.
+        let field_open_sessions = calls("open_field") + calls("Share.open_field");
+        assert_eq!(
+            field_open_sessions.saturating_sub(1),
+            case.mandatory_field_open_sessions,
+            "{} mandatory field-open sessions",
+            case.directory
+        );
+        let exponent_open_sessions = calls("open_exp")
+            + calls("Share.open_exp")
+            + calls("open_exp_custom")
+            + calls("Share.open_exp_custom");
+        assert_eq!(
+            exponent_open_sessions, case.exponent_open_sessions,
+            "{} exponent-open sessions",
+            case.directory
+        );
+        assert_eq!(
+            case.batch_mul_sessions + case.mandatory_field_open_sessions,
+            case.mul_reveal_round_floor,
+            "{} multiply/reveal dependency-depth floor",
+            case.directory
+        );
+    }
 }
 
 #[test]

--- a/crates/stoffel-lang/tests/rust/fixture_and_example_tests.rs
+++ b/crates/stoffel-lang/tests/rust/fixture_and_example_tests.rs
@@ -5,6 +5,7 @@ use stoffel_vm_types::compiled_binary::{
     utils::{load_from_file, try_to_vm_functions},
     MpcBackend,
 };
+use stoffel_vm_types::instructions::Instruction;
 use stoffellang::{compile_file, convert_to_binary, save_to_file, CompilerOptions};
 
 fn manifest_dir() -> PathBuf {
@@ -155,6 +156,37 @@ fn canonical_examples_compile_to_vm_bytecode_impl() {
     }
 
     assert!(failures.is_empty(), "{}", failures.join("\n\n"));
+}
+
+#[test]
+fn secp256k1_ecdsa_keeps_preprocessing_minimal_and_batched() {
+    let path =
+        manifest_dir().join("examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl");
+    let program = compile_source_file(&path).expect("threshold ECDSA example compiles");
+    let demand = program.client_io_manifest.preprocessing_demand;
+
+    assert_eq!(
+        demand.triples, 2,
+        "ECDSA needs exactly two nonlinear products"
+    );
+    assert_eq!(demand.randoms, 3, "key, mask, and nonce are random fields");
+    assert_eq!(demand.prandbits, 0);
+    assert_eq!(demand.prandints, 0);
+    assert!(!demand.dynamic);
+
+    let call_count = |symbol: &str| {
+        program
+            .main_chunk
+            .instructions
+            .iter()
+            .filter(|instruction| matches!(instruction, Instruction::CALL(name) if name == symbol))
+            .count()
+    };
+
+    assert_eq!(call_count("Share.batch_mul"), 1);
+    assert_eq!(call_count("Share.mul"), 0);
+    assert_eq!(call_count("Share.open_exp"), 0);
+    assert_eq!(call_count("open_exp"), 0);
 }
 
 #[test]

--- a/crates/stoffel-rust-sdk/Cargo.toml
+++ b/crates/stoffel-rust-sdk/Cargo.toml
@@ -35,8 +35,8 @@ tracing-opentelemetry = "0.33.0"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 stoffellang = { version = "0.1.0", path = "../stoffel-lang" }
-stoffel-mpc-coordinator-shared = "0.1.0"
-stoffel-mpc-coordinator-off-chain = "0.1.0"
+stoffel-mpc-coordinator-shared = { git = "https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git", branch = "dev" }
+stoffel-mpc-coordinator-off-chain = { git = "https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git", branch = "dev" }
 stoffel-vm = { version = "0.1.0", path = "../stoffel-vm" }
 stoffel-vm-runner = { version = "0.1.0", path = "../stoffel-vm-runner" }
 stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }

--- a/crates/stoffel-rust-sdk/examples/aes_secure_decrypt.rs
+++ b/crates/stoffel-rust-sdk/examples/aes_secure_decrypt.rs
@@ -75,6 +75,7 @@ async fn main() -> stoffel::Result<()> {
     println!("(client 0 = ciphertext, client 1 = key; plaintext never revealed to nodes)");
 
     let (_returned, client_outputs) = Stoffel::compile_file(PROGRAM)?
+        .optimization_level(3)
         .parties(5)
         .threshold(1)
         // Declaring output clients enables the client-output capability so the

--- a/crates/stoffel-rust-sdk/src/backend/avss.rs
+++ b/crates/stoffel-rust-sdk/src/backend/avss.rs
@@ -215,6 +215,12 @@ fn bls12381_share_to_sdk(key_name: &str, share: &Bls12381AvssShare) -> Result<Sh
         stoffel_vm_types::core_types::ShareData::Opaque(data) => {
             Ok(Share::opaque(key_name, data.to_vec()))
         }
+        stoffel_vm_types::core_types::ShareData::Deferred(_) => Err(Error::Computation(
+            "AVSS backend returned an unresolved deferred share".to_owned(),
+        )),
+        stoffel_vm_types::core_types::ShareData::Public(_) => Err(Error::Computation(
+            "AVSS backend returned an unmaterialized public share".to_owned(),
+        )),
     }
 }
 

--- a/crates/stoffel-rust-sdk/src/compiler.rs
+++ b/crates/stoffel-rust-sdk/src/compiler.rs
@@ -19,6 +19,8 @@ pub struct CompilationOptions {
     pub optimization_level: u8,
     pub print_ir: bool,
     pub entry_points: Vec<String>,
+    /// Override the backend's scalar multiply capacity per online round.
+    pub mpc_mul_batch_capacity: Option<usize>,
 }
 
 pub fn compile_source(source: &str, filename: &str, backend: MpcBackend) -> Result<Program> {
@@ -84,5 +86,12 @@ fn compiler_options(
         inline_budget: env_budget("STOFFEL_INLINE_BUDGET"),
         unroll_budget: env_budget("STOFFEL_UNROLL_BUDGET"),
         unroll_max_expansion: env_budget("STOFFEL_UNROLL_MAX_EXPANSION"),
+        mpc_mul_batch_capacity: options.mpc_mul_batch_capacity.or_else(|| {
+            matches!(backend, MpcBackend::HoneyBadger)
+                .then(|| {
+                    env_budget(stoffel_vm_types::mpc::HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV)
+                })
+                .flatten()
+        }),
     }
 }

--- a/crates/stoffel-rust-sdk/src/lib.rs
+++ b/crates/stoffel-rust-sdk/src/lib.rs
@@ -438,6 +438,21 @@ impl Stoffel {
         }
         mpc_config.validate()?;
 
+        let mut compiler_options = self.compiler_options;
+        if compiler_options.mpc_mul_batch_capacity.is_none()
+            && matches!(mpc_config.backend, MpcBackend::HoneyBadger)
+        {
+            let override_pairs =
+                std::env::var(stoffel_vm_types::mpc::HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV)
+                    .ok()
+                    .and_then(|raw| raw.parse::<usize>().ok());
+            compiler_options.mpc_mul_batch_capacity =
+                Some(stoffel_vm_types::mpc::honeybadger_mul_batch_capacity(
+                    mpc_config.threshold,
+                    override_pairs,
+                ));
+        }
+
         let source = self
             .source
             .ok_or_else(|| Error::Configuration("no program source configured".to_owned()))?;
@@ -446,13 +461,11 @@ impl Stoffel {
                 &source,
                 &filename,
                 mpc_config.backend,
-                self.compiler_options,
+                compiler_options,
             )?,
-            ProgramSource::File { path } => compiler::compile_file_with_options(
-                &path,
-                mpc_config.backend,
-                self.compiler_options,
-            )?,
+            ProgramSource::File { path } => {
+                compiler::compile_file_with_options(&path, mpc_config.backend, compiler_options)?
+            }
             ProgramSource::Bytecode(bytecode) => {
                 let program = Program::from_bytecode(&bytecode)?;
                 let bytecode_backend =

--- a/crates/stoffel-rust-sdk/src/vm.rs
+++ b/crates/stoffel-rust-sdk/src/vm.rs
@@ -204,20 +204,6 @@ pub(crate) async fn execute_local_capturing_with_options(
         .ok_or_else(|| Error::Configuration("MPC configuration is required".to_owned()))?;
     let flattened_client_inputs = flatten_local_client_inputs(runtime.client_inputs())?;
     validate_flattened_local_client_inputs(runtime, &flattened_client_inputs)?;
-    if matches!(
-        mpc_config.backend,
-        MpcBackend::Avss {
-            curve: crate::config::Curve::Bn254
-                | crate::config::Curve::Curve25519
-                | crate::config::Curve::Ed25519
-        }
-    ) && !runtime.client_inputs().is_empty()
-    {
-        return Err(Error::Unsupported(
-            "SDK local coordinator execution currently supports AVSS local client inputs only for bls12_381"
-                .to_owned(),
-        ));
-    }
     let local_client_inputs = flattened_client_inputs
         .iter()
         .map(|(client_slot, values)| {

--- a/crates/stoffel-rust-sdk/tests/sdk_usage.rs
+++ b/crates/stoffel-rust-sdk/tests/sdk_usage.rs
@@ -1851,10 +1851,10 @@ async fn local_network_builder_rejects_zero_timeout_before_runner_lookup() -> st
     Ok(())
 }
 
-#[tokio::test]
-async fn local_execution_rejects_non_bls_avss_client_inputs_before_runner_lookup(
-) -> stoffel::Result<()> {
-    let err = Stoffel::compile(
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "starts a real localhost coordinator, Ed25519 AVSS party mesh, and coordinator client"]
+async fn local_execution_supports_ed25519_avss_client_inputs() -> stoffel::Result<()> {
+    let result = Stoffel::compile(
         r#"
 def main() -> int64:
   var share = ClientStore.take_share(0, 0)
@@ -1867,15 +1867,11 @@ def main() -> int64:
         curve: Curve::Ed25519,
     })
     .with_client_input(0, &[42_i64])
+    .local_runner_path("target/debug/stoffel-run")
     .execute_local()
-    .await
-    .unwrap_err();
+    .await?;
 
-    assert!(matches!(
-        err,
-        stoffel::Error::Unsupported(message)
-            if message.contains("AVSS local client inputs only for bls12_381")
-    ));
+    assert_eq!(result, vec![Value::I64(42)]);
     Ok(())
 }
 

--- a/crates/stoffel-vm-runner/Cargo.toml
+++ b/crates/stoffel-vm-runner/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = "0.1"
 bincode = { version = "1.3.3", default-features = true }
 futures = "0.3.31"
 hex = "0.4"
+jsonrpsee = { version = "0.26.0", features = ["server"] }
 libc = "0.2"
 rustls = "0.23"
 serde = { version = "1.0", features = ["derive", "default"] }

--- a/crates/stoffel-vm-runner/Cargo.toml
+++ b/crates/stoffel-vm-runner/Cargo.toml
@@ -17,8 +17,8 @@ path = "src/bin/stoffel-run.rs"
 [dependencies]
 stoffel-vm = { version = "0.1.0", path = "../stoffel-vm" }
 stoffel-vm-types = { version = "0.1.0", path = "../stoffel-vm-types" }
-stoffel-mpc-coordinator-shared = "0.1.0"
-stoffel-mpc-coordinator-off-chain = "0.1.0"
+stoffel-mpc-coordinator-shared = { git = "https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git", branch = "dev" }
+stoffel-mpc-coordinator-off-chain = { git = "https://github.com/Stoffel-Labs/stoffel-mpc-coordinator.git", branch = "dev" }
 stoffelmpc-mpc = { package = "stoffelcrypto", version = "0.1.0" }
 stoffelnet = "0.1.0"
 ark-bls12-381 = "0.5.0"

--- a/crates/stoffel-vm-runner/src/bin/stoffel-run.rs
+++ b/crates/stoffel-vm-runner/src/bin/stoffel-run.rs
@@ -18,8 +18,11 @@ use stoffel_mpc_coordinator_off_chain::OffChainCoordinatorClient;
 use stoffel_mpc_coordinator_shared::{Coordinator, NodeRPCError, Round};
 use stoffel_vm::core_vm::VirtualMachine;
 use stoffel_vm::net::curve::{field_from_i64, field_to_i64, SupportedMpcField};
+use stoffel_vm::net::engine_config::DeploymentMode;
 use stoffel_vm::net::hb_engine::HoneyBadgerMpcEngine;
-use stoffel_vm::net::mpc_engine::{DurableIdentityDigest, MpcEngine, MpcSessionTopology};
+use stoffel_vm::net::mpc_engine::{
+    AsyncMpcEngine, DurableIdentityDigest, MpcEngine, MpcSessionTopology,
+};
 use stoffel_vm::net::{
     avss_protocol_instance_id, honeybadger_node_opts_with_truncation,
     honeybadger_protocol_instance_id, honeybadger_protocol_timeout, spawn_receive_loops_split,
@@ -196,6 +199,15 @@ type AvssOffChainNodeRpcClient<F, G> = OffChainNodeRPCClient<F, AvssCoordinatorS
 type AvssOffChainNodeRpcServer<F, G> = OffChainNodeRPCServer<F, AvssCoordinatorShare<F, G>>;
 
 const HB_PREPROCESSING_READY_PREFIX: &[u8] = b"STOFFEL_HB_PREPROCESSING_READY_V1";
+const HB_RUN_COMPLETE_PREFIX: &[u8] = b"STOFFEL_HB_RUN_COMPLETE_V1";
+
+fn parse_u64_marker(prefix: &[u8], raw_msg: &[u8]) -> Option<u64> {
+    let payload = raw_msg.strip_prefix(prefix)?;
+    if payload.len() != std::mem::size_of::<u64>() {
+        return None;
+    }
+    Some(u64::from_le_bytes(payload.try_into().ok()?))
+}
 
 fn session_registration_timeout() -> Duration {
     let seconds = env::var("STOFFEL_SESSION_REGISTRATION_TIMEOUT_SECONDS")
@@ -620,6 +632,248 @@ where
             share.ok_or_else(|| format!("missing reserved mask share for slot {slot}"))
         })
         .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn collect_hb_coordinator_inputs_for_bls(
+    vm: &mut VirtualMachine,
+    engine: &Arc<HoneyBadgerMpcEngine<ark_bls12_381::Fr, ark_bls12_381::G1Projective>>,
+    coord: &mut HbOffChainCoordinator<ark_bls12_381::Fr>,
+    node_rpc: &mut HbOffChainNodeRpcServer<ark_bls12_381::Fr>,
+    input_ids: &[Vec<u8>],
+    client_input_total: usize,
+    client_input_count: usize,
+    client_input_slots: &[usize],
+    client_input_types: &std::collections::BTreeMap<usize, Vec<ShareType>>,
+    program_id: [u8; 32],
+    run_id: u64,
+    my_id: usize,
+    as_leader: bool,
+) -> Result<(), String> {
+    if input_ids.is_empty() {
+        return Ok(());
+    }
+
+    let total_input_count = if client_input_total > 0 {
+        client_input_total
+    } else {
+        input_ids.len().saturating_mul(client_input_count)
+    };
+
+    if engine.is_standing() {
+        engine
+            .reservation_ops()
+            .map_err(|e| e.to_string())?
+            .init_reservations_for_run(
+                program_id,
+                total_input_count as u64,
+                run_id,
+                stoffel_vm::storage::preproc::PoolAvailability::default(),
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    let precomputed_mask_shares = if engine.is_standing() {
+        None
+    } else {
+        Some(
+            engine
+                .node_handle()
+                .lock()
+                .await
+                .preprocessing_material
+                .lock()
+                .await
+                .take_random_shares(total_input_count)
+                .map_err(|e| format!("take_random_shares: {e}"))?,
+        )
+    };
+
+    if let Some(ref mask_shares) = precomputed_mask_shares {
+        for (i, share) in mask_shares.iter().enumerate() {
+            node_rpc
+                .add_mask_share(i as u64, share)
+                .await
+                .map_err(|e| format!("add_mask_share: {:?}", e))?;
+        }
+    }
+
+    if as_leader {
+        eprintln!("[party {my_id}] coordinator -> InputMaskReservation");
+        coord
+            .reserve_input_masks()
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+    coord
+        .wait_for_round(Round::InputMaskReservation)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    eprintln!("[party {my_id}] waiting for reserved input indices");
+    let client_to_indices = normalize_client_to_indices(
+        coord
+            .wait_for_indices(total_input_count as u64)
+            .await
+            .map_err(|e| e.to_string())?,
+    );
+    eprintln!("[party {my_id}] reserved input indices received");
+
+    let mask_shares = if let Some(mask_shares) = precomputed_mask_shares {
+        mask_shares
+    } else {
+        let mask_shares = load_reserved_mask_shares(
+            engine,
+            total_input_count,
+            client_to_indices.values().flatten().copied(),
+        )
+        .await?;
+
+        for idx in client_to_indices.values().flatten().copied() {
+            let slot = usize::try_from(idx)
+                .map_err(|_| format!("reserved index {idx} exceeds usize range"))?;
+            let share = mask_shares
+                .get(slot)
+                .ok_or_else(|| format!("reserved index {idx} exceeds mask share slots"))?;
+            node_rpc
+                .add_mask_share(idx, share)
+                .await
+                .map_err(|e| format!("add_mask_share: {:?}", e))?;
+        }
+
+        mask_shares
+    };
+
+    for (cid, indices) in &client_to_indices {
+        for idx in indices {
+            node_rpc
+                .add_reserved_index(cid.clone(), *idx)
+                .await
+                .or_else(|e| match e {
+                    NodeRPCError::JSONError => {
+                        eprintln!(
+                            "[party {my_id}] add_reserved_index observed a stale client sink for index {idx}; continuing"
+                        );
+                        Ok(())
+                    }
+                    other => Err(format!("add_reserved_index: {:?}", other)),
+                })?;
+        }
+    }
+
+    if as_leader {
+        eprintln!("[party {my_id}] coordinator -> InputCollection");
+        coord.collect_inputs().await.map_err(|e| e.to_string())?;
+    }
+    coord
+        .wait_for_round(Round::InputCollection)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    eprintln!("[party {my_id}] waiting for masked client inputs");
+    let client_inputs = coord
+        .wait_for_inputs(total_input_count as u64, mask_shares)
+        .await
+        .map_err(|e| e.to_string())?;
+    eprintln!("[party {my_id}] masked client inputs received");
+    store_reserved_client_inputs(
+        vm,
+        &client_to_indices,
+        client_inputs,
+        client_input_count,
+        client_input_slots,
+        client_input_types,
+    );
+
+    Ok(())
+}
+
+async fn reset_hb_node_rpcs_as_designated_party(
+    node_rpc_addrs: &[SocketAddr],
+    parties: usize,
+    threshold: usize,
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
+) -> Result<(), String> {
+    if node_rpc_addrs.is_empty() {
+        return Err("persistent coordinator reset requires --node-rpc-addrs".to_owned());
+    }
+    let rpc_addrs = node_rpc_addrs
+        .iter()
+        .map(|addr| (addr.ip().to_string(), addr.port()))
+        .collect::<Vec<_>>();
+    let node_rpc: HbOffChainNodeRpcClient<ark_bls12_381::Fr> =
+        HbOffChainNodeRpcClient::<ark_bls12_381::Fr>::start_rpc_client(
+            parties, threshold, rpc_addrs, cert_der, key_der,
+        )
+        .await
+        .map_err(|e| format!("connect node RPC reset client: {e}"))?;
+    node_rpc
+        .reset()
+        .await
+        .map_err(|e| format!("reset node RPC servers: {e}"))
+}
+
+async fn wait_for_hb_run_complete_barrier(
+    net: &Arc<QuicNetworkManager>,
+    run_complete_rx: &mut mpsc::Receiver<(usize, u64)>,
+    my_id: usize,
+    parties: usize,
+    run_id: u64,
+    run_instance_id: u64,
+) -> Result<(), String> {
+    if parties <= 1 {
+        return Ok(());
+    }
+
+    let mut complete_message =
+        Vec::with_capacity(HB_RUN_COMPLETE_PREFIX.len() + std::mem::size_of::<u64>());
+    complete_message.extend_from_slice(HB_RUN_COMPLETE_PREFIX);
+    complete_message.extend_from_slice(&run_instance_id.to_le_bytes());
+
+    for peer_id in 0..parties {
+        if peer_id == my_id {
+            continue;
+        }
+        net.send(peer_id, &complete_message)
+            .await
+            .map_err(|error| {
+                format!(
+                    "Failed to send run-complete marker for run {run_id} to party {peer_id}: {error}"
+                )
+            })?;
+    }
+
+    let mut complete_parties = std::collections::HashSet::with_capacity(parties.saturating_sub(1));
+    let barrier_timeout = honeybadger_protocol_timeout();
+    let barrier_result = tokio::time::timeout(barrier_timeout, async {
+        while complete_parties.len() < parties.saturating_sub(1) {
+            let (sender_id, marker_instance_id) =
+                run_complete_rx.recv().await.ok_or_else(|| {
+                    format!("Run-complete marker channel closed before run {run_id} completed")
+                })?;
+            if sender_id == my_id {
+                continue;
+            }
+            if marker_instance_id == run_instance_id {
+                complete_parties.insert(sender_id);
+            }
+        }
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|_| {
+        format!(
+            "Timed out waiting for run-complete markers for run {run_id} ({}/{})",
+            complete_parties.len(),
+            parties.saturating_sub(1)
+        )
+    })?;
+    barrier_result?;
+
+    eprintln!("[party {my_id}] persistent run {run_id}: all parties complete");
+    Ok(())
 }
 
 /// Network adapter for MPC clients.
@@ -2309,11 +2563,22 @@ struct HbPartySetup<'a> {
     preprocessing_demand: stoffel_vm_types::compiled_binary::PreprocessingDemand,
     program_hash: [u8; 32],
     preproc_store_path: Option<&'a str>,
+    deployment_mode: DeploymentMode,
 }
+
+struct HbPartyRuntime<F, G>
+where
+    F: SupportedMpcField,
+    G: CurveGroup<ScalarField = F> + PrimeGroup + Send + Sync + 'static,
+{
+    engine: Arc<HoneyBadgerMpcEngine<F, G>>,
+    run_complete_rx: mpsc::Receiver<(usize, u64)>,
+}
+
 async fn setup_hb_party_for_curve<F, G>(
     vm: &mut VirtualMachine,
     setup: HbPartySetup<'_>,
-) -> Result<Arc<HoneyBadgerMpcEngine<F, G>>, String>
+) -> Result<HbPartyRuntime<F, G>, String>
 where
     F: SupportedMpcField,
     G: CurveGroup<ScalarField = F> + PrimeGroup + Send + Sync + 'static,
@@ -2332,6 +2597,7 @@ where
         preprocessing_demand,
         program_hash,
         preproc_store_path,
+        deployment_mode,
     } = setup;
 
     // ---- Phase 1: Wait for clients ----
@@ -2471,21 +2737,21 @@ where
     .map_err(|e| format!("Failed to create MPC node: {:?}", e))?;
     eprintln!("[party {}] MPC node setup complete", my_id);
 
-    // Clone 1: the processing node — MOVED into the processing loop task.
-    // This is the ONLY clone that calls process() on incoming messages.
-    let mut processing_node = mpc_node.clone();
-
-    // Clone 2: the engine node — used for preprocessing initiation only.
+    // The receive loop processes through the engine's resettable node handle.
+    // Earlier code captured a separate cloned node here, which works for a
+    // one-shot process but leaves persistent runs receiving on the old
+    // instance_id after `reset_for_next_run`.
     // Created via from_existing_node which wraps it in Arc<Mutex>.
     let open_message_router = Arc::new(stoffel_vm::net::OpenMessageRouter::new());
     let topology = MpcSessionTopology::try_new(instance_id, my_id, n, t)
         .map_err(|error| format!("Invalid HoneyBadger MPC topology: {error}"))?;
-    let engine = HoneyBadgerMpcEngine::<F, G>::from_existing_node_with_router_and_topology(
+    let engine = HoneyBadgerMpcEngine::<F, G>::from_existing_node_with_router_topology_and_mode(
         open_message_router.clone(),
         topology,
         persistent_identity,
         net.clone(),
         mpc_node, // moved, not cloned
+        deployment_mode,
     );
 
     configure_hb_preproc_store(
@@ -2515,10 +2781,12 @@ where
         .collect();
 
     // Single processing loop using tokio::select! for both server and client messages.
-    // Only this task calls process() — no other task touches the processing_node.
+    // Only this task calls process(); fetch the node handle per message so reset swaps are visible.
     let processing_net = net.clone();
+    let processing_engine = engine.clone();
     let process_party_id = my_id;
     let (preprocessing_ready_tx, mut preprocessing_ready_rx) = mpsc::channel::<usize>(n);
+    let (run_complete_tx, run_complete_rx) = mpsc::channel::<(usize, u64)>(n);
     tokio::spawn(async move {
         let mut msg_count = 0u64;
         let trace_messages = std::env::var("STOFFEL_RUN_TRACE_MESSAGES")
@@ -2535,6 +2803,15 @@ where
                         }
                         continue;
                     }
+                    if let Some(run_instance_id) = parse_u64_marker(HB_RUN_COMPLETE_PREFIX, &raw_msg) {
+                        if let Err(error) = run_complete_tx.send((sender_id, run_instance_id)).await {
+                            eprintln!(
+                                "[party {}] Failed to record run-complete marker from {}: {}",
+                                process_party_id, sender_id, error
+                            );
+                        }
+                        continue;
+                    }
 
                     msg_count += 1;
                     if trace_messages && (msg_count <= 5 || msg_count.is_multiple_of(1000)) {
@@ -2543,10 +2820,12 @@ where
                             process_party_id, msg_count, sender_id, raw_msg.len()
                         );
                     }
-                    if let Err(e) = processing_node
-                        .process(sender_id, raw_msg, processing_net.clone())
-                        .await
-                    {
+                    let node_handle = processing_engine.node_handle().clone();
+                    let process_result = {
+                        let mut node = node_handle.lock().await;
+                        node.process(sender_id, raw_msg, processing_net.clone()).await
+                    };
+                    if let Err(e) = process_result {
                         eprintln!(
                             "[party {}] Failed to process message from {}: {:?}",
                             process_party_id, sender_id, e
@@ -2559,10 +2838,12 @@ where
                         .get(&client_id)
                         .copied()
                         .unwrap_or(client_id);
-                    if let Err(e) = processing_node
-                        .process(mpc_sender_id, raw_msg, processing_net.clone())
-                        .await
-                    {
+                    let node_handle = processing_engine.node_handle().clone();
+                    let process_result = {
+                        let mut node = node_handle.lock().await;
+                        node.process(mpc_sender_id, raw_msg, processing_net.clone()).await
+                    };
+                    if let Err(e) = process_result {
                         eprintln!(
                             "[party {}] Failed to process client message from {} (idx {}): {:?}",
                             process_party_id, client_id, mpc_sender_id, e
@@ -2759,7 +3040,10 @@ where
         }
     }
 
-    Ok(engine)
+    Ok(HbPartyRuntime {
+        engine,
+        run_complete_rx,
+    })
 }
 struct AvssPartySetup<'a> {
     my_id: usize,
@@ -3276,6 +3560,7 @@ where
         rpc_addr.1,
         cert_der.clone(),
         key_der.clone(),
+        extract_pubkey_from_cert(&cert_der),
     )
     .await
     .map_err(|error| format!("Failed to start AVSS node RPC server: {error}"))?;
@@ -3646,6 +3931,9 @@ async fn main() {
     let mut preproc_store_path: Option<String> = None;
     let mut local_store_path: Option<String> = None;
     let mut advertise_addr: Option<SocketAddr> = None;
+    let mut persistent_runs: usize = 1;
+    let mut node_rpc_addrs: Vec<SocketAddr> = Vec::new();
+    let mut node_rpc_designated_party_cert: Option<Vec<u8>> = None;
 
     for arg in &raw_args {
         if arg == "-h" || arg == "--help" {
@@ -3697,6 +3985,9 @@ async fn main() {
         } else if let Some(_rest) = arg.strip_prefix("--preproc-store") {
         } else if let Some(_rest) = arg.strip_prefix("--local-store") {
         } else if let Some(_rest) = arg.strip_prefix("--advertise") {
+        } else if let Some(_rest) = arg.strip_prefix("--persistent-runs") {
+        } else if let Some(_rest) = arg.strip_prefix("--node-rpc-addrs") {
+        } else if let Some(_rest) = arg.strip_prefix("--node-rpc-designated-party-cert") {
         } else if let Some(_rest) = arg.strip_prefix("--no-program-upload") {
         }
     }
@@ -3919,9 +4210,40 @@ async fn main() {
                     advertise_addr = Some(v.parse().expect("Invalid --advertise addr"));
                 }
             }
+            "--persistent-runs" => {
+                if let Some(v) = args_iter.next() {
+                    persistent_runs = v.parse().expect("Invalid --persistent-runs");
+                }
+            }
+            "--node-rpc-addrs" => {
+                if let Some(v) = args_iter.next() {
+                    node_rpc_addrs = v
+                        .split(',')
+                        .filter(|s| !s.trim().is_empty())
+                        .map(|s| s.trim().parse().expect("Invalid --node-rpc-addrs entry"))
+                        .collect();
+                }
+            }
+            "--node-rpc-designated-party-cert" => {
+                if let Some(v) = args_iter.next() {
+                    node_rpc_designated_party_cert = Some(
+                        std::fs::read(&v)
+                            .expect("Failed to read --node-rpc-designated-party-cert file"),
+                    );
+                }
+            }
             "--no-program-upload" => {}
             _ => {}
         }
+    }
+
+    if persistent_runs == 0 {
+        eprintln!("Error: --persistent-runs must be greater than zero");
+        exit(2);
+    }
+    if persistent_runs > 1 && preproc_store_path.is_none() {
+        eprintln!("Error: --persistent-runs requires --preproc-store");
+        exit(2);
     }
 
     let coordinator_output_format = match output_fixed_point_fractional_bits {
@@ -4665,6 +4987,7 @@ async fn main() {
     let mut hb_bls12381_coord_engine: Option<
         Arc<HoneyBadgerMpcEngine<ark_bls12_381::Fr, ark_bls12_381::G1Projective>>,
     > = None;
+    let mut hb_bls12381_run_complete_rx: Option<mpsc::Receiver<(usize, u64)>> = None;
 
     if matches!(backend_kind, MpcBackendKind::HoneyBadger) {
         if let Some(ref ca) = coord_addr {
@@ -4697,11 +5020,16 @@ async fn main() {
             );
 
             if let Some(ref rpc) = rpc_addr {
+                let node_cert_der = cert_der.clone().unwrap();
                 let node_rpc = HbOffChainNodeRpcServer::<ark_bls12_381::Fr>::start(
                     &rpc.0,
                     rpc.1,
-                    cert_der.clone().unwrap(),
+                    node_cert_der.clone(),
                     key_der.clone().unwrap(),
+                    node_rpc_designated_party_cert
+                        .as_deref()
+                        .map(extract_pubkey_from_cert)
+                        .unwrap_or_else(|| extract_pubkey_from_cert(&node_cert_der)),
                 )
                 .await
                 .unwrap_or_else(|error| {
@@ -4774,6 +5102,7 @@ async fn main() {
                                 preprocessing_demand,
                                 program_hash: program_id,
                                 preproc_store_path: preproc_store_path.as_deref(),
+                                deployment_mode: DeploymentMode::OneShot,
                             },
                         )
                         .await
@@ -4789,7 +5118,7 @@ async fn main() {
 
                 // Bls12_381 path with coordinator support
                 if coord_opt.is_some() && matches!(curve_config, MpcCurveConfig::Bls12_381) {
-                    let engine = match setup_hb_party_for_curve::<
+                    let runtime = match setup_hb_party_for_curve::<
                         ark_bls12_381::Fr,
                         ark_bls12_381::G1Projective,
                     >(
@@ -4810,6 +5139,11 @@ async fn main() {
                             preprocessing_demand,
                             program_hash: program_id,
                             preproc_store_path: preproc_store_path.as_deref(),
+                            deployment_mode: if persistent_runs > 1 {
+                                DeploymentMode::Standing
+                            } else {
+                                DeploymentMode::OneShot
+                            },
                         },
                     )
                     .await
@@ -4820,130 +5154,46 @@ async fn main() {
                             exit(13);
                         }
                     };
+                    let HbPartyRuntime {
+                        engine,
+                        run_complete_rx,
+                    } = runtime;
                     if coord_opt.is_some() {
                         engine.enable_client_output_capture().await;
                         hb_bls12381_coord_engine = Some(engine.clone());
+                        hb_bls12381_run_complete_rx = Some(run_complete_rx);
                     }
 
                     // Coordinator mask distribution + input collection
-                    if let Some(ref mut coord) = coord_opt {
-                        let node_rpc = node_rpc_opt
-                            .as_mut()
-                            .expect("--rpc-bind required with coordinator");
+                    if persistent_runs == 1 {
+                        if let Some(ref mut coord) = coord_opt {
+                            let node_rpc = node_rpc_opt
+                                .as_mut()
+                                .expect("--rpc-bind required with coordinator");
 
-                        if !input_ids.is_empty() {
-                            // Actual total across clients (supports asymmetric
-                            // per-client input counts); fall back to the uniform
-                            // estimate only when the total wasn't supplied.
-                            let total_input_count = if client_input_total > 0 {
-                                client_input_total
-                            } else {
-                                input_ids.len().saturating_mul(client_input_count)
-                            };
-                            let precomputed_mask_shares = Some(
-                                engine
-                                    .node_handle()
-                                    .lock()
-                                    .await
-                                    .preprocessing_material
-                                    .lock()
-                                    .await
-                                    .take_random_shares(total_input_count)
-                                    .unwrap_or_else(|e| {
-                                        eprintln!("take_random_shares: {}", e);
-                                        exit(13);
-                                    }),
-                            );
-
-                            if let Some(ref mask_shares) = precomputed_mask_shares {
-                                for (i, share) in mask_shares.iter().enumerate() {
-                                    node_rpc
-                                        .add_mask_share(i as u64, share)
-                                        .await
-                                        .unwrap_or_else(|e| {
-                                            eprintln!("add_mask_share: {:?}", e);
-                                            exit(13);
-                                        });
-                                }
-                            }
-
-                            if as_leader {
-                                eprintln!("[party {my_id}] coordinator -> InputMaskReservation");
-                                coord.reserve_input_masks().await.unwrap();
-                            }
-                            coord
-                                .wait_for_round(Round::InputMaskReservation)
-                                .await
-                                .unwrap();
-
-                            eprintln!("[party {my_id}] waiting for reserved input indices");
-                            let client_to_indices = normalize_client_to_indices(
-                                coord
-                                    .wait_for_indices(total_input_count as u64)
-                                    .await
-                                    .unwrap(),
-                            );
-                            eprintln!("[party {my_id}] reserved input indices received");
-
-                            let mask_shares = if let Some(mask_shares) = precomputed_mask_shares {
-                                mask_shares
-                            } else {
-                                let mask_shares = load_reserved_mask_shares(
-                                    &engine,
-                                    total_input_count,
-                                    client_to_indices.values().flatten().copied(),
-                                )
-                                .await
-                                .unwrap_or_else(|e| {
-                                    eprintln!("load_reserved_mask_shares: {}", e);
-                                    exit(13);
-                                });
-
-                                for idx in client_to_indices.values().flatten().copied() {
-                                    node_rpc
-                                        .add_mask_share(idx, &mask_shares[idx as usize])
-                                        .await
-                                        .unwrap_or_else(|e| {
-                                            eprintln!("add_mask_share: {:?}", e);
-                                            exit(13);
-                                        });
-                                }
-
-                                mask_shares
-                            };
-
-                            for (cid, indices) in &client_to_indices {
-                                for idx in indices {
-                                    node_rpc
-                                        .add_reserved_index(cid.clone(), *idx)
-                                        .await
-                                        .unwrap_or_else(|e| {
-                                            eprintln!("add_reserved_index: {:?}", e);
-                                            exit(13);
-                                        });
-                                }
-                            }
-
-                            if as_leader {
-                                eprintln!("[party {my_id}] coordinator -> InputCollection");
-                                coord.collect_inputs().await.unwrap();
-                            }
-                            coord.wait_for_round(Round::InputCollection).await.unwrap();
-
-                            eprintln!("[party {my_id}] waiting for masked client inputs");
-                            let client_inputs = coord
-                                .wait_for_inputs(total_input_count as u64, mask_shares)
-                                .await
-                                .unwrap();
-                            eprintln!("[party {my_id}] masked client inputs received");
-                            store_reserved_client_inputs(
+                            if let Err(e) = collect_hb_coordinator_inputs_for_bls(
                                 &mut vm,
-                                &client_to_indices,
-                                client_inputs,
+                                &engine,
+                                coord,
+                                node_rpc,
+                                &input_ids,
+                                client_input_total,
                                 client_input_count,
                                 &client_input_slots,
                                 &client_input_types,
-                            );
+                                program_id,
+                                0,
+                                my_id,
+                                as_leader,
+                            )
+                            .await
+                            {
+                                eprintln!(
+                                    "[party {}] coordinator input collection failed: {}",
+                                    my_id, e
+                                );
+                                exit(13);
+                            }
                         }
                     }
                 } else {
@@ -5073,6 +5323,246 @@ async fn main() {
                 );
             }
         }
+    }
+
+    if persistent_runs > 1 {
+        if !matches!(backend_kind, MpcBackendKind::HoneyBadger)
+            || !matches!(curve_config, MpcCurveConfig::Bls12_381)
+            || coord_opt.is_none()
+            || hb_bls12381_coord_engine.is_none()
+            || hb_bls12381_run_complete_rx.is_none()
+        {
+            eprintln!(
+                "Error: --persistent-runs currently supports HoneyBadger bls12-381 off-chain coordinator party mode"
+            );
+            exit(2);
+        }
+        let mut coord = coord_opt.take().expect("coordinator checked above");
+        let engine = hb_bls12381_coord_engine
+            .as_ref()
+            .expect("engine checked above")
+            .clone();
+        let node_rpc = node_rpc_opt
+            .as_mut()
+            .expect("--rpc-bind required with persistent coordinator mode");
+        let mut run_complete_rx = hb_bls12381_run_complete_rx
+            .take()
+            .expect("run-complete receiver checked above");
+        let instance_id =
+            session_instance_id.expect("session instance_id should be set in party mode");
+        let n = session_n_parties.unwrap_or_else(|| {
+            net_opt
+                .as_ref()
+                .map(|net| net.parties().len())
+                .unwrap_or_else(|| n_parties.unwrap_or(0))
+        });
+        let t = session_threshold.unwrap_or(1);
+        let my_id = net_opt
+            .as_ref()
+            .map(|net| net.local_party_id())
+            .unwrap_or_else(|| party_id.unwrap_or(0));
+        let persistent_net = net_opt
+            .as_ref()
+            .expect("persistent coordinator mode requires a party network")
+            .clone();
+
+        if !client_roster.is_empty() {
+            vm.set_client_roster(client_roster.clone());
+        }
+
+        for run_index in 0..persistent_runs {
+            let run_id = u64::try_from(run_index)
+                .ok()
+                .and_then(|idx| idx.checked_add(1))
+                .unwrap_or(u64::MAX);
+            let run_instance_id = instance_id.saturating_add(run_index as u64);
+
+            if run_index > 0 {
+                eprintln!(
+                    "[party {my_id}] persistent run {run_id}: resetting engine to instance_id={run_instance_id}"
+                );
+                engine
+                    .reset_for_next_run(run_instance_id)
+                    .await
+                    .unwrap_or_else(|error| {
+                        eprintln!(
+                            "[party {my_id}] reset_for_next_run failed for run {run_id}: {error}"
+                        );
+                        exit(13);
+                    });
+                if let Err(error) = vm.clear_local_storage() {
+                    eprintln!("[party {my_id}] failed to clear local storage: {error}");
+                    exit(13);
+                }
+                engine.preprocess().await.unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] persistent top-up failed: {error}");
+                    exit(13);
+                });
+            }
+
+            if as_leader {
+                eprintln!("[party {my_id}] persistent run {run_id}: coordinator reset");
+                coord.reset_coord().await.unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] coordinator reset failed: {error}");
+                    exit(13);
+                });
+                reset_hb_node_rpcs_as_designated_party(
+                    &node_rpc_addrs,
+                    n,
+                    t,
+                    cert_der.clone().expect("--cert required"),
+                    key_der.clone().expect("--key required"),
+                )
+                .await
+                .unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] node RPC reset failed: {error}");
+                    exit(13);
+                });
+                eprintln!("[party {my_id}] persistent run {run_id}: node RPC reset complete");
+                coord.start_preprocessing().await.unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] coordinator preprocessing start failed: {error}");
+                    exit(13);
+                });
+            }
+
+            if let Err(e) = collect_hb_coordinator_inputs_for_bls(
+                &mut vm,
+                &engine,
+                &mut coord,
+                node_rpc,
+                &input_ids,
+                client_input_total,
+                client_input_count,
+                &client_input_slots,
+                &client_input_types,
+                program_id,
+                run_id,
+                my_id,
+                as_leader,
+            )
+            .await
+            {
+                eprintln!("[party {my_id}] persistent input collection failed: {e}");
+                exit(13);
+            }
+
+            if as_leader {
+                eprintln!("[party {my_id}] persistent run {run_id}: coordinator -> MPCExecution");
+                coord.start_mpc().await.unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] coordinator MPC start failed: {error}");
+                    exit(13);
+                });
+            }
+            coord
+                .wait_for_round(Round::MPCExecution)
+                .await
+                .unwrap_or_else(|error| {
+                    eprintln!("[party {my_id}] wait for MPCExecution failed: {error}");
+                    exit(13);
+                });
+
+            eprintln!(
+                "Starting persistent VM run {run_id} of '{}'...",
+                agreed_entry
+            );
+            let online_started_at = std::time::Instant::now();
+            let execution_result = vm.execute_async(&agreed_entry, engine.as_ref()).await;
+            eprintln!(
+                "persistent VM run {run_id} complete! elapsed_ms={}",
+                online_started_at.elapsed().as_millis()
+            );
+
+            let result = execution_result.unwrap_or_else(|err| {
+                eprintln!("Execution error in '{}': {}", agreed_entry, err);
+                exit(4);
+            });
+
+            let output_share = if output_ids.is_empty() {
+                None
+            } else {
+                coordinator_output_share_bytes(&mut vm, &result)
+            };
+            let captured_outputs = engine.drain_client_output_records().await;
+
+            if output_share.is_some() || !captured_outputs.is_empty() {
+                let mut output_shares_by_client: Vec<Vec<HbCoordinatorShare<ark_bls12_381::Fr>>> =
+                    vec![Vec::new(); output_ids.len()];
+
+                if let Some(output_share) = output_share {
+                    let share: HbCoordinatorShare<ark_bls12_381::Fr> =
+                        ark_serialize::CanonicalDeserialize::deserialize_compressed(
+                            output_share.as_slice(),
+                        )
+                        .expect("deserialize output share");
+                    for shares in output_shares_by_client.iter_mut() {
+                        shares.push(share.clone());
+                    }
+                }
+
+                for record in captured_outputs {
+                    let Some(shares) = output_shares_by_client.get_mut(record.client_id) else {
+                        eprintln!(
+                            "Execution error in '{}': HoneyBadger output client index {} has no matching coordinator client identity",
+                            agreed_entry, record.client_id
+                        );
+                        exit(4);
+                    };
+                    shares.extend(record.shares);
+                }
+
+                if as_leader {
+                    coord.send_output().await.unwrap_or_else(|error| {
+                        eprintln!("[party {my_id}] coordinator output start failed: {error}");
+                        exit(13);
+                    });
+                }
+                coord
+                    .wait_for_round(Round::OutputDistribution)
+                    .await
+                    .unwrap_or_else(|error| {
+                        eprintln!("[party {my_id}] wait for OutputDistribution failed: {error}");
+                        exit(13);
+                    });
+
+                for (cid, output_shares) in output_ids.iter().zip(output_shares_by_client) {
+                    if output_shares.is_empty() {
+                        continue;
+                    }
+                    if let Err(e) = coord
+                        .send_output_shares(cid.clone(), cid.clone(), output_shares)
+                        .await
+                    {
+                        eprintln!(
+                            "Warning: failed to submit output shares for client {:?}: {}",
+                            cid, e
+                        );
+                    }
+                }
+                if as_leader {
+                    coord.finalize().await.unwrap_or_else(|error| {
+                        eprintln!("[party {my_id}] coordinator finalize failed: {error}");
+                        exit(13);
+                    });
+                }
+            }
+
+            print_vm_result(&mut vm, result);
+            wait_for_hb_run_complete_barrier(
+                &persistent_net,
+                &mut run_complete_rx,
+                my_id,
+                n,
+                run_id,
+                run_instance_id,
+            )
+            .await
+            .unwrap_or_else(|error| {
+                eprintln!("[party {my_id}] persistent run-complete barrier failed: {error}");
+                exit(13);
+            });
+        }
+
+        return;
     }
 
     // Coordinator: signal MPC execution phase

--- a/crates/stoffel-vm-runner/src/bin/stoffel-run.rs
+++ b/crates/stoffel-vm-runner/src/bin/stoffel-run.rs
@@ -24,8 +24,9 @@ use stoffel_vm::net::mpc_engine::{
     AsyncMpcEngine, DurableIdentityDigest, MpcEngine, MpcSessionTopology,
 };
 use stoffel_vm::net::{
-    avss_protocol_instance_id, honeybadger_node_opts_with_truncation,
-    honeybadger_protocol_instance_id, honeybadger_protocol_timeout, spawn_receive_loops_split,
+    avss_protocol_instance_id, honeybadger_node_opts_with_truncation_width,
+    honeybadger_protocol_instance_id, honeybadger_protocol_timeout, mpc_protocol_sender_id,
+    spawn_receive_loops_split,
 };
 use stoffel_vm::net::{
     program_id_from_bytes, register_and_wait_for_session, run_bootnode_with_config,
@@ -74,6 +75,17 @@ struct PlannedPreprocessing {
     n_random: usize,
     n_prandbit: usize,
     n_prandint: usize,
+    preprocessing_bit_width: usize,
+}
+
+/// AVSS preprocessing targets for one program execution. Unlike HoneyBadger,
+/// AVSS accepts program-visible random and Beaver targets directly; its
+/// protocol implementation generates and consumes any extra random shares
+/// needed to construct triples, and rounds triple generation to party groups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PlannedAvssPreprocessing {
+    n_random: usize,
+    n_triples: usize,
 }
 
 fn read_trimmed_u64(path: &str) -> Option<u64> {
@@ -187,6 +199,48 @@ fn plan_preprocessing(
         n_random: n_random as usize,
         n_prandbit: prandbits as usize,
         n_prandint: prandints as usize,
+        preprocessing_bit_width: if prandbits > 0 || prandints > 0 {
+            match demand.prandint_bits {
+                0 => stoffel_vm_types::core_types::DEFAULT_FIXED_POINT_TOTAL_BITS,
+                bits => usize::from(bits),
+            }
+        } else {
+            stoffel_vm_types::core_types::DEFAULT_FIXED_POINT_TOTAL_BITS
+        },
+    }
+}
+
+/// Translate the compiler manifest into AVSS preprocessing targets.
+///
+/// Client input masks are runtime infrastructure and therefore are not part of
+/// the program-visible compiler demand; add them exactly once here. Current
+/// AVSS-aware binaries put all direct randomness in `randoms`. Folding legacy
+/// PRand fields into the same pool keeps older binaries conservatively safe.
+fn plan_avss_preprocessing(
+    demand: &stoffel_vm_types::compiled_binary::PreprocessingDemand,
+    n_client_random: usize,
+) -> PlannedAvssPreprocessing {
+    let with_headroom = |count: u64| {
+        if demand.dynamic {
+            count.saturating_mul(2)
+        } else {
+            count
+        }
+    };
+    let program_random = demand
+        .randoms
+        .saturating_add(demand.prandbits)
+        .saturating_add(demand.prandints);
+    let n_random = with_headroom(program_random)
+        .saturating_add(n_client_random as u64)
+        .try_into()
+        .unwrap_or(usize::MAX);
+    let n_triples = with_headroom(demand.triples)
+        .try_into()
+        .unwrap_or(usize::MAX);
+    PlannedAvssPreprocessing {
+        n_random,
+        n_triples,
     }
 }
 
@@ -2701,24 +2755,27 @@ where
     let n_random = plan.n_random;
     let n_prandbit = plan.n_prandbit;
     let n_prandint = plan.n_prandint;
+    let preprocessing_bit_width = plan.preprocessing_bit_width;
     let protocol_timeout = honeybadger_protocol_timeout();
     eprintln!(
-        "[party {}] Creating MPC node opts (n_triples={}, n_random={}, n_prandbit={}, n_prandint={}, dynamic={}, timeout={}s)",
+        "[party {}] Creating MPC node opts (n_triples={}, n_random={}, n_prandbit={}, n_prandint={}, preprocessing_bits={}, dynamic={}, timeout={}s)",
         my_id,
         n_triples,
         n_random,
         n_prandbit,
         n_prandint,
+        preprocessing_bit_width,
         preprocessing_demand.dynamic,
         protocol_timeout.as_secs()
     );
-    let mpc_opts = honeybadger_node_opts_with_truncation(
+    let mpc_opts = honeybadger_node_opts_with_truncation_width(
         n,
         t,
         n_triples,
         n_random,
         n_prandbit,
         n_prandint,
+        preprocessing_bit_width,
         instance_id,
     )
     .unwrap_or_else(|e| {
@@ -3052,8 +3109,10 @@ struct AvssPartySetup<'a> {
     t: usize,
     instance_id: u64,
     expected_client_count: Option<usize>,
+    coordinator_client_count_hint: usize,
     client_input_count: usize,
     client_input_types: &'a std::collections::BTreeMap<usize, Vec<ShareType>>,
+    preprocessing_demand: stoffel_vm_types::compiled_binary::PreprocessingDemand,
 }
 async fn setup_avss_party_for_curve<F, G>(
     vm: &mut VirtualMachine,
@@ -3071,8 +3130,10 @@ where
         t,
         instance_id,
         expected_client_count,
+        coordinator_client_count_hint,
         client_input_count,
         client_input_types,
+        preprocessing_demand,
     } = setup;
 
     // ---- Phase 1: Wait for clients ----
@@ -3292,7 +3353,22 @@ where
         .map_err(|error| format!("Invalid AVSS MPC topology: {error}"))?
         .with_local_identity(local_identity)
         .with_input_ids(mpc_input_ids);
-    let engine = AvssMpcEngine::<F, G>::from_config(AvssEngineConfig::new(session, sk_i, pk_map))
+    let client_count = input_ids.len().max(coordinator_client_count_hint);
+    let n_client_random = client_count.saturating_mul(client_input_count);
+    let preprocessing_plan = plan_avss_preprocessing(&preprocessing_demand, n_client_random);
+    eprintln!(
+        "[party {}] AVSS preprocessing plan: compiler_triples={} compiler_randoms={} client_masks={} requested_triples={} requested_randoms={} dynamic={}",
+        my_id,
+        preprocessing_demand.triples,
+        preprocessing_demand.randoms,
+        n_client_random,
+        preprocessing_plan.n_triples,
+        preprocessing_plan.n_random,
+        preprocessing_demand.dynamic,
+    );
+    let config = AvssEngineConfig::new(session, sk_i, pk_map)
+        .with_preprocessing_counts(preprocessing_plan.n_random, preprocessing_plan.n_triples);
+    let engine = AvssMpcEngine::<F, G>::from_config(config)
         .await
         .map_err(|e| format!("Failed to create AVSS engine: {}", e))?;
     engine.set_client_output_id_map(input_ids.clone()).await;
@@ -3309,16 +3385,20 @@ where
     let (client_tx, mut client_rx) = tokio::sync::mpsc::channel::<(usize, Vec<u8>)>(4096);
 
     for (peer_id, conn) in &connections {
-        if *peer_id == my_id {
+        let Some(authenticated_sender_id) =
+            mpc_protocol_sender_id(*peer_id, conn.remote_party_id(), n)
+        else {
+            eprintln!(
+                "[AVSS] Ignoring protocol connection with out-of-session transport ID {}",
+                peer_id
+            );
             continue;
-        }
-        let peer_id = *peer_id;
+        };
         let engine = engine.clone();
         let open_message_router = engine.open_message_router();
         let tx = msg_tx.clone();
         let conn = conn.clone();
         let net_clone = net.clone();
-        let authenticated_sender_id = conn.remote_party_id().unwrap_or(peer_id);
         tokio::spawn(async move {
             while let Ok(data) = conn.receive().await {
                 if let Ok(true) =
@@ -3417,8 +3497,13 @@ where
     // ---- Phase 5: Preprocessing ----
     tokio::time::sleep(Duration::from_secs(2)).await;
     eprintln!("[party {}] Starting AVSS preprocessing...", my_id);
+    let preprocessing_started_at = std::time::Instant::now();
     engine.preprocess().await?;
-    eprintln!("[party {}] AVSS preprocessing complete!", my_id);
+    eprintln!(
+        "[party {}] AVSS preprocessing complete! elapsed_ms={}",
+        my_id,
+        preprocessing_started_at.elapsed().as_millis()
+    );
 
     // ---- Phase 6: Client input initialization ----
     if !input_ids.is_empty() {
@@ -3533,6 +3618,7 @@ async fn run_avss_coordinated_party_for_curve<F, G>(
     expected_clients: &[String],
     as_leader: bool,
     agreed_entry: &str,
+    preprocessing_demand: stoffel_vm_types::compiled_binary::PreprocessingDemand,
 ) -> Result<(), String>
 where
     F: SupportedMpcField,
@@ -3584,8 +3670,10 @@ where
             t,
             instance_id,
             expected_client_count: None,
+            coordinator_client_count_hint: input_ids.len(),
             client_input_count: 1,
             client_input_types: &client_input_types,
+            preprocessing_demand,
         },
     )
     .await?;
@@ -3689,9 +3777,14 @@ where
         .map_err(|e| e.to_string())?;
 
     eprintln!("Starting VM execution of '{}'...", agreed_entry);
+    let online_started_at = std::time::Instant::now();
     let result = vm
         .execute(agreed_entry)
         .map_err(|err| format!("Execution error in '{}': {}", agreed_entry, err))?;
+    eprintln!(
+        "online VM execution complete! elapsed_ms={}",
+        online_started_at.elapsed().as_millis()
+    );
 
     let captured_outputs = engine.drain_client_output_records().await;
     if !captured_outputs.is_empty() {
@@ -3740,6 +3833,7 @@ async fn run_avss_coordinated_party(
     expected_clients: &[String],
     as_leader: bool,
     agreed_entry: &str,
+    preprocessing_demand: stoffel_vm_types::compiled_binary::PreprocessingDemand,
 ) -> Result<(), String> {
     match curve_config {
         MpcCurveConfig::Bls12_381 => {
@@ -3757,6 +3851,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -3775,6 +3870,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -3796,6 +3892,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -3814,6 +3911,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -3832,6 +3930,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -3850,6 +3949,7 @@ async fn run_avss_coordinated_party(
                 expected_clients,
                 as_leader,
                 agreed_entry,
+                preprocessing_demand,
             )
             .await
         }
@@ -5261,6 +5361,7 @@ async fn main() {
                         &expected_clients,
                         as_leader,
                         &agreed_entry,
+                        preprocessing_demand,
                     )
                     .await
                     {
@@ -5284,8 +5385,10 @@ async fn main() {
                                 t,
                                 instance_id,
                                 expected_client_count,
+                                coordinator_client_count_hint: 0,
                                 client_input_count,
                                 client_input_types: &client_input_types,
+                                preprocessing_demand,
                             },
                         )
                         .await
@@ -5815,8 +5918,8 @@ Examples:
 mod tests {
     use super::{
         band_pow2, client_transport_recipient, client_transport_targets, field_outputs_to_hex,
-        format_coordinator_outputs, input_client_ids_from_output_ids, plan_preprocessing,
-        render_fixed_point_i64, CoordinatorOutputFormat,
+        format_coordinator_outputs, input_client_ids_from_output_ids, plan_avss_preprocessing,
+        plan_preprocessing, render_fixed_point_i64, CoordinatorOutputFormat,
     };
     use stoffel_vm::net::MpcCurveConfig;
     use stoffel_vm_types::compiled_binary::PreprocessingDemand;
@@ -5827,6 +5930,7 @@ mod tests {
             randoms: 0,
             prandbits,
             prandints,
+            prandint_bits: u16::from(prandints > 0) * 31,
             dynamic,
         }
     }
@@ -5884,6 +5988,7 @@ mod tests {
         assert_eq!(plan.n_prandint, 1);
         assert_eq!(plan.n_triples, 16);
         assert_eq!(plan.n_random, 18);
+        assert_eq!(plan.preprocessing_bit_width, 31);
     }
 
     #[test]
@@ -5917,6 +6022,37 @@ mod tests {
         assert_eq!(stat.n_prandbit, 16);
         assert_eq!(dyn_.n_prandbit, 32);
         assert!(dyn_.n_triples >= stat.n_triples);
+    }
+
+    #[test]
+    fn avss_plan_uses_compiler_demand_and_adds_client_masks() {
+        let demand = PreprocessingDemand {
+            triples: 2,
+            randoms: 3,
+            ..PreprocessingDemand::default()
+        };
+        let plan = plan_avss_preprocessing(&demand, 4);
+        assert_eq!(plan.n_triples, 2);
+        assert_eq!(plan.n_random, 7);
+    }
+
+    #[test]
+    fn avss_plan_has_no_hardcoded_minimum_and_heads_up_dynamic_work() {
+        let clear = plan_avss_preprocessing(&PreprocessingDemand::default(), 0);
+        assert_eq!(clear.n_triples, 0);
+        assert_eq!(clear.n_random, 0);
+
+        let dynamic = PreprocessingDemand {
+            triples: 2,
+            randoms: 3,
+            prandbits: 5,
+            prandints: 1,
+            dynamic: true,
+            ..PreprocessingDemand::default()
+        };
+        let plan = plan_avss_preprocessing(&dynamic, 4);
+        assert_eq!(plan.n_triples, 4);
+        assert_eq!(plan.n_random, 22);
     }
 
     #[test]

--- a/crates/stoffel-vm-runner/src/local_runner.rs
+++ b/crates/stoffel-vm-runner/src/local_runner.rs
@@ -75,6 +75,7 @@ pub struct LocalCoordinatorRunner {
     expected_clients: Option<usize>,
     /// Per-client number of output values to receive via `send_to_client`.
     client_output_counts: std::collections::HashMap<u64, u64>,
+    persistent_runs: usize,
 }
 
 impl LocalCoordinatorRunner {
@@ -97,6 +98,7 @@ impl LocalCoordinatorRunner {
                 client_inputs: Vec::new(),
                 expected_clients: None,
                 client_output_counts: std::collections::HashMap::new(),
+                persistent_runs: 1,
             },
         }
     }
@@ -155,18 +157,23 @@ impl LocalCoordinatorRunner {
 
         let bootnode = socket_with_port_pair()?;
         let mut children = Vec::with_capacity(self.parties + local_clients.len());
-        let mut node_rpc_addrs = Vec::with_capacity(self.parties);
+        let node_rpc_addrs = (0..self.parties)
+            .map(|_| reserve_port().map(|port| SocketAddr::from((Ipv4Addr::LOCALHOST, port))))
+            .collect::<std::io::Result<Vec<_>>>()?;
         children.push(self.spawn_party(
             "leader",
             SpawnPartyContext {
                 program_path: &program_path,
                 identity: &node_identities[0],
+                rpc_addr: node_rpc_addrs[0],
+                all_node_rpc_addrs: &node_rpc_addrs,
+                reset_designated_cert: &node_identities[0].cert_path,
+                preproc_store_dir: temp.path().join("preproc-node0"),
                 role: PartyRole::Leader { bootnode },
                 clients: &local_clients,
                 coord_port,
                 timestamp,
             },
-            &mut node_rpc_addrs,
         )?);
 
         tokio::time::sleep(Duration::from_millis(500)).await;
@@ -177,6 +184,10 @@ impl LocalCoordinatorRunner {
                 SpawnPartyContext {
                     program_path: &program_path,
                     identity,
+                    rpc_addr: node_rpc_addrs[party_id],
+                    all_node_rpc_addrs: &node_rpc_addrs,
+                    reset_designated_cert: &node_identities[0].cert_path,
+                    preproc_store_dir: temp.path().join(format!("preproc-node{party_id}")),
                     role: PartyRole::Follower {
                         party_id,
                         bootnode,
@@ -186,53 +197,57 @@ impl LocalCoordinatorRunner {
                     coord_port,
                     timestamp,
                 },
-                &mut node_rpc_addrs,
             )?);
         }
 
         let timeout = self.timeout;
         let threshold = self.threshold;
         let client_results_future = async {
-            match self.backend {
-                MpcBackendKind::HoneyBadger => {
-                    futures::future::join_all(
-                        local_clients
-                            .iter()
-                            .filter(|client| client.input.has_input())
-                            .cloned()
-                            .map(|client| {
-                                run_honeybadger_offchain_client(
-                                    client,
-                                    node_rpc_addrs.clone(),
-                                    coord_port,
-                                    self.parties,
-                                    threshold,
-                                    timeout,
-                                )
-                            }),
-                    )
-                    .await
-                }
-                MpcBackendKind::Avss => {
-                    futures::future::join_all(
-                        local_clients
-                            .iter()
-                            .filter(|client| client.input.has_input())
-                            .cloned()
-                            .map(|client| {
-                                run_avss_offchain_client(
-                                    client,
-                                    node_rpc_addrs.clone(),
-                                    coord_port,
-                                    self.parties,
-                                    threshold,
-                                    timeout,
-                                )
-                            }),
-                    )
-                    .await
-                }
+            let mut all_results = Vec::new();
+            for _run in 0..self.persistent_runs {
+                let mut run_results = match self.backend {
+                    MpcBackendKind::HoneyBadger => {
+                        futures::future::join_all(
+                            local_clients
+                                .iter()
+                                .filter(|client| client.input.has_input())
+                                .cloned()
+                                .map(|client| {
+                                    run_honeybadger_offchain_client(
+                                        client,
+                                        node_rpc_addrs.clone(),
+                                        coord_port,
+                                        self.parties,
+                                        threshold,
+                                        timeout,
+                                    )
+                                }),
+                        )
+                        .await
+                    }
+                    MpcBackendKind::Avss => {
+                        futures::future::join_all(
+                            local_clients
+                                .iter()
+                                .filter(|client| client.input.has_input())
+                                .cloned()
+                                .map(|client| {
+                                    run_avss_offchain_client(
+                                        client,
+                                        node_rpc_addrs.clone(),
+                                        coord_port,
+                                        self.parties,
+                                        threshold,
+                                        timeout,
+                                    )
+                                }),
+                        )
+                        .await
+                    }
+                };
+                all_results.append(&mut run_results);
             }
+            all_results
         };
         let party_outputs_future = futures::future::join_all(
             children
@@ -336,6 +351,21 @@ impl LocalCoordinatorRunner {
         if self.timeout.is_zero() {
             return Err(LocalCoordinatorRunnerError::Configuration(
                 "timeout must be greater than zero".to_owned(),
+            ));
+        }
+        if self.persistent_runs == 0 {
+            return Err(LocalCoordinatorRunnerError::Configuration(
+                "persistent run count must be greater than zero".to_owned(),
+            ));
+        }
+        if self.persistent_runs > 1 && !matches!(self.backend, MpcBackendKind::HoneyBadger) {
+            return Err(LocalCoordinatorRunnerError::Configuration(
+                "persistent local coordinator runs currently support HoneyBadger only".to_owned(),
+            ));
+        }
+        if self.persistent_runs > 1 && !matches!(self.curve_config, MpcCurveConfig::Bls12_381) {
+            return Err(LocalCoordinatorRunnerError::Configuration(
+                "persistent local coordinator runs currently support bls12-381 only".to_owned(),
             ));
         }
         self.validate_expected_clients()?;
@@ -547,10 +577,7 @@ impl LocalCoordinatorRunner {
         &self,
         name: &str,
         context: SpawnPartyContext<'_>,
-        node_rpc_addrs: &mut Vec<SocketAddr>,
     ) -> LocalCoordinatorRunnerResult<(String, Child)> {
-        let rpc_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, reserve_port()?));
-        node_rpc_addrs.push(rpc_addr);
         let mut command = Command::new(&self.runner_path);
         command
             .arg(context.program_path)
@@ -566,7 +593,7 @@ impl LocalCoordinatorRunner {
             .arg("--off-chain-coord")
             .arg(format!("127.0.0.1:{}", context.coord_port))
             .arg("--rpc-bind")
-            .arg(rpc_addr.to_string())
+            .arg(context.rpc_addr.to_string())
             .arg("--cert")
             .arg(&context.identity.cert_path)
             .arg("--key")
@@ -582,6 +609,25 @@ impl LocalCoordinatorRunner {
             .kill_on_drop(true)
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        if self.persistent_runs > 1 {
+            std::fs::create_dir_all(&context.preproc_store_dir)?;
+            command
+                .arg("--persistent-runs")
+                .arg(self.persistent_runs.to_string())
+                .arg("--preproc-store")
+                .arg(&context.preproc_store_dir)
+                .arg("--node-rpc-addrs")
+                .arg(
+                    context
+                        .all_node_rpc_addrs
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>()
+                        .join(","),
+                )
+                .arg("--node-rpc-designated-party-cert")
+                .arg(context.reset_designated_cert);
+        }
         if !context.clients.is_empty() {
             command
                 .arg("--expected-clients")
@@ -748,6 +794,11 @@ impl LocalCoordinatorRunnerBuilder {
 
     pub fn expected_output_clients(mut self, expected_clients: usize) -> Self {
         self.runner.expected_clients = Some(expected_clients);
+        self
+    }
+
+    pub fn persistent_runs(mut self, runs: usize) -> Self {
+        self.runner.persistent_runs = runs;
         self
     }
 
@@ -1214,6 +1265,10 @@ enum PartyRole {
 struct SpawnPartyContext<'a> {
     program_path: &'a Path,
     identity: &'a NodeIdentity,
+    rpc_addr: SocketAddr,
+    all_node_rpc_addrs: &'a [SocketAddr],
+    reset_designated_cert: &'a Path,
+    preproc_store_dir: PathBuf,
     role: PartyRole,
     clients: &'a [LocalClientIdentity],
     coord_port: u16,

--- a/crates/stoffel-vm-runner/src/local_runner.rs
+++ b/crates/stoffel-vm-runner/src/local_runner.rs
@@ -3,20 +3,21 @@ use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::atomic::{AtomicU16, Ordering};
-use std::sync::OnceLock;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use ark_bls12_381::{Fr, G1Projective};
-use ark_ff::{BigInteger, PrimeField};
-use stoffel_mpc_coordinator_off_chain::tests::fake_coord::{
-    HoneyBadgerCoordinatorConnection, HoneyBadgerCoordinatorRPCServerSharedBase,
-};
+use ark_ec::CurveGroup;
+use ark_ff::{BigInteger, FftField, PrimeField};
+use async_trait::async_trait;
+use jsonrpsee::{core::RpcResult, RpcModule};
 use stoffel_mpc_coordinator_off_chain::{
-    node_rpc::NodeRPCClient as OffChainNodeRPCClient, OffChainCoordinatorClient,
-    OffChainCoordinatorServer,
+    node_rpc::NodeRPCClient as OffChainNodeRPCClient, ClientIdentity, CoordinatorRPCBaseServer,
+    CoordinatorRPCServerConnectionBase, CoordinatorRPCServerSharedBase, OffChainCoordinatorClient,
+    StoffelCoordinatorRPCServer,
 };
 use stoffel_mpc_coordinator_shared::self_signed_certs;
-use stoffel_mpc_coordinator_shared::Coordinator;
+use stoffel_mpc_coordinator_shared::{Coordinator, Round, ShareBound};
 use stoffel_vm_types::compiled_binary::{utils::save_to_file, CompiledBinary};
 use stoffelmpc_mpc::common::share::feldman::FeldmanShamirShare;
 use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
@@ -29,6 +30,102 @@ use stoffel_vm::net::{MpcBackendKind, MpcCurveConfig};
 
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(180);
 const DEFAULT_AUTH_TOKEN: &str = "stoffel-local-coordinator-runner";
+
+/// Curve-generic connection used by the local fake coordinator. The upstream
+/// test helper fixes this connection to BLS12-381 even though its coordinator
+/// state and base RPC implementation are generic over the MPC field/share.
+#[derive(Clone)]
+struct LocalCoordinatorConnection<F: FftField, S: ShareBound<F, ValueType = F>> {
+    base: CoordinatorRPCServerConnectionBase<F, S>,
+}
+
+impl<F, S> stoffel_mpc_coordinator_shared::rpc::RPCServerConnection
+    for LocalCoordinatorConnection<F, S>
+where
+    F: FftField,
+    S: ShareBound<F, ValueType = F>,
+{
+    type Internal = CoordinatorRPCServerSharedBase<F>;
+
+    fn new(internal: Arc<tokio::sync::Mutex<Self::Internal>>, id: ClientIdentity) -> Self {
+        Self {
+            base: CoordinatorRPCServerConnectionBase::new(internal, id),
+        }
+    }
+
+    fn into_rpc(self) -> RpcModule<Self> {
+        let mut rpc = StoffelCoordinatorRPCServer::into_rpc(self.clone());
+        let base_rpc = CoordinatorRPCBaseServer::into_rpc(self.base);
+        rpc.merge(base_rpc)
+            .expect("local coordinator RPC method names must be disjoint");
+        rpc
+    }
+}
+
+#[async_trait]
+impl<F, S> StoffelCoordinatorRPCServer for LocalCoordinatorConnection<F, S>
+where
+    F: FftField,
+    S: ShareBound<F, ValueType = F>,
+{
+    async fn start_preprocessing(&self) -> RpcResult<()> {
+        self.base.transition(Round::Preprocessing).await
+    }
+
+    async fn reserve_input_masks(&self) -> RpcResult<()> {
+        self.base.transition(Round::InputMaskReservation).await
+    }
+
+    async fn collect_inputs(&self) -> RpcResult<()> {
+        self.base.transition(Round::InputCollection).await
+    }
+
+    async fn start_mpc(&self) -> RpcResult<()> {
+        self.base.transition(Round::MPCExecution).await
+    }
+
+    async fn send_output(&self) -> RpcResult<()> {
+        self.base.transition(Round::OutputDistribution).await
+    }
+
+    async fn finalize(&self) -> RpcResult<()> {
+        self.base.transition(Round::ProgramFinished).await
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_local_coordinator<F, S>(
+    program_id: [u8; 32],
+    parties: usize,
+    threshold: usize,
+    node_public_keys: Vec<Vec<u8>>,
+    n_inputs: u64,
+    output_clients: Vec<Vec<u8>>,
+    addr: &str,
+    port: u16,
+    cert_der: Vec<u8>,
+    key_der: Vec<u8>,
+) -> LocalCoordinatorRunnerResult<tokio::task::JoinHandle<()>>
+where
+    F: FftField,
+    S: ShareBound<F, ValueType = F>,
+{
+    let state = CoordinatorRPCServerSharedBase::<F>::new(
+        program_id,
+        parties as u64,
+        threshold as u64,
+        node_public_keys,
+        n_inputs,
+        output_clients,
+    );
+    let shared = Arc::new(tokio::sync::Mutex::new(state));
+    Ok(
+        stoffel_mpc_coordinator_shared::rpc::start_coord::<LocalCoordinatorConnection<F, S>>(
+            addr, port, cert_der, key_der, shared,
+        )
+        .await?,
+    )
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum LocalCoordinatorRunnerError {
@@ -132,23 +229,53 @@ impl LocalCoordinatorRunner {
         let coord_port = reserve_port()?;
         let coord_cert = self_signed_certs::server_cert();
         let (n_inputs, output_clients) = self.coordinator_client_io_binding(&client_bindings)?;
-        let coord_state = HoneyBadgerCoordinatorRPCServerSharedBase::new(
-            program_id,
-            self.parties as u64,
-            self.threshold as u64,
-            node_public_keys,
-            n_inputs,
-            output_clients,
-        );
-        let _coord = OffChainCoordinatorServer::<HoneyBadgerCoordinatorConnection>::start_coord(
-            coord_state,
-            "127.0.0.1",
-            coord_port,
-            self.threshold as u64,
-            coord_cert.cert.der().to_vec(),
-            coord_cert.signing_key.serialize_der(),
-        )
-        .await?;
+        let coord_cert_der = coord_cert.cert.der().to_vec();
+        let coord_key_der = coord_cert.signing_key.serialize_der();
+        macro_rules! start_coordinator {
+            ($field:ty, $share:ty) => {
+                start_local_coordinator::<$field, $share>(
+                    program_id,
+                    self.parties,
+                    self.threshold,
+                    node_public_keys,
+                    n_inputs,
+                    output_clients,
+                    "127.0.0.1",
+                    coord_port,
+                    coord_cert_der,
+                    coord_key_der,
+                )
+                .await?
+            };
+        }
+        let _coord = match (self.backend, self.curve_config) {
+            (MpcBackendKind::HoneyBadger, _) => {
+                start_coordinator!(Fr, RobustShare<Fr>)
+            }
+            (MpcBackendKind::Avss, MpcCurveConfig::Bls12_381) => {
+                start_coordinator!(Fr, FeldmanShamirShare<Fr, G1Projective>)
+            }
+            (MpcBackendKind::Avss, MpcCurveConfig::Bn254) => start_coordinator!(
+                ark_bn254::Fr,
+                FeldmanShamirShare<ark_bn254::Fr, ark_bn254::G1Projective>
+            ),
+            (MpcBackendKind::Avss, MpcCurveConfig::Curve25519) => start_coordinator!(
+                ark_curve25519::Fr,
+                FeldmanShamirShare<ark_curve25519::Fr, ark_curve25519::EdwardsProjective>
+            ),
+            (MpcBackendKind::Avss, MpcCurveConfig::Ed25519) => start_coordinator!(
+                ark_ed25519::Fr,
+                FeldmanShamirShare<ark_ed25519::Fr, ark_ed25519::EdwardsProjective>
+            ),
+            (MpcBackendKind::Avss, MpcCurveConfig::Secp256k1) => start_coordinator!(
+                ark_secp256k1::Fr,
+                FeldmanShamirShare<ark_secp256k1::Fr, ark_secp256k1::Projective>
+            ),
+            (MpcBackendKind::Avss, MpcCurveConfig::Secp256r1) => start_coordinator!(
+                ark_secp256r1::Fr,
+                FeldmanShamirShare<ark_secp256r1::Fr, ark_secp256r1::Projective>
+            ),
+        };
 
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -226,23 +353,50 @@ impl LocalCoordinatorRunner {
                         .await
                     }
                     MpcBackendKind::Avss => {
-                        futures::future::join_all(
-                            local_clients
-                                .iter()
-                                .filter(|client| client.input.has_input())
-                                .cloned()
-                                .map(|client| {
-                                    run_avss_offchain_client(
-                                        client,
-                                        node_rpc_addrs.clone(),
-                                        coord_port,
-                                        self.parties,
-                                        threshold,
-                                        timeout,
-                                    )
-                                }),
-                        )
-                        .await
+                        macro_rules! run_avss_clients {
+                            ($field:ty, $group:ty) => {
+                                futures::future::join_all(
+                                    local_clients
+                                        .iter()
+                                        .filter(|client| {
+                                            client.input.has_input() || client.output_count > 0
+                                        })
+                                        .cloned()
+                                        .map(|client| {
+                                            run_avss_offchain_client::<$field, $group>(
+                                                client,
+                                                node_rpc_addrs.clone(),
+                                                coord_port,
+                                                self.parties,
+                                                threshold,
+                                                timeout,
+                                            )
+                                        }),
+                                )
+                                .await
+                            };
+                        }
+                        match self.curve_config {
+                            MpcCurveConfig::Bls12_381 => {
+                                run_avss_clients!(Fr, G1Projective)
+                            }
+                            MpcCurveConfig::Bn254 => {
+                                run_avss_clients!(ark_bn254::Fr, ark_bn254::G1Projective)
+                            }
+                            MpcCurveConfig::Curve25519 => run_avss_clients!(
+                                ark_curve25519::Fr,
+                                ark_curve25519::EdwardsProjective
+                            ),
+                            MpcCurveConfig::Ed25519 => {
+                                run_avss_clients!(ark_ed25519::Fr, ark_ed25519::EdwardsProjective)
+                            }
+                            MpcCurveConfig::Secp256k1 => {
+                                run_avss_clients!(ark_secp256k1::Fr, ark_secp256k1::Projective)
+                            }
+                            MpcCurveConfig::Secp256r1 => {
+                                run_avss_clients!(ark_secp256r1::Fr, ark_secp256r1::Projective)
+                            }
+                        }
                     }
                 };
                 all_results.append(&mut run_results);
@@ -339,15 +493,6 @@ impl LocalCoordinatorRunner {
         self.curve_config
             .validate_for_backend(self.backend)
             .map_err(|error| LocalCoordinatorRunnerError::Configuration(error.to_string()))?;
-        if matches!(self.backend, MpcBackendKind::Avss)
-            && !self.client_inputs.is_empty()
-            && !matches!(self.curve_config, MpcCurveConfig::Bls12_381)
-        {
-            return Err(LocalCoordinatorRunnerError::Configuration(
-                "local coordinator runner AVSS client inputs currently support the bls12-381 curve"
-                    .to_owned(),
-            ));
-        }
         if self.timeout.is_zero() {
             return Err(LocalCoordinatorRunnerError::Configuration(
                 "timeout must be greater than zero".to_owned(),
@@ -954,7 +1099,7 @@ async fn run_honeybadger_offchain_client(
             .input
             .values
             .iter()
-            .map(|value| parse_input_as_field(value))
+            .map(|value| parse_input_as_field::<Fr>(value))
             .collect::<LocalCoordinatorRunnerResult<Vec<_>>>()?;
         eprintln!(
             "[local-client {}] connecting coordinator",
@@ -1041,7 +1186,7 @@ async fn run_honeybadger_offchain_client(
 
 /// Reduce a field element to its low 64 bits (exact for the small values —
 /// bits, bytes — that client outputs carry in these examples).
-fn fr_to_u64(value: &Fr) -> u64 {
+fn fr_to_u64<F: PrimeField>(value: &F) -> u64 {
     let bytes = value.into_bigint().to_bytes_le();
     let mut buf = [0u8; 8];
     let n = bytes.len().min(8);
@@ -1049,14 +1194,18 @@ fn fr_to_u64(value: &Fr) -> u64 {
     u64::from_le_bytes(buf)
 }
 
-async fn run_avss_offchain_client(
+async fn run_avss_offchain_client<F, G>(
     client: LocalClientIdentity,
     node_rpc_addrs: Vec<SocketAddr>,
     coord_port: u16,
     parties: usize,
     threshold: usize,
     timeout: Duration,
-) -> LocalCoordinatorRunnerResult<Option<ClientOutputRecord>> {
+) -> LocalCoordinatorRunnerResult<Option<ClientOutputRecord>>
+where
+    F: FftField + PrimeField,
+    G: CurveGroup<ScalarField = F>,
+{
     tokio::time::timeout(timeout, async move {
         eprintln!(
             "[local-client {}] starting AVSS off-chain coordinator input submission",
@@ -1066,15 +1215,15 @@ async fn run_avss_offchain_client(
             .input
             .values
             .iter()
-            .map(|value| parse_input_as_field(value))
+            .map(|value| parse_input_as_field::<F>(value))
             .collect::<LocalCoordinatorRunnerResult<Vec<_>>>()?;
-        let mut coord: OffChainCoordinatorClient<Fr, FeldmanShamirShare<Fr, G1Projective>> =
+        let mut coord: OffChainCoordinatorClient<F, FeldmanShamirShare<F, G>> =
             OffChainCoordinatorClient::start_rpc_client(
                 "127.0.0.1",
                 coord_port,
                 threshold as u64,
                 parties as u64,
-                input_values.len() as u64,
+                client.output_count,
                 client.cert_der.clone(),
                 std::fs::read(&client.key_path)?,
             )
@@ -1086,14 +1235,14 @@ async fn run_avss_offchain_client(
                 "[local-client {}] reserving AVSS mask index {}",
                 client.client_slot, index
             );
-            reserve_avss_mask_index_when_ready(&mut coord, index, timeout).await?;
+            reserve_mask_index_when_ready(&mut coord, index, timeout).await?;
         }
 
         let rpc_addrs = node_rpc_addrs
             .iter()
             .map(|addr| (addr.ip().to_string(), addr.port()))
             .collect::<Vec<_>>();
-        let node_rpc: OffChainNodeRPCClient<Fr, FeldmanShamirShare<Fr, G1Projective>> =
+        let node_rpc: OffChainNodeRPCClient<F, FeldmanShamirShare<F, G>> =
             OffChainNodeRPCClient::start_rpc_client(
                 parties,
                 threshold,
@@ -1115,25 +1264,45 @@ async fn run_avss_offchain_client(
                 "[local-client {}] submitting AVSS masked input {}",
                 client.client_slot, index
             );
-            send_avss_masked_input_when_ready(&coord, input + mask, index, timeout).await?;
+            send_masked_input_when_ready(&coord, input + mask, index, timeout).await?;
         }
         eprintln!(
             "[local-client {}] AVSS input submission complete",
             client.client_slot
         );
-        // AVSS client-output reconstruction is not yet wired into the local
-        // runner; HoneyBadger is the path exercised by the client-IO examples.
-        Ok(None)
+        if client.output_count == 0 {
+            return Ok(None);
+        }
+
+        eprintln!(
+            "[local-client {}] obtaining {} AVSS client output value(s)",
+            client.client_slot, client.output_count
+        );
+        let output_values: Vec<F> = coord.obtain_outputs().await?;
+        eprintln!(
+            "[local-client {}] received {} AVSS client output value(s)",
+            client.client_slot,
+            output_values.len()
+        );
+        let values = output_values.iter().map(fr_to_u64).collect::<Vec<_>>();
+        Ok(Some(ClientOutputRecord {
+            client_slot: client.client_slot,
+            values,
+        }))
     })
     .await
     .map_err(|_| LocalCoordinatorRunnerError::Timeout(timeout))?
 }
 
-async fn reserve_mask_index_when_ready(
-    coord: &mut OffChainCoordinatorClient<Fr, RobustShare<Fr>>,
+async fn reserve_mask_index_when_ready<F, S>(
+    coord: &mut OffChainCoordinatorClient<F, S>,
     index: u64,
     timeout: Duration,
-) -> LocalCoordinatorRunnerResult<()> {
+) -> LocalCoordinatorRunnerResult<()>
+where
+    F: FftField,
+    S: ShareBound<F, ValueType = F>,
+{
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         match coord.reserve_mask_index(index).await {
@@ -1149,53 +1318,16 @@ async fn reserve_mask_index_when_ready(
     }
 }
 
-async fn reserve_avss_mask_index_when_ready(
-    coord: &mut OffChainCoordinatorClient<Fr, FeldmanShamirShare<Fr, G1Projective>>,
+async fn send_masked_input_when_ready<F, S>(
+    coord: &OffChainCoordinatorClient<F, S>,
+    masked_input: F,
     index: u64,
     timeout: Duration,
-) -> LocalCoordinatorRunnerResult<()> {
-    let deadline = tokio::time::Instant::now() + timeout;
-    loop {
-        match coord.reserve_mask_index(index).await {
-            Ok(()) => return Ok(()),
-            Err(error) if coordinator_wrong_round(&error) => {
-                if tokio::time::Instant::now() >= deadline {
-                    return Err(LocalCoordinatorRunnerError::Timeout(timeout));
-                }
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-}
-
-async fn send_masked_input_when_ready(
-    coord: &OffChainCoordinatorClient<Fr, RobustShare<Fr>>,
-    masked_input: Fr,
-    index: u64,
-    timeout: Duration,
-) -> LocalCoordinatorRunnerResult<()> {
-    let deadline = tokio::time::Instant::now() + timeout;
-    loop {
-        match coord.send_masked_input(masked_input, index).await {
-            Ok(()) => return Ok(()),
-            Err(error) if coordinator_wrong_round(&error) => {
-                if tokio::time::Instant::now() >= deadline {
-                    return Err(LocalCoordinatorRunnerError::Timeout(timeout));
-                }
-                tokio::time::sleep(Duration::from_millis(50)).await;
-            }
-            Err(error) => return Err(error.into()),
-        }
-    }
-}
-
-async fn send_avss_masked_input_when_ready(
-    coord: &OffChainCoordinatorClient<Fr, FeldmanShamirShare<Fr, G1Projective>>,
-    masked_input: Fr,
-    index: u64,
-    timeout: Duration,
-) -> LocalCoordinatorRunnerResult<()> {
+) -> LocalCoordinatorRunnerResult<()>
+where
+    F: FftField,
+    S: ShareBound<F, ValueType = F>,
+{
     let deadline = tokio::time::Instant::now() + timeout;
     loop {
         match coord.send_masked_input(masked_input, index).await {
@@ -1218,15 +1350,15 @@ fn coordinator_wrong_round(error: &stoffel_mpc_coordinator_shared::CoordinatorEr
         || message.contains("current round is")
 }
 
-fn parse_input_as_field(value: &str) -> LocalCoordinatorRunnerResult<Fr> {
+fn parse_input_as_field<F: PrimeField>(value: &str) -> LocalCoordinatorRunnerResult<F> {
     let value = value.trim();
     // Booleans are advertised by the CLI as valid client inputs; share them
     // as the field bits 1/0 so secret-bool gates work on them.
     if value.eq_ignore_ascii_case("true") {
-        return Ok(Fr::from(1u64));
+        return Ok(F::from(1u64));
     }
     if value.eq_ignore_ascii_case("false") {
-        return Ok(Fr::from(0u64));
+        return Ok(F::from(0u64));
     }
     if let Some(hex) = value
         .strip_prefix("0x")
@@ -1241,14 +1373,14 @@ fn parse_input_as_field(value: &str) -> LocalCoordinatorRunnerResult<Fr> {
                 "invalid hex client input '{value}': {error}"
             ))
         })?;
-        return Ok(Fr::from_be_bytes_mod_order(&bytes));
+        return Ok(F::from_be_bytes_mod_order(&bytes));
     }
     let value = value.parse::<i64>().map_err(|error| {
         LocalCoordinatorRunnerError::Configuration(format!(
             "invalid integer client input '{value}': {error}"
         ))
     })?;
-    Ok(stoffel_vm::net::field_from_i64::<Fr>(value))
+    Ok(stoffel_vm::net::field_from_i64::<F>(value))
 }
 
 enum PartyRole {

--- a/crates/stoffel-vm-runner/tests/local_coordinator_e2e.rs
+++ b/crates/stoffel-vm-runner/tests/local_coordinator_e2e.rs
@@ -185,6 +185,52 @@ def main() -> int64:
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "starts a persistent localhost coordinator, MPC party mesh, and coordinator client"]
+async fn local_offchain_coordinator_persistent_runs_reuse_nodes_and_reset_node_rpc() {
+    let source = r#"
+def main() -> int64:
+  var share = ClientStore.take_share(0, 0)
+  var opened: int64 = share.open()
+  return opened + 5
+"#;
+    let options = stoffellang::CompilerOptions {
+        mpc_backend: stoffel_vm_types::compiled_binary::MpcBackend::HoneyBadger,
+        ..Default::default()
+    };
+    let compiled = stoffellang::compile(source, "<local-runner-persistent-e2e>", &options)
+        .expect("compile persistent client input program");
+    let binary = stoffellang::convert_to_binary(&compiled);
+
+    let output = LocalCoordinatorRunner::builder(env!("CARGO_BIN_EXE_stoffel-run"), binary)
+        .parties(5)
+        .threshold(1)
+        .timeout(Duration::from_secs(300))
+        .client_inputs([LocalClientInput::raw(0, ["42"])])
+        .persistent_runs(3)
+        .build()
+        .expect("local persistent runner config")
+        .run()
+        .await
+        .expect("local persistent coordinator run");
+
+    assert_eq!(
+        output.consistent_returned_values().unwrap(),
+        vec!["47", "47", "47"]
+    );
+    assert_eq!(output.returned_values().len(), 15);
+    assert!(
+        output.combined_output.contains("persistent run 2")
+            && output.combined_output.contains("persistent run 3")
+            && output.combined_output.contains("node RPC reset complete")
+            && output
+                .combined_output
+                .contains("persistent run 2: all parties complete"),
+        "expected persistent reset and completion-barrier markers in output:\n{}",
+        output.combined_output
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 #[ignore = "starts a real localhost coordinator and long-running MPC AES party mesh"]
 async fn local_offchain_coordinator_runs_optimized_aes_circuit_without_docker_compose() {
     // Compiling the optimized AES circuit recurses deeply (the inlined S-box

--- a/crates/stoffel-vm-runner/tests/local_coordinator_e2e.rs
+++ b/crates/stoffel-vm-runner/tests/local_coordinator_e2e.rs
@@ -74,6 +74,13 @@ async fn local_offchain_coordinator_runs_avss_networked_vm_without_docker_compos
 
     assert_eq!(output.returned_values(), vec!["7", "7", "7", "7", "7"]);
     assert_eq!(output.consistent_returned_values().unwrap(), vec!["7"]);
+    assert!(
+        output.combined_output.contains(
+            "compiler_triples=0 compiler_randoms=0 client_masks=0 requested_triples=0 requested_randoms=0"
+        ),
+        "AVSS clear program must not use hardcoded preprocessing defaults:\n{}",
+        output.combined_output
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -143,6 +150,52 @@ def main() -> int64:
 
     assert_eq!(output.returned_values(), vec!["47", "47", "47", "47", "47"]);
     assert_eq!(output.consistent_returned_values().unwrap(), vec!["47"]);
+    assert!(
+        output.combined_output.contains(
+            "compiler_triples=0 compiler_randoms=0 client_masks=1 requested_triples=0 requested_randoms=1"
+        ),
+        "AVSS client input must provision exactly one runtime mask:\n{}",
+        output.combined_output
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "starts a real localhost coordinator, secp256k1 AVSS party mesh, and coordinator client"]
+async fn local_offchain_coordinator_supports_secp256k1_avss_client_io() {
+    let source = r#"
+def main() -> int64:
+  var share = ClientStore.take_share(0, 0)
+  MpcOutput.send_to_client(0, [share])
+  var opened: int64 = share.open()
+  return opened + 5
+"#;
+    let options = stoffellang::CompilerOptions {
+        mpc_backend: stoffel_vm_types::compiled_binary::MpcBackend::Avss,
+        mpc_curve: stoffel_vm_types::compiled_binary::MpcCurve::Secp256k1,
+        ..Default::default()
+    };
+    let compiled = stoffellang::compile(source, "<local-avss-secp256k1-client-e2e>", &options)
+        .expect("compile secp256k1 AVSS client IO program");
+    let binary = stoffellang::convert_to_binary(&compiled);
+
+    let output = LocalCoordinatorRunner::builder(env!("CARGO_BIN_EXE_stoffel-run"), binary)
+        .backend(MpcBackendKind::Avss)
+        .curve(MpcCurveConfig::Secp256k1)
+        .parties(5)
+        .threshold(1)
+        .timeout(Duration::from_secs(180))
+        .client_inputs([LocalClientInput::raw(0, ["42"])])
+        .build()
+        .expect("local runner config")
+        .run()
+        .await
+        .expect("local secp256k1 AVSS coordinator client IO run");
+
+    assert_eq!(output.returned_values(), vec!["47", "47", "47", "47", "47"]);
+    assert_eq!(output.consistent_returned_values().unwrap(), vec!["47"]);
+    assert_eq!(output.client_outputs.len(), 1);
+    assert_eq!(output.client_outputs[0].client_slot, 0);
+    assert_eq!(output.client_outputs[0].values, vec![42]);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/stoffel-vm-types/src/compiled_binary.rs
+++ b/crates/stoffel-vm-types/src/compiled_binary.rs
@@ -27,14 +27,16 @@ use std::io::{self, Read, Write};
 // Magic bytes that identify a StoffelVM bytecode file
 pub const MAGIC_BYTES: &[u8; 4] = b"STFL";
 // Current bytecode format version
-// v9: added LDS/STS spill-slot instructions
-pub const FORMAT_VERSION: u16 = 9;
+// v10: added the maximum required PRandInt bit width to preprocessing demand
+pub const FORMAT_VERSION: u16 = 10;
 pub const CLIENT_IO_MANIFEST_FORMAT_VERSION: u16 = 2;
 pub const MPC_BACKEND_MANIFEST_FORMAT_VERSION: u16 = 3;
 pub const MPC_CURVE_MANIFEST_FORMAT_VERSION: u16 = 4;
 pub const FUNCTION_TYPE_METADATA_FORMAT_VERSION: u16 = 5;
 /// Version at which the client IO manifest carries a `PreprocessingDemand`.
 pub const PREPROCESSING_DEMAND_MANIFEST_FORMAT_VERSION: u16 = 8;
+/// Version at which preprocessing demand records the maximum PRandInt width.
+pub const PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION: u16 = 10;
 
 const MAX_BINARY_COLLECTION_LEN: usize = 1_000_000;
 /// Per-function instruction vectors are allowed to grow far larger than the
@@ -340,6 +342,11 @@ pub struct PreprocessingDemand {
     /// typed `Share.random`, which lowers to it) and one per secret fixed-point
     /// division (truncation).
     pub prandints: u64,
+    /// Maximum bit width required by any PRandInt-backed operation. Counts and
+    /// width are independent: batching changes the former but never the latter.
+    /// Zero means no statically known requirement (or a pre-v10 binary).
+    #[serde(default)]
+    pub prandint_bits: u16,
     /// True when the static estimate may undercount (data-dependent loops,
     /// recursion, or runtime-sized batch operations).
     pub dynamic: bool,
@@ -352,6 +359,13 @@ impl PreprocessingDemand {
         self.randoms = self.randoms.saturating_add(randoms);
         self.prandbits = self.prandbits.saturating_add(prandbits);
         self.prandints = self.prandints.saturating_add(prandints);
+    }
+
+    /// Record a PRandInt width requirement, retaining the widest operation.
+    pub fn require_prandint_bits(&mut self, bit_width: usize) {
+        self.prandint_bits = self
+            .prandint_bits
+            .max(u16::try_from(bit_width).unwrap_or(u16::MAX));
     }
 }
 
@@ -1170,6 +1184,7 @@ impl CompiledBinary {
                 self.version >= MPC_BACKEND_MANIFEST_FORMAT_VERSION,
                 self.version >= MPC_CURVE_MANIFEST_FORMAT_VERSION,
                 self.version >= PREPROCESSING_DEMAND_MANIFEST_FORMAT_VERSION,
+                self.version >= PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION,
                 writer,
             )?;
         }
@@ -1182,6 +1197,7 @@ impl CompiledBinary {
         include_backend: bool,
         include_curve: bool,
         include_demand: bool,
+        include_prandint_bits: bool,
         writer: &mut W,
     ) -> BinaryResult<()> {
         if include_backend {
@@ -1209,6 +1225,9 @@ impl CompiledBinary {
             writer.write_all(&demand.prandbits.to_le_bytes())?;
             writer.write_all(&demand.prandints.to_le_bytes())?;
             writer.write_all(&[u8::from(demand.dynamic)])?;
+            if include_prandint_bits {
+                writer.write_all(&demand.prandint_bits.to_le_bytes())?;
+            }
         }
         Ok(())
     }
@@ -1647,6 +1666,7 @@ impl CompiledBinary {
                 version >= MPC_BACKEND_MANIFEST_FORMAT_VERSION,
                 version >= MPC_CURVE_MANIFEST_FORMAT_VERSION,
                 version >= PREPROCESSING_DEMAND_MANIFEST_FORMAT_VERSION,
+                version >= PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION,
             )?
         } else {
             ClientIoManifest::default()
@@ -1725,6 +1745,7 @@ impl CompiledBinary {
                 version >= MPC_BACKEND_MANIFEST_FORMAT_VERSION,
                 version >= MPC_CURVE_MANIFEST_FORMAT_VERSION,
                 version >= PREPROCESSING_DEMAND_MANIFEST_FORMAT_VERSION,
+                version >= PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION,
             )?
         } else {
             ClientIoManifest::default()
@@ -1798,6 +1819,7 @@ impl CompiledBinary {
                 version >= MPC_BACKEND_MANIFEST_FORMAT_VERSION,
                 version >= MPC_CURVE_MANIFEST_FORMAT_VERSION,
                 version >= PREPROCESSING_DEMAND_MANIFEST_FORMAT_VERSION,
+                version >= PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION,
             )?
         } else {
             ClientIoManifest::default()
@@ -1811,6 +1833,7 @@ impl CompiledBinary {
         has_backend: bool,
         has_curve: bool,
         has_demand: bool,
+        has_prandint_bits: bool,
     ) -> BinaryResult<ClientIoManifest> {
         let mpc_backend = if has_backend {
             Self::deserialize_mpc_backend(reader)?
@@ -1851,12 +1874,23 @@ impl CompiledBinary {
             });
         }
         let preprocessing_demand = if has_demand {
+            let triples = read_u64(reader)?;
+            let randoms = read_u64(reader)?;
+            let prandbits = read_u64(reader)?;
+            let prandints = read_u64(reader)?;
+            let dynamic = read_u8(reader)? != 0;
+            let prandint_bits = if has_prandint_bits {
+                read_u16(reader)?
+            } else {
+                0
+            };
             PreprocessingDemand {
-                triples: read_u64(reader)?,
-                randoms: read_u64(reader)?,
-                prandbits: read_u64(reader)?,
-                prandints: read_u64(reader)?,
-                dynamic: read_u8(reader)? != 0,
+                triples,
+                randoms,
+                prandbits,
+                prandints,
+                prandint_bits,
+                dynamic,
             }
         } else {
             PreprocessingDemand::default()
@@ -3647,7 +3681,8 @@ mod tests {
                     triples: 7,
                     randoms: 2,
                     prandbits: 0,
-                    prandints: 0,
+                    prandints: 1,
+                    prandint_bits: 31,
                     dynamic: false,
                 },
                 ..ClientIoManifest::default()
@@ -3671,6 +3706,27 @@ mod tests {
         assert_eq!(register_counts, vec![17]);
         assert_eq!(manifest.preprocessing_demand.triples, 7);
         assert_eq!(manifest.preprocessing_demand.randoms, 2);
+        assert_eq!(manifest.preprocessing_demand.prandints, 1);
+        assert_eq!(manifest.preprocessing_demand.prandint_bits, 31);
+
+        let mut legacy_binary = binary;
+        legacy_binary.version = PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION - 1;
+        let mut legacy_bytes = Vec::new();
+        legacy_binary.serialize(&mut legacy_bytes).unwrap();
+
+        let (_count, version, legacy_manifest) =
+            CompiledBinary::try_for_each_vm_function_from_reader(
+                &mut Cursor::new(legacy_bytes),
+                |_function| Ok(()),
+            )
+            .unwrap();
+
+        assert_eq!(
+            version,
+            PREPROCESSING_PRANDINT_BITS_MANIFEST_FORMAT_VERSION - 1
+        );
+        assert_eq!(legacy_manifest.preprocessing_demand.prandints, 1);
+        assert_eq!(legacy_manifest.preprocessing_demand.prandint_bits, 0);
     }
 
     #[test]

--- a/crates/stoffel-vm-types/src/compiled_binary.rs
+++ b/crates/stoffel-vm-types/src/compiled_binary.rs
@@ -330,13 +330,15 @@ pub struct ClientIoManifest {
 pub struct PreprocessingDemand {
     /// Beaver triples — one per secret*secret multiplication.
     pub triples: u64,
-    /// Program-visible random shares — masks for inputs/reveals and direct
-    /// random-share requests. Backends may allocate extra internal randoms for
-    /// derived material such as triples.
+    /// Program-visible random field shares — masks for inputs/reveals and
+    /// direct `Share.random_field` requests. Backends may allocate extra
+    /// internal randoms for derived material such as triples.
     pub randoms: u64,
     /// Random bits — `frac_bits` per secret fixed-point division (truncation).
     pub prandbits: u64,
-    /// Random integers — one per secret fixed-point division (truncation).
+    /// Random integers — one per direct `Share.random_int` request (including
+    /// typed `Share.random`, which lowers to it) and one per secret fixed-point
+    /// division (truncation).
     pub prandints: u64,
     /// True when the static estimate may undercount (data-dependent loops,
     /// recursion, or runtime-sized batch operations).

--- a/crates/stoffel-vm-types/src/core_types.rs
+++ b/crates/stoffel-vm-types/src/core_types.rs
@@ -19,7 +19,8 @@ use smallvec::SmallVec;
 use std::any::Any;
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, OnceLock};
 
 const ARRAY_DENSE_INLINE_CAPACITY: usize = 16;
 const ARRAY_DENSE_INDEX_LIMIT: usize = 32;
@@ -810,6 +811,62 @@ pub struct ClearShareInput {
     value: ClearShareValue,
 }
 
+/// A compile/runtime-known public value carried in the secret-share domain.
+///
+/// Keeping this provenance beside the value lets the VM perform public/public
+/// arithmetic exactly and lower secret/public multiplication to local scalar
+/// algebra even after the value crosses function and loop boundaries. The
+/// backend representation is created lazily only when an operation genuinely
+/// needs share bytes (for example persistence or a commitment observer).
+pub struct PublicShare {
+    input: ClearShareInput,
+    materialized: OnceLock<ShareData>,
+}
+
+impl PublicShare {
+    pub fn new(input: ClearShareInput) -> Self {
+        Self {
+            input,
+            materialized: OnceLock::new(),
+        }
+    }
+
+    pub const fn input(&self) -> ClearShareInput {
+        self.input
+    }
+
+    pub fn materialized(&self) -> Option<&ShareData> {
+        self.materialized.get()
+    }
+
+    pub fn set_materialized(&self, share: ShareData) -> Result<(), ShareData> {
+        self.materialized.set(share)
+    }
+}
+
+impl PartialEq for PublicShare {
+    fn eq(&self, other: &Self) -> bool {
+        self.input == other.input
+    }
+}
+
+impl Eq for PublicShare {}
+
+impl Hash for PublicShare {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.input.hash(state);
+    }
+}
+
+impl fmt::Debug for PublicShare {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PublicShare")
+            .field("input", &self.input)
+            .field("materialized", &self.materialized.get())
+            .finish()
+    }
+}
+
 impl ClearShareInput {
     pub const fn new(share_type: ShareType, value: ClearShareValue) -> Self {
         Self { share_type, value }
@@ -852,8 +909,155 @@ impl ShareDataFormat {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+/// A process-local share expression whose interactive multiplications have not
+/// necessarily been issued to the MPC backend yet.
+///
+/// Deferred expressions are an execution detail, never a wire format. Their
+/// monotonically increasing identity makes shared subexpressions cheap to
+/// recognize without comparing (potentially very large) expression trees.
+pub struct DeferredShare {
+    id: u64,
+    share_type: ShareType,
+    format: ShareDataFormat,
+    operation: DeferredShareOperation,
+    resolved: OnceLock<ShareData>,
+}
+
+impl DeferredShare {
+    fn new(
+        share_type: ShareType,
+        format: ShareDataFormat,
+        operation: DeferredShareOperation,
+    ) -> Self {
+        static NEXT_DEFERRED_SHARE_ID: AtomicU64 = AtomicU64::new(1);
+
+        Self {
+            id: NEXT_DEFERRED_SHARE_ID.fetch_add(1, Ordering::Relaxed),
+            share_type,
+            format,
+            operation,
+            resolved: OnceLock::new(),
+        }
+    }
+
+    pub const fn id(&self) -> u64 {
+        self.id
+    }
+
+    pub const fn share_type(&self) -> ShareType {
+        self.share_type
+    }
+
+    pub const fn format(&self) -> ShareDataFormat {
+        self.format
+    }
+
+    pub const fn operation(&self) -> &DeferredShareOperation {
+        &self.operation
+    }
+
+    pub fn resolved(&self) -> Option<&ShareData> {
+        self.resolved.get()
+    }
+
+    /// Cache the materialized value of this expression. A second resolver may
+    /// race with the first one, so callers should treat an already-filled cell
+    /// as success and read the winner through [`Self::resolved`].
+    pub fn set_resolved(&self, share_data: ShareData) -> Result<(), ShareData> {
+        self.resolved.set(share_data)
+    }
+}
+
+impl PartialEq for DeferredShare {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for DeferredShare {}
+
+impl Hash for DeferredShare {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl fmt::Debug for DeferredShare {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DeferredShare")
+            .field("id", &self.id)
+            .field("share_type", &self.share_type)
+            .field("format", &self.format)
+            .field("operation", &self.operation.kind_name())
+            .field("resolved", &self.resolved.get().is_some())
+            .finish()
+    }
+}
+
+/// Pure share-algebra nodes retained around deferred interactive products.
+/// Only `Multiply` consumes an MPC communication round; every other variant is
+/// evaluated locally once its operands have become materialized.
+#[derive(Clone, Debug)]
+pub enum DeferredShareOperation {
+    Multiply { left: ShareData, right: ShareData },
+    Add { left: ShareData, right: ShareData },
+    Sub { left: ShareData, right: ShareData },
+    Neg { share: ShareData },
+    AddScalar { share: ShareData, scalar: i64 },
+    SubScalar { share: ShareData, scalar: i64 },
+    ScalarSub { scalar: i64, share: ShareData },
+    DivScalar { share: ShareData, scalar: i64 },
+    MulScalar { share: ShareData, scalar: i64 },
+    MulField { share: ShareData, scalar: Arc<[u8]> },
+    AddField { share: ShareData, field: Arc<[u8]> },
+}
+
+impl DeferredShareOperation {
+    pub const fn is_multiply(&self) -> bool {
+        matches!(self, Self::Multiply { .. })
+    }
+
+    pub const fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Multiply { .. } => "multiply",
+            Self::Add { .. } => "add",
+            Self::Sub { .. } => "subtract",
+            Self::Neg { .. } => "negate",
+            Self::AddScalar { .. } => "add-scalar",
+            Self::SubScalar { .. } => "subtract-scalar",
+            Self::ScalarSub { .. } => "scalar-subtract",
+            Self::DivScalar { .. } => "divide-scalar",
+            Self::MulScalar { .. } => "multiply-scalar",
+            Self::MulField { .. } => "multiply-field",
+            Self::AddField { .. } => "add-field",
+        }
+    }
+
+    pub fn visit_operands(&self, mut visit: impl FnMut(&ShareData)) {
+        match self {
+            Self::Multiply { left, right }
+            | Self::Add { left, right }
+            | Self::Sub { left, right } => {
+                visit(left);
+                visit(right);
+            }
+            Self::Neg { share }
+            | Self::AddScalar { share, .. }
+            | Self::SubScalar { share, .. }
+            | Self::ScalarSub { share, .. }
+            | Self::DivScalar { share, .. }
+            | Self::MulScalar { share, .. }
+            | Self::MulField { share, .. }
+            | Self::AddField { share, .. } => visit(share),
+        }
+    }
+}
+
+#[derive(Clone)]
 pub enum ShareData {
+    /// A value publicly known to all parties but represented in the share type
+    /// domain. Backend bytes are materialized lazily when required.
+    Public(Arc<PublicShare>),
     /// Opaque share bytes (e.g., HoneyBadger RobustShare).
     ///
     /// Stored as `Arc<[u8]>` so cloning a share — which happens on every
@@ -869,44 +1073,171 @@ pub enum ShareData {
         /// Extracted Feldman commitments — commitment\[0\] is the public key
         commitments: Arc<[Vec<u8>]>,
     },
+    /// Process-local deferred share expression. This variant must be resolved
+    /// before serialization, persistence, or a protocol observation.
+    Deferred(Arc<DeferredShare>),
 }
 
 impl ShareData {
+    pub fn public(input: ClearShareInput) -> Self {
+        Self::Public(Arc::new(PublicShare::new(input)))
+    }
+
+    pub fn public_input(&self) -> Option<ClearShareInput> {
+        match self {
+            Self::Public(public) => Some(public.input()),
+            Self::Deferred(node) => node.resolved().and_then(ShareData::public_input),
+            Self::Opaque(_) | Self::Feldman { .. } => None,
+        }
+    }
+
+    pub fn deferred(
+        share_type: ShareType,
+        format: ShareDataFormat,
+        operation: DeferredShareOperation,
+    ) -> Self {
+        Self::Deferred(Arc::new(DeferredShare::new(share_type, format, operation)))
+    }
+
+    pub fn deferred_multiply(share_type: ShareType, left: ShareData, right: ShareData) -> Self {
+        debug_assert_eq!(left.format(), right.format());
+        let format = left.format();
+        Self::deferred(
+            share_type,
+            format,
+            DeferredShareOperation::Multiply { left, right },
+        )
+    }
+
+    pub fn deferred_node(&self) -> Option<&Arc<DeferredShare>> {
+        match self {
+            Self::Deferred(node) => Some(node),
+            Self::Public(_) | Self::Opaque(_) | Self::Feldman { .. } => None,
+        }
+    }
+
+    pub fn is_deferred(&self) -> bool {
+        matches!(self, Self::Deferred(node) if node.resolved().is_none())
+    }
+
+    pub fn materialized(&self) -> Option<&ShareData> {
+        match self {
+            Self::Opaque(_) | Self::Feldman { .. } => Some(self),
+            Self::Public(public) => public.materialized().and_then(ShareData::materialized),
+            Self::Deferred(node) => node.resolved().and_then(ShareData::materialized),
+        }
+    }
+
     /// Share bytes for MPC engine operations (multiply, open, etc.)
     pub fn as_bytes(&self) -> &[u8] {
-        match self {
+        match self
+            .materialized()
+            .unwrap_or_else(|| panic!("attempted to access unresolved deferred share bytes"))
+        {
             ShareData::Opaque(b) => b,
             ShareData::Feldman { data, .. } => data,
+            ShareData::Public(_) => unreachable!("materialized public shares carry backend data"),
+            ShareData::Deferred(_) => unreachable!("materialized shares cannot be deferred"),
         }
     }
 
     /// Consume and return the share bytes.
     pub fn into_bytes(self) -> Vec<u8> {
         match self {
+            ShareData::Public(public) => public
+                .materialized()
+                .cloned()
+                .expect("attempted to consume unmaterialized public share bytes")
+                .into_bytes(),
             ShareData::Opaque(b) => b.to_vec(),
             ShareData::Feldman { data, .. } => data.to_vec(),
+            ShareData::Deferred(node) => node
+                .resolved()
+                .cloned()
+                .expect("attempted to consume unresolved deferred share bytes")
+                .into_bytes(),
         }
     }
 
     /// Feldman commitments, if available.
     pub fn commitments(&self) -> Option<&[Vec<u8>]> {
         match self {
+            ShareData::Public(public) => public.materialized().and_then(ShareData::commitments),
             ShareData::Opaque(_) => None,
             ShareData::Feldman { commitments, .. } => Some(commitments),
+            ShareData::Deferred(node) => node.resolved().and_then(ShareData::commitments),
         }
     }
 
     /// Representation format carried by this share payload.
     pub fn format(&self) -> ShareDataFormat {
         match self {
+            ShareData::Public(public) => public
+                .materialized()
+                .map(ShareData::format)
+                .unwrap_or(ShareDataFormat::Opaque),
             ShareData::Opaque(_) => ShareDataFormat::Opaque,
             ShareData::Feldman { .. } => ShareDataFormat::Feldman,
+            ShareData::Deferred(node) => node.format(),
         }
     }
 
     /// Whether this share carries Feldman commitments.
     pub fn has_commitments(&self) -> bool {
         self.format() == ShareDataFormat::Feldman
+    }
+}
+
+impl PartialEq for ShareData {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Public(left), Self::Public(right)) => left == right,
+            (Self::Opaque(left), Self::Opaque(right)) => left == right,
+            (
+                Self::Feldman {
+                    data: left_data,
+                    commitments: left_commitments,
+                },
+                Self::Feldman {
+                    data: right_data,
+                    commitments: right_commitments,
+                },
+            ) => left_data == right_data && left_commitments == right_commitments,
+            (Self::Deferred(left), Self::Deferred(right)) => left == right,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for ShareData {}
+
+impl Hash for ShareData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        std::mem::discriminant(self).hash(state);
+        match self {
+            Self::Public(public) => public.hash(state),
+            Self::Opaque(bytes) => bytes.hash(state),
+            Self::Feldman { data, commitments } => {
+                data.hash(state);
+                commitments.hash(state);
+            }
+            Self::Deferred(node) => node.hash(state),
+        }
+    }
+}
+
+impl fmt::Debug for ShareData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Public(public) => f.debug_tuple("Public").field(public).finish(),
+            Self::Opaque(bytes) => f.debug_tuple("Opaque").field(bytes).finish(),
+            Self::Feldman { data, commitments } => f
+                .debug_struct("Feldman")
+                .field("data", data)
+                .field("commitments", commitments)
+                .finish(),
+            Self::Deferred(node) => f.debug_tuple("Deferred").field(node).finish(),
+        }
     }
 }
 

--- a/crates/stoffel-vm-types/src/lib.rs
+++ b/crates/stoffel-vm-types/src/lib.rs
@@ -3,4 +3,5 @@ pub mod compiled_binary;
 pub mod core_types;
 pub mod functions;
 pub mod instructions;
+pub mod mpc;
 pub mod registers;

--- a/crates/stoffel-vm-types/src/mpc.rs
+++ b/crates/stoffel-vm-types/src/mpc.rs
@@ -1,0 +1,38 @@
+//! Backend-independent MPC execution limits shared by the compiler and runtime.
+
+/// Environment override for the number of secret-pair multiply operands in one
+/// HoneyBadger multiplication session.
+pub const HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV: &str = "STOFFEL_HB_MUL_MAX_PAIRS_PER_SESSION";
+
+/// Number of `(threshold + 1)` reconstruction groups accepted by the default
+/// HoneyBadger multiplication session.
+pub const DEFAULT_HONEYBADGER_MUL_BATCH_RECON_CHUNKS: usize = 128;
+
+/// The default number of pairwise products HoneyBadger can execute in one
+/// online round for a topology with Byzantine threshold `threshold`.
+///
+/// `override_pairs` is deliberately explicit: callers decide where process
+/// configuration is read, keeping this shared capability calculation pure.
+pub const fn honeybadger_mul_batch_capacity(
+    threshold: usize,
+    override_pairs: Option<usize>,
+) -> usize {
+    if let Some(value) = override_pairs {
+        return if value == 0 { 1 } else { value };
+    }
+    DEFAULT_HONEYBADGER_MUL_BATCH_RECON_CHUNKS.saturating_mul(threshold.saturating_add(1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn honeybadger_capacity_tracks_threshold_and_override() {
+        assert_eq!(honeybadger_mul_batch_capacity(0, None), 128);
+        assert_eq!(honeybadger_mul_batch_capacity(1, None), 256);
+        assert_eq!(honeybadger_mul_batch_capacity(2, None), 384);
+        assert_eq!(honeybadger_mul_batch_capacity(9, Some(17)), 17);
+        assert_eq!(honeybadger_mul_batch_capacity(9, Some(0)), 1);
+    }
+}

--- a/crates/stoffel-vm/src/core_vm/effect_scheduler.rs
+++ b/crates/stoffel-vm/src/core_vm/effect_scheduler.rs
@@ -36,6 +36,9 @@ impl AsyncEffectScheduler {
         loop {
             match state.run_until_effect_or_budget_to_depth(checkpoint, self.local_budget)? {
                 VmRunSlice::Complete(value) => {
+                    let value = state
+                        .materialize_deferred_return_value(engine, value)
+                        .await?;
                     progress.report_final();
                     return Ok(value);
                 }

--- a/crates/stoffel-vm/src/core_vm/execution.rs
+++ b/crates/stoffel-vm/src/core_vm/execution.rs
@@ -238,6 +238,12 @@ impl VirtualMachine {
         })
     }
 
+    /// Clear configured LocalStorage for a new isolated runtime execution.
+    pub fn clear_local_storage(&mut self) -> VirtualMachineResult<()> {
+        self.state.clear_local_storage()?;
+        Ok(())
+    }
+
     fn foreign_entry_error(function: &str) -> VmError {
         VmError::CannotExecuteForeignFunction {
             function: function.to_owned(),

--- a/crates/stoffel-vm/src/core_vm/tests.rs
+++ b/crates/stoffel-vm/src/core_vm/tests.rs
@@ -47,9 +47,13 @@ fn callback_error(error: &VirtualMachineError) -> &ForeignFunctionCallbackError 
 }
 
 fn compile_vm_source(source: &str) -> VirtualMachine {
+    compile_vm_source_at(source, 0)
+}
+
+fn compile_vm_source_at(source: &str, optimization_level: u8) -> VirtualMachine {
     let options = stoffellang::CompilerOptions {
-        optimize: false,
-        optimization_level: 0,
+        optimize: optimization_level > 0,
+        optimization_level,
         print_ir: false,
         mpc_backend: MpcBackend::HoneyBadger,
         mpc_curve: MpcCurve::default(),
@@ -57,6 +61,7 @@ fn compile_vm_source(source: &str) -> VirtualMachine {
         inline_budget: None,
         unroll_budget: None,
         unroll_max_expansion: None,
+        mpc_mul_batch_capacity: None,
     };
     let program =
         stoffellang::compile(source, "vm-test.stfl", &options).expect("test source should compile");
@@ -584,17 +589,30 @@ impl AsyncMpcEngine for AsyncBatchOpenEngine {
 }
 
 struct AsyncBatchMulEngine {
+    batch_capacity: Option<usize>,
     sync_mul_calls: AtomicUsize,
     sync_batch_calls: AtomicUsize,
     async_batch_calls: AtomicUsize,
+    async_batch_sizes: Mutex<Vec<usize>>,
+    async_batch_open_calls: AtomicUsize,
 }
 
 impl AsyncBatchMulEngine {
     fn new() -> Self {
         Self {
+            batch_capacity: None,
             sync_mul_calls: AtomicUsize::new(0),
             sync_batch_calls: AtomicUsize::new(0),
             async_batch_calls: AtomicUsize::new(0),
+            async_batch_sizes: Mutex::new(Vec::new()),
+            async_batch_open_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn with_capacity(batch_capacity: usize) -> Self {
+        Self {
+            batch_capacity: Some(batch_capacity),
+            ..Self::new()
         }
     }
 }
@@ -612,6 +630,10 @@ impl MpcEngine for AsyncBatchMulEngine {
         true
     }
 
+    fn multiplication_batch_capacity(&self) -> Option<usize> {
+        self.batch_capacity
+    }
+
     fn start(&self) -> MpcEngineResult<()> {
         Ok(())
     }
@@ -620,8 +642,34 @@ impl MpcEngine for AsyncBatchMulEngine {
         Ok(ShareData::Opaque(Vec::new().into()))
     }
 
+    fn mul_share_scalar_local(
+        &self,
+        _ty: ShareType,
+        share_bytes: &[u8],
+        scalar: i64,
+    ) -> crate::net::share_algebra::ShareAlgebraResult<Vec<u8>> {
+        Ok(vec![share_bytes
+            .first()
+            .copied()
+            .unwrap_or_default()
+            .wrapping_mul(scalar as u8)])
+    }
+
     fn open_share(&self, _ty: ShareType, _share_bytes: &[u8]) -> MpcEngineResult<ClearShareValue> {
         Err(MpcEngineError::operation_failed("open_share", "not used"))
+    }
+
+    fn batch_open_shares(
+        &self,
+        _ty: ShareType,
+        shares: &[Vec<u8>],
+    ) -> MpcEngineResult<Vec<ClearShareValue>> {
+        Ok(shares
+            .iter()
+            .map(
+                |share| ClearShareValue::Integer(share.first().copied().unwrap_or_default() as i64),
+            )
+            .collect())
     }
 
     fn capabilities(&self) -> MpcCapabilities {
@@ -684,6 +732,7 @@ impl AsyncMpcEngine for AsyncBatchMulEngine {
         pairs: &[(Vec<u8>, Vec<u8>)],
     ) -> MpcEngineResult<Vec<ShareData>> {
         self.async_batch_calls.fetch_add(1, Ordering::SeqCst);
+        self.async_batch_sizes.lock().push(pairs.len());
         Ok(pairs
             .iter()
             .map(|(left, right)| {
@@ -697,13 +746,213 @@ impl AsyncMpcEngine for AsyncBatchMulEngine {
     async fn open_share_async(
         &self,
         _ty: ShareType,
-        _share_bytes: &[u8],
+        share_bytes: &[u8],
     ) -> MpcEngineResult<ClearShareValue> {
-        Err(MpcEngineError::operation_failed(
-            "async_open_share",
-            "not used",
+        Ok(ClearShareValue::Integer(
+            share_bytes.first().copied().unwrap_or_default() as i64,
         ))
     }
+
+    async fn batch_open_shares_async(
+        &self,
+        _ty: ShareType,
+        shares: &[Vec<u8>],
+    ) -> MpcEngineResult<Vec<ClearShareValue>> {
+        self.async_batch_open_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(shares
+            .iter()
+            .map(
+                |share| ClearShareValue::Integer(share.first().copied().unwrap_or_default() as i64),
+            )
+            .collect())
+    }
+}
+
+#[tokio::test]
+async fn runtime_scheduler_batches_independent_singular_multiplications() {
+    let source = r#"
+def main(a: secret int64, b: secret int64, c: secret int64, d: secret int64) -> list[secret int64]:
+  var first = Share.mul(a, b)
+  var second = Share.mul(c, d)
+  return [first, second]
+"#;
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+    let ty = ShareType::secret_int(64);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[
+                Value::Share(ty, ShareData::Opaque(vec![2].into())),
+                Value::Share(ty, ShareData::Opaque(vec![3].into())),
+                Value::Share(ty, ShareData::Opaque(vec![4].into())),
+                Value::Share(ty, ShareData::Opaque(vec![5].into())),
+            ],
+            engine.as_ref(),
+        )
+        .await
+        .expect("singular products should be deferred and batched at return");
+
+    assert_eq!(
+        read_vm_array(&mut vm, result),
+        vec![
+            Value::Share(ty, ShareData::Opaque(vec![6].into())),
+            Value::Share(ty, ShareData::Opaque(vec![20].into())),
+        ]
+    );
+    assert_eq!(*engine.async_batch_sizes.lock(), vec![2]);
+}
+
+#[tokio::test]
+async fn runtime_scheduler_respects_singular_multiplication_dependencies() {
+    let source = r#"
+def main(a: secret int64, b: secret int64, c: secret int64, d: secret int64) -> secret int64:
+  var first = Share.mul(a, b)
+  var second = Share.mul(c, d)
+  return Share.mul(first, second)
+"#;
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+    let ty = ShareType::secret_int(64);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[
+                Value::Share(ty, ShareData::Opaque(vec![2].into())),
+                Value::Share(ty, ShareData::Opaque(vec![3].into())),
+                Value::Share(ty, ShareData::Opaque(vec![4].into())),
+                Value::Share(ty, ShareData::Opaque(vec![5].into())),
+            ],
+            engine.as_ref(),
+        )
+        .await
+        .expect("dependent singular products should resolve in legal rounds");
+
+    assert_eq!(
+        result,
+        Value::Share(ty, ShareData::Opaque(vec![120].into()))
+    );
+    assert_eq!(*engine.async_batch_sizes.lock(), vec![2, 1]);
+}
+
+#[tokio::test]
+async fn runtime_scheduler_honors_backend_multiplication_capacity() {
+    let source = r#"
+def main(a: secret int64, b: secret int64, c: secret int64, d: secret int64) -> list[secret int64]:
+  return [Share.mul(a, b), Share.mul(a, c), Share.mul(a, d)]
+"#;
+    let engine = Arc::new(AsyncBatchMulEngine::with_capacity(2));
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+    let ty = ShareType::secret_int(64);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[
+                Value::Share(ty, ShareData::Opaque(vec![2].into())),
+                Value::Share(ty, ShareData::Opaque(vec![3].into())),
+                Value::Share(ty, ShareData::Opaque(vec![4].into())),
+                Value::Share(ty, ShareData::Opaque(vec![5].into())),
+            ],
+            engine.as_ref(),
+        )
+        .await
+        .expect("capacity-bounded singular products should execute");
+
+    assert_eq!(
+        read_vm_array(&mut vm, result),
+        vec![
+            Value::Share(ty, ShareData::Opaque(vec![6].into())),
+            Value::Share(ty, ShareData::Opaque(vec![8].into())),
+            Value::Share(ty, ShareData::Opaque(vec![10].into())),
+        ]
+    );
+    assert_eq!(*engine.async_batch_sizes.lock(), vec![2, 1]);
+}
+
+#[tokio::test]
+async fn public_products_and_reveals_do_not_start_online_mpc_rounds() {
+    let source = r#"
+def main() -> int64:
+  var left = Share.from_clear_int(6, 64)
+  var right = Share.from_clear_int(7, 64)
+  return Share.open(Share.mul(left, right))
+"#;
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+
+    let result = vm
+        .execute_async("main", engine.as_ref())
+        .await
+        .expect("public product should remain local through its reveal");
+
+    assert_eq!(result, Value::I64(42));
+    assert!(engine.async_batch_sizes.lock().is_empty());
+    assert_eq!(engine.async_batch_open_calls.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn public_products_do_not_require_a_multiplication_backend_capability() {
+    let source = r#"
+def main() -> int64:
+  var left = Share.from_clear_int(6, 64)
+  var right = Share.from_clear_int(7, 64)
+  return Share.open(Share.mul(left, right))
+"#;
+    let engine = Arc::new(BarrierInputEngine::new(1));
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+
+    let result = vm
+        .execute_async("main", engine.as_ref())
+        .await
+        .expect("a public product should not require Beaver multiplication support");
+
+    assert_eq!(result, Value::I64(42));
+    assert_eq!(engine.input_started.load(Ordering::SeqCst), 0);
+}
+
+#[tokio::test]
+async fn public_share_provenance_crosses_loops_and_calls() {
+    let source = r#"
+def scale(value: secret int64, factor: secret int64) -> secret int64:
+  return Share.mul(value, factor)
+
+def main(value: secret int64) -> int64:
+  var factor = Share.from_clear_int(1, 64)
+  var two = Share.from_clear_int(2, 64)
+  for i in 0..3:
+    factor = Share.mul(factor, two)
+  return Share.open(scale(value, factor))
+"#;
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 0);
+    vm.set_mpc_engine(runtime_engine);
+    let ty = ShareType::secret_int(64);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[Value::Share(ty, ShareData::Opaque(vec![6].into()))],
+            engine.as_ref(),
+        )
+        .await
+        .expect("secret by public multiplication should lower to local algebra");
+
+    assert_eq!(result, Value::I64(48));
+    assert!(engine.async_batch_sizes.lock().is_empty());
 }
 
 struct BarrierConsensusEngine {
@@ -3067,7 +3316,7 @@ async fn execute_many_async_single_invocation_uses_async_entry_path() {
 }
 
 #[tokio::test]
-async fn execute_many_async_yields_on_share_from_clear_builtin_call() {
+async fn execute_many_async_keeps_share_from_clear_and_reveal_local() {
     let engine = Arc::new(BarrierInputEngine::new(2));
     let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
     let mut vm = VirtualMachine::builder()
@@ -3088,13 +3337,13 @@ async fn execute_many_async_yields_on_share_from_clear_builtin_call() {
         vm.execute_many_async(["from_clear_first", "from_clear_second"], engine.as_ref()),
     )
     .await
-    .expect("Share.from_clear calls should both reach the async input barrier")
-    .expect("batched async share construction should succeed");
+    .expect("public share operations should complete without waiting on the input barrier")
+    .expect("batched public share construction should succeed");
 
     assert_eq!(result, vec![Value::I64(17), Value::I64(23)]);
     assert_eq!(engine.sync_input_calls.load(Ordering::SeqCst), 0);
-    assert_eq!(engine.input_started.load(Ordering::SeqCst), 2);
-    assert_eq!(engine.input_finished.load(Ordering::SeqCst), 2);
+    assert_eq!(engine.input_started.load(Ordering::SeqCst), 0);
+    assert_eq!(engine.input_finished.load(Ordering::SeqCst), 0);
 }
 
 #[tokio::test]
@@ -3613,8 +3862,7 @@ fn turmoil_async_mpc_builtins_cover_every_async_backend_operation() -> turmoil::
 }
 
 #[test]
-fn turmoil_secret_register_program_resumes_across_networked_input_mul_and_open() -> turmoil::Result
-{
+fn turmoil_public_secret_register_math_avoids_network_rounds() -> turmoil::Result {
     let mut sim = turmoil::Builder::new()
         .rng_seed(0x5241_4d31)
         .simulation_duration(Duration::from_secs(10))
@@ -3658,12 +3906,12 @@ fn turmoil_secret_register_program_resumes_across_networked_input_mul_and_open()
             .execute_async("secret_register_math", engine.as_ref())
             .await?;
         assert_eq!(result, Value::I64(52));
-        assert_eq!(engine.started(TurmoilAsyncOperation::InputShare), 2);
-        assert_eq!(engine.finished(TurmoilAsyncOperation::InputShare), 2);
-        assert_eq!(engine.started(TurmoilAsyncOperation::Multiply), 1);
-        assert_eq!(engine.finished(TurmoilAsyncOperation::Multiply), 1);
-        assert_eq!(engine.started(TurmoilAsyncOperation::Open), 1);
-        assert_eq!(engine.finished(TurmoilAsyncOperation::Open), 1);
+        assert_eq!(engine.started(TurmoilAsyncOperation::InputShare), 0);
+        assert_eq!(engine.finished(TurmoilAsyncOperation::InputShare), 0);
+        assert_eq!(engine.started(TurmoilAsyncOperation::Multiply), 0);
+        assert_eq!(engine.finished(TurmoilAsyncOperation::Multiply), 0);
+        assert_eq!(engine.started(TurmoilAsyncOperation::Open), 0);
+        assert_eq!(engine.finished(TurmoilAsyncOperation::Open), 0);
         Ok(())
     });
 
@@ -3743,9 +3991,9 @@ fn turmoil_execute_many_async_runs_mixed_programs_under_randomized_network_order
                 Value::I64(32),
             ]
         );
-        assert_eq!(engine.started(TurmoilAsyncOperation::InputShare), 2);
-        assert_eq!(engine.started(TurmoilAsyncOperation::Multiply), 1);
-        assert_eq!(engine.started(TurmoilAsyncOperation::Open), 2);
+        assert_eq!(engine.started(TurmoilAsyncOperation::InputShare), 0);
+        assert_eq!(engine.started(TurmoilAsyncOperation::Multiply), 0);
+        assert_eq!(engine.started(TurmoilAsyncOperation::Open), 1);
         assert_eq!(engine.started(TurmoilAsyncOperation::RbcReceive), 1);
         Ok(())
     });
@@ -4072,6 +4320,62 @@ async fn share_batch_open_builtin_uses_async_batch_open() {
 }
 
 #[tokio::test]
+async fn share_batch_open_partitions_mixed_runtime_types_and_restores_order() {
+    let engine = Arc::new(AsyncBatchOpenEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let bool_ty = ShareType::boolean();
+    let int_ty = ShareType::secret_int(64);
+    let mut vm = VirtualMachine::builder()
+        .with_standard_library(false)
+        .with_mpc_engine(runtime_engine)
+        .build();
+    let shares = vm.create_array_ref(3).expect("create shares array");
+    vm.push_array_values(
+        shares,
+        &[
+            Value::Share(bool_ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(int_ty, ShareData::Opaque(vec![8].into())),
+            Value::Share(bool_ty, ShareData::Opaque(vec![0].into())),
+        ],
+    )
+    .expect("seed mixed shares array");
+    vm.register_function(VMFunction::new(
+        "mixed_batch_open".to_string(),
+        vec!["shares".to_string()],
+        Vec::new(),
+        None,
+        1,
+        vec![
+            Instruction::PUSHARG(0),
+            Instruction::CALL("Share.batch_open".to_string()),
+            Instruction::RET(0),
+        ],
+        HashMap::new(),
+    ));
+
+    let result = vm
+        .execute_async_with_args("mixed_batch_open", &[Value::from(shares)], engine.as_ref())
+        .await
+        .expect("mixed Share.batch_open should partition by type");
+    let Value::Array(result_ref) = result else {
+        panic!("Share.batch_open should return an array");
+    };
+    let values = (0..3)
+        .map(|index| {
+            vm.read_table_field(TableRef::from(result_ref), &Value::I64(index))
+                .expect("read mixed open result")
+                .expect("mixed open result present")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![Value::I64(1), Value::I64(8), Value::I64(0)]);
+    assert_eq!(
+        engine.async_batch_calls.load(Ordering::SeqCst),
+        2,
+        "one homogeneous protocol batch per runtime share type"
+    );
+}
+
+#[tokio::test]
 async fn share_batch_mul_builtin_uses_async_batch_multiply() {
     let engine = Arc::new(AsyncBatchMulEngine::new());
     let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
@@ -4138,6 +4442,246 @@ async fn share_batch_mul_builtin_uses_async_batch_multiply() {
     );
     assert_eq!(engine.sync_mul_calls.load(Ordering::SeqCst), 0);
     assert_eq!(engine.async_batch_calls.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn share_batch_mul_partitions_mixed_runtime_types_and_restores_order() {
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let bool_ty = ShareType::boolean();
+    let int_ty = ShareType::secret_int(64);
+    let mut vm = VirtualMachine::builder()
+        .with_standard_library(false)
+        .with_mpc_engine(runtime_engine)
+        .build();
+    let lefts = vm.create_array_ref(3).expect("create left shares array");
+    vm.push_array_values(
+        lefts,
+        &[
+            Value::Share(bool_ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(int_ty, ShareData::Opaque(vec![3].into())),
+            Value::Share(bool_ty, ShareData::Opaque(vec![0].into())),
+        ],
+    )
+    .expect("seed mixed left shares");
+    let rights = vm.create_array_ref(3).expect("create right shares array");
+    vm.push_array_values(
+        rights,
+        &[
+            Value::Share(bool_ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(int_ty, ShareData::Opaque(vec![4].into())),
+            Value::Share(bool_ty, ShareData::Opaque(vec![1].into())),
+        ],
+    )
+    .expect("seed mixed right shares");
+    vm.register_function(VMFunction::new(
+        "mixed_batch_mul".to_string(),
+        vec!["lefts".to_string(), "rights".to_string()],
+        Vec::new(),
+        None,
+        2,
+        vec![
+            Instruction::PUSHARG(0),
+            Instruction::PUSHARG(1),
+            Instruction::CALL("Share.batch_mul".to_string()),
+            Instruction::RET(0),
+        ],
+        HashMap::new(),
+    ));
+
+    let result = vm
+        .execute_async_with_args(
+            "mixed_batch_mul",
+            &[Value::from(lefts), Value::from(rights)],
+            engine.as_ref(),
+        )
+        .await
+        .expect("mixed Share.batch_mul should partition by type");
+    let Value::Array(result_ref) = result else {
+        panic!("Share.batch_mul should return an array");
+    };
+    let values = (0..3)
+        .map(|index| {
+            vm.read_table_field(TableRef::from(result_ref), &Value::I64(index))
+                .expect("read mixed multiply result")
+                .expect("mixed multiply result present")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        values,
+        vec![
+            Value::Share(bool_ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(int_ty, ShareData::Opaque(vec![12].into())),
+            Value::Share(bool_ty, ShareData::Opaque(vec![0].into())),
+        ]
+    );
+    assert_eq!(engine.sync_batch_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        engine.async_batch_calls.load(Ordering::SeqCst),
+        2,
+        "one homogeneous protocol batch per runtime share type"
+    );
+}
+
+#[tokio::test]
+async fn o3_executes_independent_same_type_scalar_mul_and_reveal_in_one_round_each() {
+    let source = r#"
+def main(a: secret bool, b: secret bool, c: secret bool, d: secret bool) -> list[int64]:
+  var first_product = Share.mul(a, b)
+  var second_product = Share.mul(c, d)
+  var first_opened = Share.open(first_product)
+  var second_opened = Share.open(second_product)
+  return [first_opened, second_opened]
+"#;
+    let options = stoffellang::CompilerOptions {
+        optimize: true,
+        optimization_level: 3,
+        mpc_backend: MpcBackend::HoneyBadger,
+        mpc_mul_batch_capacity: Some(256),
+        ..Default::default()
+    };
+    let compiled = stoffellang::compile(source, "same-type-scalar-batch.stfl", &options)
+        .expect("same-type scalar batch source should compile at O3");
+    assert_eq!(compiled.client_io_manifest.preprocessing_demand.triples, 2);
+    let call_count = |name: &str| {
+        compiled
+            .main_chunk
+            .instructions
+            .iter()
+            .filter(
+                |instruction| matches!(instruction, Instruction::CALL(callee) if callee == name),
+            )
+            .count()
+    };
+    assert_eq!(call_count("Share.batch_mul"), 1);
+    assert_eq!(call_count("Share.mul"), 0);
+    assert_eq!(call_count("Share.batch_open"), 1);
+    assert_eq!(call_count("Share.open"), 0);
+
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 3);
+    vm.set_mpc_engine(runtime_engine);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![1].into())),
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![1].into())),
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![1].into())),
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![0].into())),
+            ],
+            engine.as_ref(),
+        )
+        .await
+        .expect("O3 same-type scalar operations should batch safely");
+    let Value::Array(result_ref) = result else {
+        panic!("main should return an array");
+    };
+    let values = (0..2)
+        .map(|index| {
+            vm.read_table_field(TableRef::from(result_ref), &Value::I64(index))
+                .expect("read compiled result")
+                .expect("compiled result present")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![Value::I64(1), Value::I64(0)]);
+    assert_eq!(engine.sync_mul_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        engine.async_batch_calls.load(Ordering::SeqCst),
+        1,
+        "independent same-type multiplies must share one protocol session"
+    );
+    assert_eq!(
+        engine.async_batch_open_calls.load(Ordering::SeqCst),
+        1,
+        "independent same-type reveals must share one protocol session"
+    );
+}
+
+#[tokio::test]
+async fn o3_batches_explicit_scalar_mul_and_reveal_with_runtime_type_partitioning() {
+    let source = r#"
+def main(a: secret bool, b: secret bool, x: secret int64, y: secret int64) -> list[int64]:
+  var bit_product = Share.mul(a, b)
+  var int_product = Share.mul(x, y)
+  var opened_bit = Share.open(bit_product)
+  var opened_int = Share.open(int_product)
+  return [opened_bit, opened_int]
+"#;
+    let options = stoffellang::CompilerOptions {
+        optimize: true,
+        optimization_level: 3,
+        mpc_backend: MpcBackend::HoneyBadger,
+        mpc_mul_batch_capacity: Some(256),
+        ..Default::default()
+    };
+    let compiled = stoffellang::compile(source, "mixed-scalar-batch.stfl", &options)
+        .expect("mixed scalar batch source should compile at O3");
+    assert_eq!(
+        compiled.client_io_manifest.preprocessing_demand.triples, 2,
+        "batch lowering must preserve the exact two-product preprocessing demand"
+    );
+    assert!(
+        !compiled.client_io_manifest.preprocessing_demand.dynamic,
+        "statically sized scalar batching must not require online top-ups"
+    );
+    let call_count = |name: &str| {
+        compiled
+            .main_chunk
+            .instructions
+            .iter()
+            .filter(
+                |instruction| matches!(instruction, Instruction::CALL(callee) if callee == name),
+            )
+            .count()
+    };
+    assert_eq!(call_count("Share.batch_mul"), 1);
+    assert_eq!(call_count("Share.mul"), 0);
+    assert_eq!(call_count("Share.batch_open"), 1);
+    assert_eq!(call_count("Share.open"), 0);
+
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let mut vm = compile_vm_source_at(source, 3);
+    vm.set_mpc_engine(runtime_engine);
+
+    let result = vm
+        .execute_async_with_args(
+            "main",
+            &[
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![1].into())),
+                Value::Share(ShareType::boolean(), ShareData::Opaque(vec![1].into())),
+                Value::Share(ShareType::secret_int(64), ShareData::Opaque(vec![3].into())),
+                Value::Share(ShareType::secret_int(64), ShareData::Opaque(vec![4].into())),
+            ],
+            engine.as_ref(),
+        )
+        .await
+        .expect("O3 mixed-type scalar operations should batch safely");
+    let Value::Array(result_ref) = result else {
+        panic!("main should return an array");
+    };
+    let values = (0..2)
+        .map(|index| {
+            vm.read_table_field(TableRef::from(result_ref), &Value::I64(index))
+                .expect("read compiled result")
+                .expect("compiled result present")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(values, vec![Value::I64(1), Value::I64(12)]);
+    assert_eq!(engine.sync_mul_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        engine.async_batch_calls.load(Ordering::SeqCst),
+        2,
+        "one multiply partition for bool and one for int64"
+    );
+    assert_eq!(
+        engine.async_batch_open_calls.load(Ordering::SeqCst),
+        2,
+        "one reveal partition for bool and one for int64"
+    );
 }
 
 #[test]

--- a/crates/stoffel-vm/src/core_vm/tests.rs
+++ b/crates/stoffel-vm/src/core_vm/tests.rs
@@ -585,6 +585,7 @@ impl AsyncMpcEngine for AsyncBatchOpenEngine {
 
 struct AsyncBatchMulEngine {
     sync_mul_calls: AtomicUsize,
+    sync_batch_calls: AtomicUsize,
     async_batch_calls: AtomicUsize,
 }
 
@@ -592,6 +593,7 @@ impl AsyncBatchMulEngine {
     fn new() -> Self {
         Self {
             sync_mul_calls: AtomicUsize::new(0),
+            sync_batch_calls: AtomicUsize::new(0),
             async_batch_calls: AtomicUsize::new(0),
         }
     }
@@ -643,6 +645,22 @@ impl MpcEngineMultiplication for AsyncBatchMulEngine {
             "multiply_share",
             "sync multiply_share should not be used by async batch builtin calls",
         ))
+    }
+
+    fn batch_multiply_shares(
+        &self,
+        _ty: ShareType,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> MpcEngineResult<Vec<ShareData>> {
+        self.sync_batch_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(pairs
+            .iter()
+            .map(|(left, right)| {
+                let left_byte = left.first().copied().unwrap_or_default();
+                let right_byte = right.first().copied().unwrap_or_default();
+                ShareData::Opaque(vec![left_byte.wrapping_mul(right_byte)].into())
+            })
+            .collect())
     }
 }
 
@@ -4120,6 +4138,74 @@ async fn share_batch_mul_builtin_uses_async_batch_multiply() {
     );
     assert_eq!(engine.sync_mul_calls.load(Ordering::SeqCst), 0);
     assert_eq!(engine.async_batch_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn share_batch_mul_builtin_uses_sync_batch_multiply() {
+    let engine = Arc::new(AsyncBatchMulEngine::new());
+    let runtime_engine: Arc<dyn MpcEngine> = engine.clone();
+    let ty = ShareType::boolean();
+    let mut vm = VirtualMachine::builder()
+        .with_standard_library(false)
+        .with_mpc_engine(runtime_engine)
+        .build();
+    let lefts = vm.create_array_ref(2).expect("create left shares array");
+    vm.push_array_values(
+        lefts,
+        &[
+            Value::Share(ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(ty, ShareData::Opaque(vec![0].into())),
+        ],
+    )
+    .expect("seed left shares array");
+    let rights = vm.create_array_ref(2).expect("create right shares array");
+    vm.push_array_values(
+        rights,
+        &[
+            Value::Share(ty, ShareData::Opaque(vec![1].into())),
+            Value::Share(ty, ShareData::Opaque(vec![1].into())),
+        ],
+    )
+    .expect("seed right shares array");
+    vm.register_function(VMFunction::new(
+        "sync_builtin_batch_mul".to_string(),
+        vec!["lefts".to_string(), "rights".to_string()],
+        Vec::new(),
+        None,
+        2,
+        vec![
+            Instruction::PUSHARG(0),
+            Instruction::PUSHARG(1),
+            Instruction::CALL("Share.batch_mul".to_string()),
+            Instruction::RET(0),
+        ],
+        HashMap::new(),
+    ));
+
+    let result = vm
+        .execute_with_args(
+            "sync_builtin_batch_mul",
+            &[Value::from(lefts), Value::from(rights)],
+        )
+        .expect("Share.batch_mul should execute through synchronous batch engine");
+    let Value::Array(result_ref) = result else {
+        panic!("Share.batch_mul should return an array");
+    };
+
+    assert_eq!(vm.read_array_len(result_ref).expect("result length"), 2);
+    assert_eq!(
+        vm.read_table_field(TableRef::from(result_ref), &Value::I64(0))
+            .expect("read first result"),
+        Some(Value::Share(ty, ShareData::Opaque(vec![1].into())))
+    );
+    assert_eq!(
+        vm.read_table_field(TableRef::from(result_ref), &Value::I64(1))
+            .expect("read second result"),
+        Some(Value::Share(ty, ShareData::Opaque(vec![0].into())))
+    );
+    assert_eq!(engine.sync_mul_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(engine.sync_batch_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(engine.async_batch_calls.load(Ordering::SeqCst), 0);
 }
 
 #[test]

--- a/crates/stoffel-vm/src/foreign_functions/mpc.rs
+++ b/crates/stoffel-vm/src/foreign_functions/mpc.rs
@@ -79,6 +79,10 @@ impl<'a> ForeignFunctionContext<'a> {
         self.services.input_share_data(clear)
     }
 
+    pub(crate) fn materialize_public_share_data(&self, share: &ShareData) -> VmResult<ShareData> {
+        self.services.materialize_public_share_data(share)
+    }
+
     pub(crate) fn open_share_data(
         &self,
         ty: ShareType,

--- a/crates/stoffel-vm/src/foreign_functions/mpc.rs
+++ b/crates/stoffel-vm/src/foreign_functions/mpc.rs
@@ -159,6 +159,16 @@ impl<'a> ForeignFunctionContext<'a> {
         self.services.secret_share_mul_data(ty, lhs_data, rhs_data)
     }
 
+    pub(crate) fn secret_share_batch_mul_data(
+        &self,
+        ty: ShareType,
+        lhs_data: &[ShareData],
+        rhs_data: &[ShareData],
+    ) -> VmResult<Vec<ShareData>> {
+        self.services
+            .secret_share_batch_mul_data(ty, lhs_data, rhs_data)
+    }
+
     pub(crate) fn secret_share_neg_data(
         &self,
         ty: ShareType,

--- a/crates/stoffel-vm/src/foreign_functions/services.rs
+++ b/crates/stoffel-vm/src/foreign_functions/services.rs
@@ -315,6 +315,8 @@ pub(crate) trait ForeignMpcServices {
 
     fn input_share_data(&self, clear: ClearShareInput) -> VmResult<ShareData>;
 
+    fn materialize_public_share_data(&self, share: &ShareData) -> VmResult<ShareData>;
+
     fn open_share_data(&self, ty: ShareType, share_data: &ShareData) -> VmResult<ClearShareValue>;
 
     fn batch_open_share_data(
@@ -472,6 +474,10 @@ impl ForeignMpcServices for VMState {
         VMState::input_share_data(self, clear)
     }
 
+    fn materialize_public_share_data(&self, share: &ShareData) -> VmResult<ShareData> {
+        VMState::materialize_public_share_data(self, share)
+    }
+
     fn open_share_data(&self, ty: ShareType, share_data: &ShareData) -> VmResult<ClearShareValue> {
         VMState::open_share_data(self, ty, share_data)
     }
@@ -616,6 +622,12 @@ pub(crate) trait ForeignShareObjectServices {
         context: &'static str,
     ) -> VmResult<Option<(ShareType, Vec<ShareData>)>>;
 
+    fn extract_share_array(
+        &mut self,
+        value: &Value,
+        context: &'static str,
+    ) -> VmResult<Vec<(ShareType, ShareData)>>;
+
     fn share_type(&mut self, value: &Value) -> VmResult<ShareType>;
 
     fn share_party_id(&mut self, value: &Value) -> VmResult<Option<usize>>;
@@ -652,6 +664,14 @@ impl ForeignShareObjectServices for VMState {
         context: &'static str,
     ) -> VmResult<Option<(ShareType, Vec<ShareData>)>> {
         VMState::extract_homogeneous_share_array(self, value, context)
+    }
+
+    fn extract_share_array(
+        &mut self,
+        value: &Value,
+        context: &'static str,
+    ) -> VmResult<Vec<(ShareType, ShareData)>> {
+        VMState::extract_share_array(self, value, context)
     }
 
     fn share_type(&mut self, value: &Value) -> VmResult<ShareType> {

--- a/crates/stoffel-vm/src/foreign_functions/services.rs
+++ b/crates/stoffel-vm/src/foreign_functions/services.rs
@@ -365,6 +365,13 @@ pub(crate) trait ForeignMpcServices {
         rhs_data: &ShareData,
     ) -> VmResult<ShareData>;
 
+    fn secret_share_batch_mul_data(
+        &self,
+        ty: ShareType,
+        lhs_data: &[ShareData],
+        rhs_data: &[ShareData],
+    ) -> VmResult<Vec<ShareData>>;
+
     fn secret_share_neg_data(&self, ty: ShareType, share_data: &ShareData) -> VmResult<ShareData>;
 
     fn secret_share_add_scalar_data(
@@ -533,6 +540,15 @@ impl ForeignMpcServices for VMState {
         rhs_data: &ShareData,
     ) -> VmResult<ShareData> {
         VMState::secret_share_mul_data(self, ty, lhs_data, rhs_data)
+    }
+
+    fn secret_share_batch_mul_data(
+        &self,
+        ty: ShareType,
+        lhs_data: &[ShareData],
+        rhs_data: &[ShareData],
+    ) -> VmResult<Vec<ShareData>> {
+        VMState::secret_share_batch_mul_data(self, ty, lhs_data, rhs_data)
     }
 
     fn secret_share_neg_data(&self, ty: ShareType, share_data: &ShareData) -> VmResult<ShareData> {

--- a/crates/stoffel-vm/src/foreign_functions/share_objects.rs
+++ b/crates/stoffel-vm/src/foreign_functions/share_objects.rs
@@ -30,6 +30,14 @@ impl<'a> ForeignFunctionContext<'a> {
             .extract_homogeneous_share_array(value, context)?)
     }
 
+    pub(crate) fn extract_share_array(
+        &mut self,
+        value: &Value,
+        context: &'static str,
+    ) -> ForeignFunctionCallbackResult<Vec<(ShareType, ShareData)>> {
+        Ok(self.services.extract_share_array(value, context)?)
+    }
+
     pub(crate) fn get_share_type(
         &mut self,
         value: &Value,

--- a/crates/stoffel-vm/src/mpc_builtins/share/metadata.rs
+++ b/crates/stoffel-vm/src/mpc_builtins/share/metadata.rs
@@ -83,6 +83,7 @@ fn share_get_commitment(mut ctx: ForeignFunctionContext) -> ForeignFunctionCallb
         let index = value_to_usize(&index_value, "index")?;
         (share_data, index)
     };
+    let share_data = ctx.materialize_public_share_data(&share_data)?;
     let commitments = share_data
         .commitments()
         .ok_or("Share does not have Feldman commitments (requires AVSS backend)")?;
@@ -103,6 +104,7 @@ fn share_commitment_count(mut ctx: ForeignFunctionContext) -> ForeignFunctionCal
         args.cloned(0)?
     };
     let (_, share_data) = ctx.extract_share_data(&share_value)?;
+    let share_data = ctx.materialize_public_share_data(&share_data)?;
     match share_data.commitments() {
         Some(commitments) => Ok(Value::I64(usize_to_vm_i64(
             commitments.len(),
@@ -119,5 +121,6 @@ fn share_has_commitments(mut ctx: ForeignFunctionContext) -> ForeignFunctionCall
         args.cloned(0)?
     };
     let (_, share_data) = ctx.extract_share_data(&share_value)?;
+    let share_data = ctx.materialize_public_share_data(&share_data)?;
     Ok(Value::Bool(share_data.has_commitments()))
 }

--- a/crates/stoffel-vm/src/mpc_builtins/share/network_ops.rs
+++ b/crates/stoffel-vm/src/mpc_builtins/share/network_ops.rs
@@ -99,11 +99,11 @@ fn share_batch_mul(mut ctx: ForeignFunctionContext) -> ForeignFunctionCallbackRe
         );
     }
 
-    let mut results = Vec::with_capacity(left_data.len());
-    for (left, right) in left_data.iter().zip(right_data.iter()) {
-        let result_data = ctx.secret_share_mul_data(share_type, left, right)?;
-        results.push(Value::Share(share_type, result_data));
-    }
+    let results = ctx
+        .secret_share_batch_mul_data(share_type, &left_data, &right_data)?
+        .into_iter()
+        .map(|data| Value::Share(share_type, data))
+        .collect::<Vec<_>>();
 
     let result_ref = ctx.create_array_ref(results.len())?;
     ctx.push_array_ref_values(result_ref, &results)?;

--- a/crates/stoffel-vm/src/mpc_builtins/share/network_ops.rs
+++ b/crates/stoffel-vm/src/mpc_builtins/share/network_ops.rs
@@ -8,7 +8,7 @@ use crate::net::curve::clear_share_value_to_vm_value;
 use crate::net::mpc_engine::MpcExponentGenerator;
 use crate::value_conversions::value_to_usize;
 use crate::VirtualMachineResult;
-use stoffel_vm_types::core_types::{ShareType, Value};
+use stoffel_vm_types::core_types::{ShareData, ShareType, Value};
 
 pub(super) fn register(vm: &mut VirtualMachine) -> VirtualMachineResult<()> {
     vm.try_register_mpc_online_foreign_method("Share", "mul", MpcOnlineBuiltin::Mul, share_mul)?;
@@ -73,25 +73,12 @@ fn share_batch_mul(mut ctx: ForeignFunctionContext) -> ForeignFunctionCallbackRe
         (args.cloned(0)?, args.cloned(1)?)
     };
 
-    let Some((share_type, left_data)) =
-        ctx.extract_homogeneous_share_array(&lefts_arg, "Share.batch_mul lefts_array")?
-    else {
+    let lefts = ctx.extract_share_array(&lefts_arg, "Share.batch_mul lefts_array")?;
+    let rights = ctx.extract_share_array(&rights_arg, "Share.batch_mul rights_array")?;
+    if lefts.is_empty() && rights.is_empty() {
         return ctx.create_array(0);
-    };
-    let Some((right_share_type, right_data)) =
-        ctx.extract_homogeneous_share_array(&rights_arg, "Share.batch_mul rights_array")?
-    else {
-        return ctx.create_array(0);
-    };
-
-    if share_type != right_share_type {
-        return Err(
-            crate::foreign_functions::ForeignFunctionCallbackError::Message(
-                "Share.batch_mul requires arrays with matching share types".to_string(),
-            ),
-        );
     }
-    if left_data.len() != right_data.len() {
+    if lefts.len() != rights.len() {
         return Err(
             crate::foreign_functions::ForeignFunctionCallbackError::Message(
                 "Share.batch_mul requires arrays with the same length".to_string(),
@@ -99,11 +86,61 @@ fn share_batch_mul(mut ctx: ForeignFunctionContext) -> ForeignFunctionCallbackRe
         );
     }
 
-    let results = ctx
-        .secret_share_batch_mul_data(share_type, &left_data, &right_data)?
+    type Group = (ShareType, Vec<usize>, Vec<ShareData>, Vec<ShareData>);
+    let mut groups: Vec<Group> = Vec::new();
+    for (index, ((left_type, left_data), (right_type, right_data))) in
+        lefts.into_iter().zip(rights).enumerate()
+    {
+        if left_type != right_type {
+            return Err(format!(
+                "Share.batch_mul pair {index} has mismatched share types: {left_type:?} and {right_type:?}"
+            )
+            .into());
+        }
+        let group = if let Some(group) = groups.iter_mut().find(|group| {
+            group.0 == left_type
+                && group
+                    .2
+                    .first()
+                    .is_none_or(|data| data.format() == left_data.format())
+        }) {
+            group
+        } else {
+            groups.push((left_type, Vec::new(), Vec::new(), Vec::new()));
+            groups.last_mut().expect("just inserted a type group")
+        };
+        group.1.push(index);
+        group.2.push(left_data);
+        group.3.push(right_data);
+    }
+
+    let output_len = groups.iter().map(|group| group.1.len()).sum();
+    let mut results = vec![None; output_len];
+    for (share_type, indices, left_data, right_data) in groups {
+        let products = ctx.secret_share_batch_mul_data(share_type, &left_data, &right_data)?;
+        if products.len() != indices.len() {
+            return Err(format!(
+                "Share.batch_mul backend returned {} products for {} lanes",
+                products.len(),
+                indices.len()
+            )
+            .into());
+        }
+        for (index, data) in indices.into_iter().zip(products) {
+            results[index] = Some(Value::Share(share_type, data));
+        }
+    }
+    let results = results
         .into_iter()
-        .map(|data| Value::Share(share_type, data))
-        .collect::<Vec<_>>();
+        .enumerate()
+        .map(|(index, value)| {
+            value.ok_or_else(|| {
+                crate::foreign_functions::ForeignFunctionCallbackError::Message(format!(
+                    "Share.batch_mul result lane {index} was not produced"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let result_ref = ctx.create_array_ref(results.len())?;
     ctx.push_array_ref_values(result_ref, &results)?;
@@ -132,17 +169,57 @@ fn share_batch_open(mut ctx: ForeignFunctionContext) -> ForeignFunctionCallbackR
         args.cloned(0)?
     };
 
-    let Some((share_type, share_data)) =
-        ctx.extract_homogeneous_share_array(&shares_arg, "Share.batch_open shares_array")?
-    else {
+    let shares = ctx.extract_share_array(&shares_arg, "Share.batch_open shares_array")?;
+    if shares.is_empty() {
         return ctx.create_array(0);
-    };
+    }
 
-    let revealed: Vec<Value> = ctx
-        .batch_open_share_data(share_type, &share_data)?
+    type Group = (ShareType, Vec<usize>, Vec<ShareData>);
+    let output_len = shares.len();
+    let mut groups: Vec<Group> = Vec::new();
+    for (index, (share_type, share_data)) in shares.into_iter().enumerate() {
+        let group = if let Some(group) = groups.iter_mut().find(|group| {
+            group.0 == share_type
+                && group
+                    .2
+                    .first()
+                    .is_none_or(|data| data.format() == share_data.format())
+        }) {
+            group
+        } else {
+            groups.push((share_type, Vec::new(), Vec::new()));
+            groups.last_mut().expect("just inserted a type group")
+        };
+        group.1.push(index);
+        group.2.push(share_data);
+    }
+
+    let mut revealed = vec![None; output_len];
+    for (share_type, indices, share_data) in groups {
+        let values = ctx.batch_open_share_data(share_type, &share_data)?;
+        if values.len() != indices.len() {
+            return Err(format!(
+                "Share.batch_open backend returned {} values for {} lanes",
+                values.len(),
+                indices.len()
+            )
+            .into());
+        }
+        for (index, value) in indices.into_iter().zip(values) {
+            revealed[index] = Some(clear_share_value_to_vm_value(share_type, value));
+        }
+    }
+    let revealed = revealed
         .into_iter()
-        .map(|value| clear_share_value_to_vm_value(share_type, value))
-        .collect();
+        .enumerate()
+        .map(|(index, value)| {
+            value.ok_or_else(|| {
+                crate::foreign_functions::ForeignFunctionCallbackError::Message(format!(
+                    "Share.batch_open result lane {index} was not produced"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
 
     let result_ref = ctx.create_array_ref(revealed.len())?;
     ctx.push_array_ref_values(result_ref, &revealed)?;

--- a/crates/stoffel-vm/src/mpc_values/clear_share.rs
+++ b/crates/stoffel-vm/src/mpc_values/clear_share.rs
@@ -38,12 +38,23 @@ fn canonical_clear_share_value(
     clear_value: &Value,
 ) -> MpcValueResult<ClearShareValue> {
     match (share_type, clear_value) {
-        (ShareType::SecretInt { .. }, Value::I64(value)) => Ok(ClearShareValue::Integer(*value)),
         (ShareType::SecretInt { bit_length }, Value::Bool(value))
             if bit_length == stoffel_vm_types::core_types::BOOLEAN_SECRET_INT_BITS =>
         {
             Ok(ClearShareValue::Boolean(*value))
         }
+        (ShareType::SecretInt { bit_length }, value)
+            if bit_length == stoffel_vm_types::core_types::BOOLEAN_SECRET_INT_BITS
+                && is_integer_value(value) =>
+        {
+            // A one-bit secret integer is the VM's boolean share type. Keep its
+            // clear representation canonical at the construction boundary so
+            // public opens and backend-materialized opens produce the same VM
+            // value (`Bool`, never an optimization-dependent `I64`). MPC
+            // backends already open a one-bit field value as `value != 0`.
+            Ok(ClearShareValue::Boolean(integer_value_is_nonzero(value)))
+        }
+        (ShareType::SecretInt { .. }, Value::I64(value)) => Ok(ClearShareValue::Integer(*value)),
         (ShareType::SecretInt { .. }, value) if is_integer_value(value) => Ok(
             ClearShareValue::Integer(value_to_i64(value, "clear integer")?),
         ),
@@ -60,6 +71,20 @@ fn canonical_clear_share_value(
             share_type,
             value: value.clone(),
         }),
+    }
+}
+
+fn integer_value_is_nonzero(value: &Value) -> bool {
+    match value {
+        Value::I64(value) => *value != 0,
+        Value::I32(value) => *value != 0,
+        Value::I16(value) => *value != 0,
+        Value::I8(value) => *value != 0,
+        Value::U64(value) => *value != 0,
+        Value::U32(value) => *value != 0,
+        Value::U16(value) => *value != 0,
+        Value::U8(value) => *value != 0,
+        _ => unreachable!("caller checks that the value is an integer"),
     }
 }
 

--- a/crates/stoffel-vm/src/mpc_values/tests.rs
+++ b/crates/stoffel-vm/src/mpc_values/tests.rs
@@ -34,6 +34,24 @@ fn clear_share_input_canonicalizes_explicit_fixed_point_integer_input() {
 }
 
 #[test]
+fn clear_share_input_canonicalizes_explicit_boolean_integer_input() {
+    let share_type = ShareType::boolean();
+
+    for (value, expected) in [
+        (Value::I64(0), false),
+        (Value::I64(1), true),
+        (Value::I64(-1), true),
+        (Value::U64(u64::MAX), true),
+    ] {
+        let input = clear_share_input(&value, Some(share_type))
+            .expect("integer values should be canonicalized for boolean shares");
+
+        assert_eq!(input.share_type(), share_type);
+        assert_eq!(input.value(), ClearShareValue::Boolean(expected));
+    }
+}
+
+#[test]
 fn share_object_metadata_errors_are_typed() {
     let mut store = ObjectStore::new();
     let object_ref = store

--- a/crates/stoffel-vm/src/net/avss_server.rs
+++ b/crates/stoffel-vm/src/net/avss_server.rs
@@ -31,6 +31,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use super::avss_engine::{AvssEngineConfig, AvssMpcEngine};
+use super::mpc_protocol_sender_id;
 
 fn is_duplicate_connection_tiebreaker_error(error: &str) -> bool {
     error.contains("duplicate connection: tie-breaker")
@@ -678,10 +679,15 @@ where
 
         let connections = net.get_all_server_connections();
         for (peer_id, conn) in &connections {
-            let authenticated_sender_id = Self::connection_party_id(*peer_id, conn);
-            if authenticated_sender_id == self.node_id || authenticated_sender_id >= self.n {
+            let Some(authenticated_sender_id) =
+                mpc_protocol_sender_id(*peer_id, conn.remote_party_id(), self.n)
+            else {
+                warn!(
+                    "[AVSS] Ignoring protocol connection with out-of-session transport ID {}",
+                    peer_id
+                );
                 continue;
-            }
+            };
             let peer_id = authenticated_sender_id;
             let engine = engine.clone();
             let tx = msg_tx.clone();
@@ -799,10 +805,15 @@ where
         // Server connection receive loops
         let connections = net.get_all_server_connections();
         for (peer_id, conn) in &connections {
-            let authenticated_sender_id = Self::connection_party_id(*peer_id, conn);
-            if authenticated_sender_id == self.node_id || authenticated_sender_id >= self.n {
+            let Some(authenticated_sender_id) =
+                mpc_protocol_sender_id(*peer_id, conn.remote_party_id(), self.n)
+            else {
+                warn!(
+                    "[AVSS] Ignoring protocol connection with out-of-session transport ID {}",
+                    peer_id
+                );
                 continue;
-            }
+            };
             let peer_id = authenticated_sender_id;
             let engine = engine.clone();
             let tx = server_tx.clone();

--- a/crates/stoffel-vm/src/net/curve.rs
+++ b/crates/stoffel-vm/src/net/curve.rs
@@ -108,7 +108,9 @@ impl From<MpcCurveError> for String {
 /// so `SupportedMpcField` is implemented once and covers both curves.
 /// Engine implementations use the group type to preserve the configured curve
 /// identity where the field alone is ambiguous.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Default, serde::Serialize, serde::Deserialize,
+)]
 pub enum MpcCurveConfig {
     #[default]
     Bls12_381,
@@ -180,7 +182,7 @@ impl MpcCurveConfig {
 }
 
 /// Field-dispatch metadata for VM-local share math.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub enum MpcFieldKind {
     Bls12_381Fr,
     Bn254Fr,

--- a/crates/stoffel-vm/src/net/deferred_mpc.rs
+++ b/crates/stoffel-vm/src/net/deferred_mpc.rs
@@ -1,0 +1,1325 @@
+use crate::error::{MpcBackendResultExt, VmError, VmResult};
+use crate::net::mpc_engine::{AsyncMpcEngine, MpcEngine};
+use crate::net::share_algebra;
+use rustc_hash::FxHashMap;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::sync::Arc;
+use stoffel_vm_types::core_types::{
+    ClearShareInput, ClearShareValue, DeferredShare, DeferredShareOperation, ShareData,
+    ShareDataFormat, ShareType,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct MultiplicationGroup {
+    share_type: ShareType,
+    format: ShareDataFormat,
+}
+
+#[derive(Debug)]
+struct MultiplicationNode {
+    share: Arc<DeferredShare>,
+    predecessors: Vec<usize>,
+    successors: Vec<usize>,
+    dependency_depth: usize,
+    remaining_depth: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadyMultiplication {
+    index: usize,
+    remaining_depth: usize,
+    secondary_priority: usize,
+    share_id: u64,
+}
+
+impl Ord for ReadyMultiplication {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.remaining_depth
+            .cmp(&other.remaining_depth)
+            .then_with(|| self.secondary_priority.cmp(&other.secondary_priority))
+            // Oldest source node wins deterministic ties.
+            .then_with(|| other.share_id.cmp(&self.share_id))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum SchedulePriority {
+    SourceOrder,
+    SuccessorFanout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadyBackwardMultiplication {
+    index: usize,
+    primary_priority: i128,
+    secondary_priority: i128,
+    tertiary_priority: usize,
+    share_id: u64,
+}
+
+impl Ord for ReadyBackwardMultiplication {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.primary_priority
+            .cmp(&other.primary_priority)
+            .then_with(|| self.secondary_priority.cmp(&other.secondary_priority))
+            .then_with(|| self.tertiary_priority.cmp(&other.tertiary_priority))
+            .then_with(|| other.share_id.cmp(&self.share_id))
+    }
+}
+
+impl PartialOrd for ReadyBackwardMultiplication {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackwardSchedulePriority {
+    CriticalDepth,
+    CapacityBalance,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReadyDeadlineMultiplication {
+    index: usize,
+    deadline: usize,
+    share_id: u64,
+}
+
+impl Ord for ReadyDeadlineMultiplication {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Earlier backward-assigned rounds are more urgent.
+        other
+            .deadline
+            .cmp(&self.deadline)
+            .then_with(|| other.share_id.cmp(&self.share_id))
+    }
+}
+
+impl PartialOrd for ReadyDeadlineMultiplication {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd for ReadyMultiplication {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Resolve all deferred products reachable from `roots` and return ordinary
+/// materialized shares in the same order.
+///
+/// The scheduler reduces the full share-expression graph to a multiplication
+/// DAG: local linear nodes forward the frontier of their nearest interactive
+/// ancestors, while multiply nodes introduce a new dependency vertex. Ready
+/// vertices of the same runtime type and representation are issued together,
+/// bounded by the backend's declared native session capacity.
+pub(crate) async fn resolve_deferred_shares<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    roots: &[ShareData],
+) -> VmResult<Vec<ShareData>> {
+    let multiplications = build_multiplication_dag(roots);
+    if multiplications.is_empty() {
+        return materialize_roots(engine, roots).await;
+    }
+
+    execute_multiplication_dag(engine, &multiplications).await?;
+
+    materialize_roots(engine, roots).await
+}
+
+/// Construct a deferred multiplication without turning a public constant into
+/// an interactive lane. Public/public products remain public; multiplying a
+/// secret by an integral public share becomes a local scalar operation. Values
+/// that cannot be represented by the backend's scalar API (notably fixed-point
+/// constants) are materialized and retain the ordinary interactive semantics.
+pub(crate) async fn defer_multiply_share<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share_type: ShareType,
+    left: ShareData,
+    right: ShareData,
+) -> VmResult<ShareData> {
+    let left_public = left.public_input();
+    let right_public = right.public_input();
+
+    if let (Some(left_input), Some(right_input)) = (left_public, right_public) {
+        if let Some(product) = public_product(share_type, left_input, right_input) {
+            return Ok(product);
+        }
+    }
+
+    if right_public.is_none() {
+        if let Some(scalar) = left_public.and_then(public_scalar) {
+            let format = right.format();
+            return Ok(ShareData::deferred(
+                share_type,
+                format,
+                DeferredShareOperation::MulScalar {
+                    share: right,
+                    scalar,
+                },
+            ));
+        }
+    }
+    if left_public.is_none() {
+        if let Some(scalar) = right_public.and_then(public_scalar) {
+            let format = left.format();
+            return Ok(ShareData::deferred(
+                share_type,
+                format,
+                DeferredShareOperation::MulScalar {
+                    share: left,
+                    scalar,
+                },
+            ));
+        }
+    }
+
+    let left = materialize_public_share_async(engine, &left).await?;
+    let right = materialize_public_share_async(engine, &right).await?;
+    if left.format() != right.format() {
+        return Err(VmError::ShareDataFormatMismatch {
+            operation: "async_multiply_share",
+            left: left.format().as_str(),
+            right: right.format().as_str(),
+        });
+    }
+    Ok(ShareData::deferred_multiply(share_type, left, right))
+}
+
+pub(crate) fn multiplication_requires_protocol(
+    share_type: ShareType,
+    left: &ShareData,
+    right: &ShareData,
+) -> bool {
+    let left_public = left.public_input();
+    let right_public = right.public_input();
+    if let (Some(left), Some(right)) = (left_public, right_public) {
+        if public_product(share_type, left, right).is_some() {
+            return false;
+        }
+    }
+    if right_public.is_none() && left_public.and_then(public_scalar).is_some() {
+        return false;
+    }
+    if left_public.is_none() && right_public.and_then(public_scalar).is_some() {
+        return false;
+    }
+    true
+}
+
+fn public_scalar(input: ClearShareInput) -> Option<i64> {
+    match input.value() {
+        ClearShareValue::Integer(value) => Some(value),
+        ClearShareValue::UnsignedInteger(value) => i64::try_from(value).ok(),
+        ClearShareValue::Boolean(value) => Some(i64::from(value)),
+        ClearShareValue::FixedPoint(_) => None,
+    }
+}
+
+fn public_product(
+    share_type: ShareType,
+    left: ClearShareInput,
+    right: ClearShareInput,
+) -> Option<ShareData> {
+    if left.share_type() != share_type || right.share_type() != share_type {
+        return None;
+    }
+    let value = match (left.value(), right.value()) {
+        (ClearShareValue::Integer(left), ClearShareValue::Integer(right))
+            if share_type != ShareType::boolean() =>
+        {
+            let ShareType::SecretInt { bit_length } = share_type else {
+                return None;
+            };
+            ClearShareValue::Integer(wrap_signed(
+                i128::from(left) * i128::from(right),
+                bit_length,
+            )?)
+        }
+        (ClearShareValue::UnsignedInteger(left), ClearShareValue::UnsignedInteger(right)) => {
+            let ShareType::SecretUInt { bit_length } = share_type else {
+                return None;
+            };
+            ClearShareValue::UnsignedInteger(wrap_unsigned(
+                u128::from(left) * u128::from(right),
+                bit_length,
+            )?)
+        }
+        (ClearShareValue::Boolean(left), ClearShareValue::Boolean(right))
+            if share_type == ShareType::boolean() =>
+        {
+            ClearShareValue::Boolean(left && right)
+        }
+        // Fixed-point multiplication is defined over each backend's encoded
+        // representation and truncation protocol. Recomputing it as an f64
+        // expression could change rounding, so retain the protocol operation.
+        _ => return None,
+    };
+    Some(ShareData::public(ClearShareInput::new(share_type, value)))
+}
+
+fn wrap_signed(value: i128, bit_length: usize) -> Option<i64> {
+    if bit_length == 0 || bit_length > 64 {
+        return None;
+    }
+    if bit_length == 64 {
+        return Some(value as i64);
+    }
+    let modulus = 1i128 << bit_length;
+    let sign_bit = 1i128 << (bit_length - 1);
+    let truncated = value.rem_euclid(modulus);
+    Some(if truncated >= sign_bit {
+        (truncated - modulus) as i64
+    } else {
+        truncated as i64
+    })
+}
+
+fn wrap_unsigned(value: u128, bit_length: usize) -> Option<u64> {
+    if bit_length == 0 || bit_length > 64 {
+        return None;
+    }
+    if bit_length == 64 {
+        Some(value as u64)
+    } else {
+        Some((value % (1u128 << bit_length)) as u64)
+    }
+}
+
+pub(crate) async fn materialize_public_share_async<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share: &ShareData,
+) -> VmResult<ShareData> {
+    let ShareData::Public(public) = share else {
+        return Ok(share.materialized().unwrap_or(share).clone());
+    };
+    if let Some(materialized) = public.materialized() {
+        return Ok(materialized.clone());
+    }
+    let materialized = engine
+        .input_share_async(public.input())
+        .await
+        .map_mpc_backend_err("async_input_share")?;
+    let _ = public.set_materialized(materialized.clone());
+    Ok(public.materialized().unwrap_or(&materialized).clone())
+}
+
+async fn materialize_roots<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    roots: &[ShareData],
+) -> VmResult<Vec<ShareData>> {
+    let mut materialized = Vec::with_capacity(roots.len());
+    for root in roots {
+        if matches!(root, ShareData::Public(_)) {
+            materialized.push(materialize_public_share_async(engine, root).await?);
+        } else {
+            materialized.push(materialize_local_share(engine, root)?);
+        }
+    }
+    Ok(materialized)
+}
+
+fn collect_unresolved_nodes(roots: &[ShareData]) -> Vec<Arc<DeferredShare>> {
+    let mut by_id: FxHashMap<u64, Arc<DeferredShare>> = FxHashMap::default();
+    let mut pending = roots.to_vec();
+
+    while let Some(share) = pending.pop() {
+        let Some(node) = share.deferred_node() else {
+            continue;
+        };
+        if node.resolved().is_some() || by_id.contains_key(&node.id()) {
+            continue;
+        }
+        by_id.insert(node.id(), node.clone());
+        node.operation()
+            .visit_operands(|operand| pending.push(operand.clone()));
+    }
+
+    let mut nodes: Vec<_> = by_id.into_values().collect();
+    nodes.sort_unstable_by_key(|node| node.id());
+    nodes
+}
+
+fn build_multiplication_dag(roots: &[ShareData]) -> Vec<MultiplicationNode> {
+    let deferred = collect_unresolved_nodes(roots);
+    let mut frontiers: FxHashMap<u64, Vec<usize>> = FxHashMap::default();
+    let mut multiplications = Vec::<MultiplicationNode>::new();
+
+    for node in &deferred {
+        let mut predecessors = Vec::new();
+        node.operation().visit_operands(|operand| {
+            let Some(parent) = operand.deferred_node() else {
+                return;
+            };
+            if parent.resolved().is_some() {
+                return;
+            }
+            if let Some(frontier) = frontiers.get(&parent.id()) {
+                predecessors.extend(frontier.iter().copied());
+            }
+        });
+        predecessors.sort_unstable();
+        predecessors.dedup();
+
+        if node.operation().is_multiply() {
+            let index = multiplications.len();
+            let dependency_depth = 1 + predecessors
+                .iter()
+                .map(|predecessor| multiplications[*predecessor].dependency_depth)
+                .max()
+                .unwrap_or(0);
+            multiplications.push(MultiplicationNode {
+                share: node.clone(),
+                predecessors,
+                successors: Vec::new(),
+                dependency_depth,
+                remaining_depth: 1,
+            });
+            frontiers.insert(node.id(), vec![index]);
+        } else {
+            frontiers.insert(node.id(), predecessors);
+        }
+    }
+
+    for index in 0..multiplications.len() {
+        for predecessor in multiplications[index].predecessors.clone() {
+            multiplications[predecessor].successors.push(index);
+        }
+    }
+
+    // Node identities are allocated after all of their operands, so reverse
+    // identity order is a valid reverse topological order.
+    for index in (0..multiplications.len()).rev() {
+        multiplications[index].remaining_depth = 1 + multiplications[index]
+            .successors
+            .iter()
+            .map(|successor| multiplications[*successor].remaining_depth)
+            .max()
+            .unwrap_or(0);
+    }
+
+    multiplications
+}
+
+async fn execute_multiplication_dag<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    multiplications: &[MultiplicationNode],
+) -> VmResult<()> {
+    if multiplications.is_empty() {
+        return Ok(());
+    }
+
+    let capacity = engine
+        .multiplication_batch_capacity()
+        .unwrap_or(usize::MAX)
+        .max(1);
+    maybe_write_scheduler_dag(multiplications, capacity)?;
+    let plan = select_multiplication_plan(multiplications, capacity)?;
+
+    for (group, round) in plan {
+        let mut pairs = Vec::with_capacity(round.len());
+        for index in &round {
+            let operation = multiplications[*index].share.operation();
+            let DeferredShareOperation::Multiply { left, right } = operation else {
+                return Err(VmError::Message(
+                    "deferred MPC scheduler indexed a non-multiplication node".to_owned(),
+                ));
+            };
+            let left = materialize_local_share(engine, left)?;
+            let right = materialize_local_share(engine, right)?;
+            pairs.push((left.as_bytes().to_vec(), right.as_bytes().to_vec()));
+        }
+
+        let products = engine
+            .batch_multiply_share_async(group.share_type, &pairs)
+            .await
+            .map_mpc_backend_err("async_batch_multiply_share")?;
+        if products.len() != round.len() {
+            return Err(VmError::Message(format!(
+                "MPC backend returned {} products for a deferred batch of {}",
+                products.len(),
+                round.len()
+            )));
+        }
+
+        for (index, product) in round.iter().copied().zip(products) {
+            if product.format() != group.format {
+                return Err(VmError::ShareDataFormatMismatch {
+                    operation: "deferred_batch_multiply",
+                    left: group.format.as_str(),
+                    right: product.format().as_str(),
+                });
+            }
+            let node = &multiplications[index].share;
+            let _ = node.set_resolved(product);
+        }
+    }
+
+    Ok(())
+}
+
+/// Persist the exact source-ordered multiplication graph for offline scheduler
+/// analysis when explicitly requested. Pair logs produced by an MPC backend are
+/// execution ordered, so they cannot reproduce deterministic source-order ties
+/// after testing a different schedule. This opt-in graph keeps that distinction
+/// explicit and has no cost when the environment variable is absent.
+fn maybe_write_scheduler_dag(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+) -> VmResult<()> {
+    use std::io::Write;
+
+    let Some(path) = std::env::var_os("STOFFEL_MPC_SCHEDULER_DAG_OUT") else {
+        return Ok(());
+    };
+    let count = u32::try_from(multiplications.len()).map_err(|_| {
+        VmError::Message("scheduler DAG has more nodes than the diagnostic format supports".into())
+    })?;
+    let write = || -> std::io::Result<()> {
+        let mut writer = std::io::BufWriter::new(std::fs::File::create(path)?);
+        writer.write_all(b"STFSCH01")?;
+        writer.write_all(&(capacity as u64).to_le_bytes())?;
+        writer.write_all(&count.to_le_bytes())?;
+        for (index, node) in multiplications.iter().enumerate() {
+            writer.write_all(&(index as u32).to_le_bytes())?;
+            writer.write_all(&node.share.id().to_le_bytes())?;
+            writer.write_all(&(node.dependency_depth as u32).to_le_bytes())?;
+            writer.write_all(&(node.remaining_depth as u32).to_le_bytes())?;
+            writer.write_all(&(node.predecessors.len() as u32).to_le_bytes())?;
+            for &predecessor in &node.predecessors {
+                writer.write_all(&(predecessor as u32).to_le_bytes())?;
+            }
+        }
+        writer.flush()
+    };
+    write().map_err(|error| {
+        VmError::Message(format!("failed to write scheduler DAG diagnostic: {error}"))
+    })
+}
+
+fn select_multiplication_plan(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    // Pre-plan multiple deterministic legal schedules and return the shortest.
+    // The source-order plan is the historical HLFET scheduler, so retaining it
+    // as a candidate makes every added priority monotonic: it can improve the
+    // online round count but cannot regress it.
+    let source_plan =
+        plan_multiplication_dag(multiplications, capacity, SchedulePriority::SourceOrder)?;
+    let source_rounds = source_plan.len();
+    let lower_bound = multiplication_plan_lower_bound(multiplications, capacity, source_rounds);
+    if source_rounds == lower_bound {
+        emit_scheduler_diagnostics(source_rounds, None, None, None, source_rounds, lower_bound);
+        return Ok(source_plan);
+    }
+
+    let fanout_plan =
+        plan_multiplication_dag(multiplications, capacity, SchedulePriority::SuccessorFanout)?;
+    let fanout_rounds = fanout_plan.len();
+    debug_assert!(fanout_rounds >= lower_bound);
+    if fanout_rounds == lower_bound {
+        emit_scheduler_diagnostics(
+            source_rounds,
+            Some(fanout_rounds),
+            None,
+            None,
+            fanout_rounds,
+            lower_bound,
+        );
+        return Ok(fanout_plan);
+    }
+
+    let deadline_plan = plan_backward_deadline_dag(multiplications, capacity)?;
+    let deadline_rounds = deadline_plan.len();
+    if deadline_rounds == lower_bound {
+        emit_scheduler_diagnostics(
+            source_rounds,
+            Some(fanout_rounds),
+            Some(deadline_rounds),
+            None,
+            deadline_rounds,
+            lower_bound,
+        );
+        return Ok(deadline_plan);
+    }
+    let pressure_plan = plan_backward_capacity_balance_dag(multiplications, capacity)?;
+    let pressure_rounds = pressure_plan.len();
+    let mut best = source_plan;
+    for candidate in [fanout_plan, deadline_plan, pressure_plan] {
+        if candidate.len() < best.len() {
+            best = candidate;
+        }
+    }
+    debug_assert!(best.len() >= lower_bound);
+    emit_scheduler_diagnostics(
+        source_rounds,
+        Some(fanout_rounds),
+        Some(deadline_rounds),
+        Some(pressure_rounds),
+        best.len(),
+        lower_bound,
+    );
+    Ok(best)
+}
+
+fn emit_scheduler_diagnostics(
+    source_rounds: usize,
+    fanout_rounds: Option<usize>,
+    deadline_rounds: Option<usize>,
+    pressure_rounds: Option<usize>,
+    selected_rounds: usize,
+    lower_bound: usize,
+) {
+    if std::env::var_os("STOFFEL_MPC_SCHEDULER_DIAGNOSTICS").is_none() {
+        return;
+    }
+    let label = |rounds: Option<usize>| {
+        rounds
+            .map(|rounds| rounds.to_string())
+            .unwrap_or_else(|| "skipped".to_owned())
+    };
+    eprintln!(
+        "MPC_SCHEDULER candidates source={} fanout={} backward_deadline={} \
+backward_capacity_balance={} \
+selected={} certified_lower_bound={} optimal={}",
+        source_rounds,
+        label(fanout_rounds),
+        label(deadline_rounds),
+        label(pressure_rounds),
+        selected_rounds,
+        lower_bound,
+        selected_rounds == lower_bound,
+    );
+}
+
+/// A cheap scheduler-independent lower bound on the number of multiplication
+/// sessions required by the backend contract.
+///
+/// Every dependency chain consumes one session per multiplication. In
+/// addition, different runtime share types/representations cannot share a
+/// backend batch, so each compatibility group independently needs
+/// `ceil(work / capacity)` sessions. Taking the larger bound is sound for every
+/// scheduling priority and lets diagnostics distinguish proven optima from
+/// merely good upper bounds.
+fn multiplication_plan_lower_bound(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    legal_upper_bound: usize,
+) -> usize {
+    assert!(capacity > 0);
+    let critical_path = multiplications
+        .iter()
+        .map(|node| node.dependency_depth)
+        .max()
+        .unwrap_or(0);
+    let mut work_by_group: FxHashMap<MultiplicationGroup, usize> = FxHashMap::default();
+    for node in multiplications {
+        *work_by_group.entry(multiplication_group(node)).or_default() += 1;
+    }
+    let grouped_work = work_by_group
+        .into_values()
+        .map(|work| work.div_ceil(capacity))
+        .sum::<usize>();
+    let basic_bound = critical_path.max(grouped_work);
+    let mut lower_bound = basic_bound;
+    for horizon in basic_bound..legal_upper_bound {
+        if multiplication_window_horizon_infeasible(multiplications, capacity, horizon) {
+            lower_bound = horizon + 1;
+        }
+    }
+    lower_bound
+}
+
+/// Necessary capacity condition for a candidate horizon. A multiplication's
+/// dependency depth is its earliest legal session; its remaining depth gives
+/// the latest session from which all descendants can still finish. Every node
+/// whose entire legal window lies inside `[first, last]` must execute there, so
+/// more than `capacity * interval_length` such nodes is a machine-checkable
+/// contradiction independent of the scheduling heuristic.
+fn multiplication_window_horizon_infeasible(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    horizon: usize,
+) -> bool {
+    if multiplications.is_empty() {
+        return false;
+    }
+    let stride = horizon + 2;
+    let mut forced = vec![0usize; stride * stride];
+    let cell = |earliest: usize, latest: usize| earliest * stride + latest;
+    for node in multiplications {
+        let earliest = node.dependency_depth;
+        let Some(latest) = horizon
+            .checked_sub(node.remaining_depth)
+            .map(|round| round + 1)
+        else {
+            return true;
+        };
+        if earliest > latest {
+            return true;
+        }
+        forced[cell(earliest, latest)] += 1;
+    }
+    for earliest in (1..=horizon).rev() {
+        for latest in 1..=horizon {
+            forced[cell(earliest, latest)] = forced[cell(earliest, latest)]
+                + forced[cell(earliest + 1, latest)]
+                + forced[cell(earliest, latest - 1)]
+                - forced[cell(earliest + 1, latest - 1)];
+        }
+    }
+    for first in 1..=horizon {
+        for last in first..=horizon {
+            if forced[cell(first, last)] > capacity * (last - first + 1) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Build a reverse HLFET schedule, favoring nodes that jointly release the
+/// greatest number of critical-depth parents, then use its round assignments
+/// as forward deadlines. The two passes expose capacity pressure on both ends
+/// of the DAG while each returned session remains a normal legal list-schedule
+/// step.
+fn plan_backward_deadline_dag(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    plan_backward_deadline_dag_with_priority(
+        multiplications,
+        capacity,
+        BackwardSchedulePriority::CriticalDepth,
+    )
+}
+
+/// Build an independent reverse schedule that balances the number of complete
+/// capacity batches on either side of a ready multiplication. Its assignments
+/// expose legal forward schedules that a longest-path reverse pass cannot,
+/// while the outer portfolio retains every historical candidate as a
+/// round-count fallback.
+fn plan_backward_capacity_balance_dag(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    plan_backward_deadline_dag_with_priority(
+        multiplications,
+        capacity,
+        BackwardSchedulePriority::CapacityBalance,
+    )
+}
+
+fn plan_backward_deadline_dag_with_priority(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    priority: BackwardSchedulePriority,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    let backward = build_backward_schedule(multiplications, capacity, priority)?;
+    let deadlines = backward_deadlines(multiplications.len(), &backward);
+    plan_multiplication_dag_by_deadline(multiplications, capacity, &deadlines)
+}
+
+fn build_backward_schedule(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    priority: BackwardSchedulePriority,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    let mut remaining_successors: Vec<_> = multiplications
+        .iter()
+        .map(|node| node.successors.len())
+        .collect();
+    let mut ready: FxHashMap<MultiplicationGroup, BinaryHeap<ReadyBackwardMultiplication>> =
+        FxHashMap::default();
+    for (index, node) in multiplications.iter().enumerate() {
+        if remaining_successors[index] == 0 {
+            push_backward_ready(&mut ready, index, node, multiplications, capacity, priority);
+        }
+    }
+
+    let mut scheduled = 0usize;
+    let mut backward = Vec::new();
+    while scheduled < multiplications.len() {
+        let group = ready
+            .iter()
+            .filter_map(|(group, queue)| queue.peek().map(|item| (*group, *item)))
+            .max_by(|(_, left), (_, right)| left.cmp(right))
+            .map(|(group, _)| group)
+            .ok_or_else(|| {
+                VmError::Message(
+                    "deferred MPC multiplication graph contains a dependency cycle".to_owned(),
+                )
+            })?;
+        let queue = ready.get_mut(&group).expect("selected ready group exists");
+        let mut round = Vec::with_capacity(capacity.min(queue.len()));
+        while round.len() < capacity {
+            let Some(item) = queue.pop() else {
+                break;
+            };
+            round.push(item.index);
+        }
+        if queue.is_empty() {
+            ready.remove(&group);
+        }
+
+        for &index in &round {
+            scheduled += 1;
+            for &predecessor in &multiplications[index].predecessors {
+                remaining_successors[predecessor] -= 1;
+                if remaining_successors[predecessor] == 0 {
+                    push_backward_ready(
+                        &mut ready,
+                        predecessor,
+                        &multiplications[predecessor],
+                        multiplications,
+                        capacity,
+                        priority,
+                    );
+                }
+            }
+        }
+        backward.push((group, round));
+    }
+    backward.reverse();
+    Ok(backward)
+}
+
+fn backward_deadlines(
+    multiplication_count: usize,
+    backward: &[(MultiplicationGroup, Vec<usize>)],
+) -> Vec<usize> {
+    let mut deadlines = vec![usize::MAX; multiplication_count];
+    for (round, (_, nodes)) in backward.iter().enumerate() {
+        for &node in nodes {
+            deadlines[node] = round;
+        }
+    }
+    deadlines
+}
+
+fn push_backward_ready(
+    ready: &mut FxHashMap<MultiplicationGroup, BinaryHeap<ReadyBackwardMultiplication>>,
+    index: usize,
+    node: &MultiplicationNode,
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    priority: BackwardSchedulePriority,
+) {
+    let group = multiplication_group(node);
+    let critical_predecessors = node
+        .predecessors
+        .iter()
+        .filter(|&&predecessor| {
+            multiplications[predecessor].dependency_depth + 1 == node.dependency_depth
+        })
+        .count();
+    let critical_successors = node
+        .successors
+        .iter()
+        .filter(|&&successor| {
+            multiplications[successor].dependency_depth == node.dependency_depth + 1
+        })
+        .count();
+    let (primary_priority, secondary_priority, tertiary_priority) = match priority {
+        BackwardSchedulePriority::CriticalDepth => (
+            node.dependency_depth as i128,
+            critical_predecessors as i128,
+            node.predecessors.len(),
+        ),
+        BackwardSchedulePriority::CapacityBalance => (
+            critical_predecessors as i128,
+            backward_capacity_pressure(node, critical_successors, capacity),
+            node.successors.len(),
+        ),
+    };
+    ready
+        .entry(group)
+        .or_default()
+        .push(ReadyBackwardMultiplication {
+            index,
+            primary_priority,
+            secondary_priority,
+            tertiary_priority,
+            share_id: node.share.id(),
+        });
+}
+
+/// Capacity-normalized branching pressure for reverse list scheduling.
+///
+/// Critical fan-in remains the primary key because a join synchronizes scarce
+/// predecessor chains. Within that class, logarithmic fan-out rewards broad
+/// downstream influence without allowing one enormous frontier to dominate.
+/// Whole-batch terms reserve enough upstream work without over-expanding the
+/// downstream frontier. This score never decides correctness: it constructs an
+/// additional legal candidate and the scheduler retains the shortest candidate
+/// plan.
+fn backward_capacity_pressure(
+    node: &MultiplicationNode,
+    critical_successors: usize,
+    capacity: usize,
+) -> i128 {
+    let predecessor_count = node.predecessors.len();
+    let successor_count = node.successors.len();
+    let quarter_capacity = (capacity / 4).max(1);
+    2 * log2_one_plus(successor_count) as i128 + critical_successors as i128
+        - 2 * log2_one_plus(predecessor_count) as i128
+        - 4 * (successor_count / capacity) as i128
+        + 8 * (predecessor_count / quarter_capacity) as i128
+}
+
+fn log2_one_plus(value: usize) -> usize {
+    value
+        .checked_add(1)
+        .map_or(usize::BITS as usize, |value| value.ilog2() as usize)
+}
+
+fn plan_multiplication_dag_by_deadline(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    deadlines: &[usize],
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    assert_eq!(multiplications.len(), deadlines.len());
+    let mut indegrees: Vec<_> = multiplications
+        .iter()
+        .map(|node| node.predecessors.len())
+        .collect();
+    let mut ready: FxHashMap<MultiplicationGroup, BinaryHeap<ReadyDeadlineMultiplication>> =
+        FxHashMap::default();
+    for (index, node) in multiplications.iter().enumerate() {
+        if indegrees[index] == 0 {
+            push_deadline_ready(&mut ready, index, node, deadlines[index]);
+        }
+    }
+
+    let mut completed = 0usize;
+    let mut plan = Vec::new();
+    while completed < multiplications.len() {
+        let group = ready
+            .iter()
+            .filter_map(|(group, queue)| queue.peek().map(|item| (*group, *item)))
+            .max_by(|(_, left), (_, right)| left.cmp(right))
+            .map(|(group, _)| group)
+            .ok_or_else(|| {
+                VmError::Message(
+                    "deferred MPC multiplication graph contains a dependency cycle".to_owned(),
+                )
+            })?;
+        let queue = ready.get_mut(&group).expect("selected ready group exists");
+        let mut round = Vec::with_capacity(capacity.min(queue.len()));
+        while round.len() < capacity {
+            let Some(item) = queue.pop() else {
+                break;
+            };
+            round.push(item.index);
+        }
+        if queue.is_empty() {
+            ready.remove(&group);
+        }
+
+        for &index in &round {
+            completed += 1;
+            for &successor in &multiplications[index].successors {
+                indegrees[successor] -= 1;
+                if indegrees[successor] == 0 {
+                    push_deadline_ready(
+                        &mut ready,
+                        successor,
+                        &multiplications[successor],
+                        deadlines[successor],
+                    );
+                }
+            }
+        }
+        plan.push((group, round));
+    }
+    Ok(plan)
+}
+
+fn push_deadline_ready(
+    ready: &mut FxHashMap<MultiplicationGroup, BinaryHeap<ReadyDeadlineMultiplication>>,
+    index: usize,
+    node: &MultiplicationNode,
+    deadline: usize,
+) {
+    ready
+        .entry(multiplication_group(node))
+        .or_default()
+        .push(ReadyDeadlineMultiplication {
+            index,
+            deadline,
+            share_id: node.share.id(),
+        });
+}
+
+fn plan_multiplication_dag(
+    multiplications: &[MultiplicationNode],
+    capacity: usize,
+    priority: SchedulePriority,
+) -> VmResult<Vec<(MultiplicationGroup, Vec<usize>)>> {
+    let mut indegrees: Vec<_> = multiplications
+        .iter()
+        .map(|node| node.predecessors.len())
+        .collect();
+    let mut ready: FxHashMap<MultiplicationGroup, BinaryHeap<ReadyMultiplication>> =
+        FxHashMap::default();
+    for (index, node) in multiplications.iter().enumerate() {
+        if indegrees[index] == 0 {
+            push_ready(&mut ready, index, node, priority);
+        }
+    }
+
+    let mut completed = 0usize;
+    let mut plan = Vec::new();
+    while completed < multiplications.len() {
+        let group = ready
+            .iter()
+            .filter_map(|(group, queue)| queue.peek().map(|item| (*group, *item)))
+            .max_by(|(_, left), (_, right)| left.cmp(right))
+            .map(|(group, _)| group)
+            .ok_or_else(|| {
+                VmError::Message(
+                    "deferred MPC multiplication graph contains a dependency cycle".to_owned(),
+                )
+            })?;
+        let queue = ready.get_mut(&group).expect("selected ready group exists");
+        let mut round = Vec::with_capacity(capacity.min(queue.len()));
+        while round.len() < capacity {
+            let Some(item) = queue.pop() else {
+                break;
+            };
+            round.push(item.index);
+        }
+        if queue.is_empty() {
+            ready.remove(&group);
+        }
+
+        // Successors released by this protocol session become eligible only
+        // for the next planned session.
+        for &index in &round {
+            completed += 1;
+            for &successor in &multiplications[index].successors {
+                indegrees[successor] -= 1;
+                if indegrees[successor] == 0 {
+                    push_ready(&mut ready, successor, &multiplications[successor], priority);
+                }
+            }
+        }
+        plan.push((group, round));
+    }
+    Ok(plan)
+}
+
+fn push_ready(
+    ready: &mut FxHashMap<MultiplicationGroup, BinaryHeap<ReadyMultiplication>>,
+    index: usize,
+    node: &MultiplicationNode,
+    priority: SchedulePriority,
+) {
+    let group = multiplication_group(node);
+    let (remaining_depth, secondary_priority) = match priority {
+        SchedulePriority::SourceOrder => (node.remaining_depth, 0),
+        SchedulePriority::SuccessorFanout => (node.remaining_depth, node.successors.len()),
+    };
+    ready.entry(group).or_default().push(ReadyMultiplication {
+        index,
+        remaining_depth,
+        secondary_priority,
+        share_id: node.share.id(),
+    });
+}
+
+fn multiplication_group(node: &MultiplicationNode) -> MultiplicationGroup {
+    MultiplicationGroup {
+        share_type: node.share.share_type(),
+        format: node.share.format(),
+    }
+}
+
+fn materialize_local_share<E: MpcEngine + ?Sized>(
+    engine: &E,
+    root: &ShareData,
+) -> VmResult<ShareData> {
+    if matches!(root, ShareData::Public(_)) {
+        return materialize_public_share_sync(engine, root);
+    }
+    if let Some(materialized) = root.materialized() {
+        return Ok(materialized.clone());
+    }
+
+    let mut stack = vec![(root.clone(), false)];
+    while let Some((share, operands_visited)) = stack.pop() {
+        if matches!(share, ShareData::Public(_)) {
+            materialize_public_share_sync(engine, &share)?;
+            continue;
+        }
+        if share.materialized().is_some() {
+            continue;
+        }
+        let node = share.deferred_node().cloned().ok_or_else(|| {
+            VmError::Message("deferred share lost its expression node".to_owned())
+        })?;
+        if node.operation().is_multiply() {
+            return Err(VmError::Message(format!(
+                "deferred multiplication {} was materialized before its dependencies completed",
+                node.id()
+            )));
+        }
+
+        if !operands_visited {
+            stack.push((share, true));
+            let mut operands = Vec::new();
+            node.operation()
+                .visit_operands(|operand| operands.push(operand.clone()));
+            for operand in operands.into_iter().rev() {
+                if operand.materialized().is_none() {
+                    stack.push((operand, false));
+                }
+            }
+            continue;
+        }
+
+        let result = evaluate_local_operation(engine, &node)?;
+        let _ = node.set_resolved(result);
+    }
+
+    root.materialized().cloned().ok_or_else(|| {
+        VmError::Message("failed to materialize deferred local share expression".to_owned())
+    })
+}
+
+fn materialize_public_share_sync<E: MpcEngine + ?Sized>(
+    engine: &E,
+    share: &ShareData,
+) -> VmResult<ShareData> {
+    let ShareData::Public(public) = share else {
+        return Ok(share.materialized().unwrap_or(share).clone());
+    };
+    if let Some(materialized) = public.materialized() {
+        return Ok(materialized.clone());
+    }
+    let materialized = engine
+        .input_share(public.input())
+        .map_mpc_backend_err("input_share")?;
+    let _ = public.set_materialized(materialized.clone());
+    Ok(public.materialized().unwrap_or(&materialized).clone())
+}
+
+fn evaluate_local_operation<E: MpcEngine + ?Sized>(
+    engine: &E,
+    node: &DeferredShare,
+) -> VmResult<ShareData> {
+    let ty = node.share_type();
+    let (template, result) = match node.operation() {
+        DeferredShareOperation::Multiply { .. } => {
+            return Err(VmError::Message(
+                "interactive multiplication reached the local evaluator".to_owned(),
+            ));
+        }
+        DeferredShareOperation::Add { left, right } => (
+            left,
+            engine
+                .add_share_local(ty, left.as_bytes(), right.as_bytes())
+                .map_mpc_backend_err("add_share_local")?,
+        ),
+        DeferredShareOperation::Sub { left, right } => (
+            left,
+            engine
+                .sub_share_local(ty, left.as_bytes(), right.as_bytes())
+                .map_mpc_backend_err("sub_share_local")?,
+        ),
+        DeferredShareOperation::Neg { share } => (
+            share,
+            engine
+                .neg_share_local(ty, share.as_bytes())
+                .map_mpc_backend_err("neg_share_local")?,
+        ),
+        DeferredShareOperation::AddScalar { share, scalar } => (
+            share,
+            engine
+                .add_share_scalar_local(ty, share.as_bytes(), *scalar)
+                .map_mpc_backend_err("add_share_scalar_local")?,
+        ),
+        DeferredShareOperation::SubScalar { share, scalar } => (
+            share,
+            engine
+                .sub_share_scalar_local(ty, share.as_bytes(), *scalar)
+                .map_mpc_backend_err("sub_share_scalar_local")?,
+        ),
+        DeferredShareOperation::ScalarSub { scalar, share } => (
+            share,
+            engine
+                .scalar_sub_share_local(ty, *scalar, share.as_bytes())
+                .map_mpc_backend_err("scalar_sub_share_local")?,
+        ),
+        DeferredShareOperation::DivScalar { share, scalar } => (
+            share,
+            engine
+                .div_share_scalar_local(ty, share.as_bytes(), *scalar)
+                .map_mpc_backend_err("div_share_scalar_local")?,
+        ),
+        DeferredShareOperation::MulScalar { share, scalar } => (
+            share,
+            engine
+                .mul_share_scalar_local(ty, share.as_bytes(), *scalar)
+                .map_mpc_backend_err("mul_share_scalar_local")?,
+        ),
+        DeferredShareOperation::MulField { share, scalar } => (
+            share,
+            engine
+                .mul_share_field_local(ty, share.as_bytes(), scalar)
+                .map_mpc_backend_err("mul_share_field_local")?,
+        ),
+        DeferredShareOperation::AddField { share, field } => (
+            share,
+            engine
+                .add_share_field_local(ty, share.as_bytes(), field)
+                .map_mpc_backend_err("add_share_field_local")?,
+        ),
+    };
+
+    share_algebra::preserve_share_data_format_for_curve(engine.curve_config(), template, result)
+        .map_mpc_backend_err("preserve_share_data_format")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn opaque(value: u8) -> ShareData {
+        ShareData::Opaque(vec![value].into())
+    }
+
+    fn multiply(ty: ShareType, left: ShareData, right: ShareData) -> ShareData {
+        ShareData::deferred_multiply(ty, left, right)
+    }
+
+    fn add(ty: ShareType, left: ShareData, right: ShareData) -> ShareData {
+        ShareData::deferred(
+            ty,
+            ShareDataFormat::Opaque,
+            DeferredShareOperation::Add { left, right },
+        )
+    }
+
+    #[test]
+    fn scheduler_selects_a_shorter_fanout_plan_without_regressing_source_order() {
+        let ty = ShareType::secret_int(64);
+        let first = multiply(ty, opaque(1), opaque(2));
+        let second = multiply(ty, opaque(3), opaque(4));
+        let shared_parent = multiply(ty, opaque(5), opaque(6));
+
+        // The first sink needs all three source products. The other two sinks
+        // both need `shared_parent`. With capacity two, source-order HLFET
+        // takes four sessions, while the equally legal fanout tie-break starts
+        // the shared parent immediately and completes in three.
+        let all_sources = add(
+            ty,
+            add(ty, first.clone(), second.clone()),
+            shared_parent.clone(),
+        );
+        let roots = vec![
+            multiply(ty, all_sources, opaque(7)),
+            multiply(ty, shared_parent.clone(), opaque(8)),
+            multiply(ty, shared_parent, opaque(9)),
+        ];
+        let dag = build_multiplication_dag(&roots);
+
+        let source = plan_multiplication_dag(&dag, 2, SchedulePriority::SourceOrder)
+            .expect("source-order schedule should be legal");
+        let fanout = plan_multiplication_dag(&dag, 2, SchedulePriority::SuccessorFanout)
+            .expect("fanout schedule should be legal");
+        let selected =
+            select_multiplication_plan(&dag, 2).expect("scheduler should select a legal plan");
+
+        assert_eq!(source.len(), 4);
+        assert_eq!(fanout.len(), 3);
+        assert_eq!(selected.len(), fanout.len());
+        assert_eq!(
+            multiplication_plan_lower_bound(&dag, 2, selected.len()),
+            selected.len()
+        );
+        assert!(selected.len() <= source.len());
+    }
+
+    #[test]
+    fn scheduler_uses_backward_capacity_pressure_to_start_prerequisites_early() {
+        let ty = ShareType::secret_int(64);
+        let first = multiply(ty, opaque(1), opaque(2));
+        let second = multiply(ty, opaque(3), opaque(4));
+        let third = multiply(ty, opaque(5), opaque(6));
+        let all_sources = add(ty, add(ty, first.clone(), second.clone()), third.clone());
+        let first_sink = multiply(ty, all_sources.clone(), opaque(7));
+        let second_sink = multiply(ty, all_sources, opaque(8));
+        let third_sink = multiply(ty, add(ty, second, third), opaque(9));
+        let final_inputs = add(
+            ty,
+            add(ty, first, first_sink),
+            add(ty, second_sink, third_sink),
+        );
+        let roots = vec![multiply(ty, final_inputs, opaque(10))];
+        let dag = build_multiplication_dag(&roots);
+
+        let source = plan_multiplication_dag(&dag, 2, SchedulePriority::SourceOrder)
+            .expect("source-order schedule should be legal");
+        let fanout = plan_multiplication_dag(&dag, 2, SchedulePriority::SuccessorFanout)
+            .expect("fanout schedule should be legal");
+        let deadline = plan_backward_deadline_dag(&dag, 2)
+            .expect("backward-deadline schedule should be legal");
+        let selected =
+            select_multiplication_plan(&dag, 2).expect("scheduler should select a legal plan");
+
+        assert_eq!(source.len(), 5);
+        assert_eq!(fanout.len(), 5);
+        assert_eq!(deadline.len(), 4);
+        assert_eq!(selected.len(), deadline.len());
+        assert_eq!(
+            multiplication_plan_lower_bound(&dag, 2, selected.len()),
+            selected.len()
+        );
+        assert!(selected.len() <= source.len());
+    }
+
+    #[test]
+    fn scheduler_certificate_accounts_for_incompatible_batch_groups() {
+        let wide = ShareType::secret_int(64);
+        let bit = ShareType::secret_int(1);
+        let roots = vec![
+            multiply(wide, opaque(1), opaque(2)),
+            multiply(bit, opaque(3), opaque(4)),
+        ];
+        let dag = build_multiplication_dag(&roots);
+        let selected =
+            select_multiplication_plan(&dag, 2).expect("scheduler should select a legal plan");
+
+        // Both multiplications are independent and the raw width is two, but
+        // the backend cannot put different ShareTypes in one homogeneous
+        // batch. Each compatibility group therefore requires its own session.
+        assert_eq!(multiplication_plan_lower_bound(&dag, 2, selected.len()), 2);
+        assert_eq!(selected.len(), 2);
+    }
+
+    #[test]
+    fn scheduler_certificate_detects_interval_capacity_pressure() {
+        let ty = ShareType::secret_int(64);
+        let root = multiply(ty, opaque(1), opaque(2));
+        let roots = (0..4)
+            .map(|value| multiply(ty, root.clone(), opaque(value + 3)))
+            .collect::<Vec<_>>();
+        let dag = build_multiplication_dag(&roots);
+        let selected =
+            select_multiplication_plan(&dag, 3).expect("scheduler should select a legal plan");
+
+        // Critical path and raw work both say two rounds. The root consumes the
+        // first round by itself, forcing all four children into a single
+        // three-wide second-round window, so two rounds are impossible.
+        assert_eq!(selected.len(), 3);
+        assert_eq!(multiplication_plan_lower_bound(&dag, 3, selected.len()), 3);
+        assert!(multiplication_window_horizon_infeasible(&dag, 3, 2));
+        assert!(!multiplication_window_horizon_infeasible(&dag, 3, 3));
+    }
+}

--- a/crates/stoffel-vm/src/net/deployment_epoch.rs
+++ b/crates/stoffel-vm/src/net/deployment_epoch.rs
@@ -1,0 +1,154 @@
+use crate::net::deployment_manifest::DeploymentId;
+use crate::storage::preproc::{PreprocStore, PreprocStoreError};
+use serde::{Deserialize, Serialize};
+
+const EPOCH_NS: &[u8] = b"epoch:";
+const RUNSTATE_NS: &[u8] = b"runstate:";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RunPhase {
+    Prepared,
+    InProgress,
+    Complete,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunState {
+    pub run_id: u64,
+    pub phase: RunPhase,
+}
+
+fn deployment_program_key(
+    prefix: &str,
+    deployment_id: &DeploymentId,
+    program_hash: &[u8; 32],
+) -> Vec<u8> {
+    let mut key = Vec::with_capacity(prefix.len() + deployment_id.as_str().len() + 1 + 64);
+    key.extend_from_slice(prefix.as_bytes());
+    key.extend_from_slice(deployment_id.as_str().as_bytes());
+    key.push(b':');
+    key.extend_from_slice(hex::encode(program_hash).as_bytes());
+    key
+}
+
+fn observed_key(deployment_id: &DeploymentId, program_hash: &[u8; 32], party_id: usize) -> Vec<u8> {
+    let mut key = deployment_program_key("last_observed:", deployment_id, program_hash);
+    key.push(b':');
+    key.extend_from_slice(party_id.to_string().as_bytes());
+    key
+}
+
+fn runstate_key(
+    program_hash: &[u8; 32],
+    persistent_identity: [u8; 32],
+    party_id: usize,
+) -> Vec<u8> {
+    let mut key = Vec::with_capacity(32 + 32 + 8);
+    key.extend_from_slice(program_hash);
+    key.extend_from_slice(&persistent_identity);
+    key.extend_from_slice(&party_id.to_le_bytes());
+    key
+}
+
+fn decode_u64(raw: Option<Vec<u8>>) -> Result<u64, PreprocStoreError> {
+    match raw {
+        Some(raw) => {
+            if raw.len() != 8 {
+                return Err(PreprocStoreError::Deserialization(format!(
+                    "epoch value has {} bytes, expected 8",
+                    raw.len()
+                )));
+            }
+            Ok(u64::from_le_bytes(raw.as_slice().try_into().map_err(
+                |_| PreprocStoreError::Deserialization("bad epoch bytes".into()),
+            )?))
+        }
+        None => Ok(0),
+    }
+}
+
+pub async fn allocate_epoch_and_record(
+    store: &dyn PreprocStore,
+    deployment_id: &DeploymentId,
+    program_hash: &[u8; 32],
+) -> Result<(u64, bool), PreprocStoreError> {
+    let next_key = deployment_program_key("next:", deployment_id, program_hash);
+    let announced_key = deployment_program_key("announced:", deployment_id, program_hash);
+    let next = decode_u64(store.load_blob(EPOCH_NS, &next_key).await?)?;
+    let announced = decode_u64(store.load_blob(EPOCH_NS, &announced_key).await?)?;
+    if next > announced {
+        return Ok((announced + 1, true));
+    }
+    let allocated = store.atomic_increment(EPOCH_NS, &next_key).await?;
+    Ok((allocated, false))
+}
+
+pub async fn record_announced_epoch(
+    store: &dyn PreprocStore,
+    deployment_id: &DeploymentId,
+    program_hash: &[u8; 32],
+    epoch: u64,
+) -> Result<(), PreprocStoreError> {
+    let announced_key = deployment_program_key("announced:", deployment_id, program_hash);
+    store
+        .store_blob(EPOCH_NS, &announced_key, &epoch.to_le_bytes())
+        .await
+}
+
+pub async fn reconcile_announced_epochs(
+    store: &dyn PreprocStore,
+    deployment_id: &DeploymentId,
+    program_hash: &[u8; 32],
+    party_id: usize,
+) -> Result<u64, PreprocStoreError> {
+    let announced_key = deployment_program_key("announced:", deployment_id, program_hash);
+    let last_key = observed_key(deployment_id, program_hash, party_id);
+    let announced = decode_u64(store.load_blob(EPOCH_NS, &announced_key).await?)?;
+    let last_observed = decode_u64(store.load_blob(EPOCH_NS, &last_key).await?)?;
+    Ok(announced.max(last_observed))
+}
+
+pub async fn record_observed_epoch(
+    store: &dyn PreprocStore,
+    deployment_id: &DeploymentId,
+    program_hash: &[u8; 32],
+    party_id: usize,
+    epoch: u64,
+) -> Result<(), PreprocStoreError> {
+    let last_key = observed_key(deployment_id, program_hash, party_id);
+    let last = decode_u64(store.load_blob(EPOCH_NS, &last_key).await?)?;
+    if epoch < last {
+        return Err(PreprocStoreError::Serialization(format!(
+            "stale epoch {epoch} is below last observed {last}"
+        )));
+    }
+    store
+        .store_blob(EPOCH_NS, &last_key, &epoch.to_le_bytes())
+        .await
+}
+
+pub async fn write_runstate(
+    store: &dyn PreprocStore,
+    program_hash: &[u8; 32],
+    persistent_identity: [u8; 32],
+    party_id: usize,
+    state: RunState,
+) -> Result<(), PreprocStoreError> {
+    let key = runstate_key(program_hash, persistent_identity, party_id);
+    let data = bincode::serialize(&state)?;
+    store.store_blob(RUNSTATE_NS, &key, &data).await
+}
+
+pub async fn read_runstate(
+    store: &dyn PreprocStore,
+    program_hash: &[u8; 32],
+    persistent_identity: [u8; 32],
+    party_id: usize,
+) -> Result<Option<RunState>, PreprocStoreError> {
+    let key = runstate_key(program_hash, persistent_identity, party_id);
+    store
+        .load_blob(RUNSTATE_NS, &key)
+        .await?
+        .map(|data| bincode::deserialize(&data).map_err(PreprocStoreError::from))
+        .transpose()
+}

--- a/crates/stoffel-vm/src/net/deployment_manifest.rs
+++ b/crates/stoffel-vm/src/net/deployment_manifest.rs
@@ -1,0 +1,125 @@
+use crate::net::backend::MpcBackendKind;
+use crate::net::curve::{MpcCurveConfig, MpcFieldKind};
+use crate::net::engine_config::DeploymentMode;
+use crate::net::mpc_engine::DurableIdentityDigest;
+use crate::storage::preproc::PoolAvailability;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DeploymentId(String);
+
+impl DeploymentId {
+    pub fn new(value: impl Into<String>) -> Result<Self, DeploymentManifestError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(DeploymentManifestError::InvalidDeploymentId);
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeploymentTimeouts {
+    pub quorum_timeout_secs: u64,
+    pub cursor_sync_timeout_secs: u64,
+    pub readiness_timeout_secs: u64,
+}
+
+impl Default for DeploymentTimeouts {
+    fn default() -> Self {
+        Self {
+            quorum_timeout_secs: 30,
+            cursor_sync_timeout_secs: 10,
+            readiness_timeout_secs: 5,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeploymentManifest {
+    pub deployment_id: DeploymentId,
+    pub backend: MpcBackendKind,
+    pub program_hash: [u8; 32],
+    pub program_source: String,
+    pub curve: MpcCurveConfig,
+    pub field: MpcFieldKind,
+    pub n: usize,
+    pub t: usize,
+    pub deployment_mode: DeploymentMode,
+    pub persistent_identity: Vec<DurableIdentityDigest>,
+    pub node_addresses: Vec<SocketAddr>,
+    pub coordinator_rpc: SocketAddr,
+    pub preproc_targets: PoolAvailability,
+    pub preproc_low_watermark: PoolAvailability,
+    pub capacity: u64,
+    pub timeouts: DeploymentTimeouts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum DeploymentManifestError {
+    #[error("deployment id must not be empty")]
+    InvalidDeploymentId,
+    #[error("persistent deployment manifests must use Standing mode")]
+    NotStanding,
+    #[error(
+        "manifest party count mismatch: n={n}, identities={identities}, node_addresses={addresses}"
+    )]
+    PartyCountMismatch {
+        n: usize,
+        identities: usize,
+        addresses: usize,
+    },
+    #[error("manifest threshold {threshold} must be less than party count {n}")]
+    ThresholdOutOfRange { threshold: usize, n: usize },
+    #[error("manifest field {field:?} does not match curve {curve:?}")]
+    FieldCurveMismatch {
+        field: MpcFieldKind,
+        curve: MpcCurveConfig,
+    },
+    #[error("manifest backend {backend:?} does not support curve {curve:?}: {reason}")]
+    BackendCurveUnsupported {
+        backend: MpcBackendKind,
+        curve: MpcCurveConfig,
+        reason: String,
+    },
+}
+
+impl DeploymentManifest {
+    pub fn validate(&self) -> Result<(), DeploymentManifestError> {
+        if self.deployment_mode != DeploymentMode::Standing {
+            return Err(DeploymentManifestError::NotStanding);
+        }
+        if self.persistent_identity.len() != self.n || self.node_addresses.len() != self.n {
+            return Err(DeploymentManifestError::PartyCountMismatch {
+                n: self.n,
+                identities: self.persistent_identity.len(),
+                addresses: self.node_addresses.len(),
+            });
+        }
+        if self.t >= self.n {
+            return Err(DeploymentManifestError::ThresholdOutOfRange {
+                threshold: self.t,
+                n: self.n,
+            });
+        }
+        if self.curve.field_kind() != self.field {
+            return Err(DeploymentManifestError::FieldCurveMismatch {
+                field: self.field,
+                curve: self.curve,
+            });
+        }
+        self.curve
+            .validate_for_backend(self.backend)
+            .map_err(|error| DeploymentManifestError::BackendCurveUnsupported {
+                backend: self.backend,
+                curve: self.curve,
+                reason: error.to_string(),
+            })?;
+        Ok(())
+    }
+}

--- a/crates/stoffel-vm/src/net/discovery/bootnode.rs
+++ b/crates/stoffel-vm/src/net/discovery/bootnode.rs
@@ -1,8 +1,12 @@
 use super::{registration_token_is_valid, send_ctrl, send_session_announce, DiscoveryMessage};
 use crate::net::{
-    program_sync::{send_ctrl as send_prog_ctrl, send_program_bytes, ProgramSyncMessage},
+    program_sync::{
+        program_id_from_bytes, send_ctrl as send_prog_ctrl, send_program_bytes, ProgramSyncMessage,
+    },
     session::{derive_instance_id, random_instance_id, SessionInfo, SessionMessage},
 };
+use bincode::Options;
+use serde::de::DeserializeOwned;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
 use stoffelnet::network_utils::PartyId;
 use stoffelnet::transports::quic::PeerConnection;
@@ -350,11 +354,11 @@ impl BootnodeConnection {
     }
 
     async fn handle_buffer(&mut self, buf: Vec<u8>) {
-        if let Ok(message) = bincode::deserialize::<DiscoveryMessage>(&buf) {
+        if let Ok(message) = deserialize_exact::<DiscoveryMessage>(&buf) {
             self.handle_discovery_message(message).await;
-        } else if let Ok(message) = bincode::deserialize::<ProgramSyncMessage>(&buf) {
+        } else if let Ok(message) = deserialize_exact::<ProgramSyncMessage>(&buf) {
             self.handle_program_sync_message(message).await;
-        } else if let Ok(message) = bincode::deserialize::<SessionMessage>(&buf) {
+        } else if let Ok(message) = deserialize_exact::<SessionMessage>(&buf) {
             self.handle_session_message(message);
         }
     }
@@ -708,7 +712,20 @@ fn session_nonce() -> u64 {
 }
 
 fn program_id_matches_bytes(program_id: &[u8; 32], bytes: &[u8]) -> bool {
-    blake3::hash(bytes).as_bytes() == program_id
+    program_id_from_bytes(bytes) == *program_id
+}
+
+/// The bootnode control stream multiplexes several legacy bincode enums. Root
+/// `bincode::deserialize` accepts trailing bytes, which can make a longer
+/// message from one protocol look like a shorter variant from another (for
+/// example, `SessionAck` looked like `DiscoveryMessage::ProgramFetchRequest`).
+/// Requiring full-buffer consumption makes dispatch deterministic for their
+/// distinct wire shapes.
+fn deserialize_exact<T: DeserializeOwned>(bytes: &[u8]) -> bincode::Result<T> {
+    bincode::DefaultOptions::new()
+        .with_fixint_encoding()
+        .reject_trailing_bytes()
+        .deserialize(bytes)
 }
 
 #[cfg(test)]
@@ -948,6 +965,45 @@ mod tests {
             .await;
 
         assert!(state.program_bytes_for(&[4u8; 32]).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn session_registration_accepts_canonical_domain_separated_program_id() {
+        let state = BootnodeState::new(None);
+        let conn = Arc::new(RecordingConnection::default());
+        let mut handler = BootnodeConnection::new(conn, state.clone(), None);
+        let bytes = b"valid stoffel bytecode".to_vec();
+        let program_id = program_id_from_bytes(&bytes);
+
+        handler
+            .handle_session_registration(registration(0, program_id), Some(bytes.clone()), None)
+            .await;
+
+        assert_eq!(
+            state.program_bytes_for(&program_id).await.as_deref(),
+            Some(&bytes)
+        );
+    }
+
+    #[test]
+    fn session_ack_is_not_misdecoded_as_program_fetch_request() {
+        let ack = SessionMessage::SessionAck {
+            party_id: 4,
+            program_id: [7u8; 32],
+            instance_id: 99,
+        };
+        let bytes = bincode::serialize(&ack).expect("serialize session ack");
+
+        assert!(deserialize_exact::<DiscoveryMessage>(&bytes).is_err());
+        assert!(deserialize_exact::<ProgramSyncMessage>(&bytes).is_err());
+        assert!(matches!(
+            deserialize_exact::<SessionMessage>(&bytes),
+            Ok(SessionMessage::SessionAck {
+                party_id,
+                program_id,
+                instance_id,
+            }) if party_id == 4 && program_id == [7u8; 32] && instance_id == 99
+        ));
     }
 
     #[tokio::test]

--- a/crates/stoffel-vm/src/net/hb_server.rs
+++ b/crates/stoffel-vm/src/net/hb_server.rs
@@ -17,6 +17,8 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
 use tracing::{error, info, warn};
 
+use super::mpc_protocol_sender_id;
+
 /// Configuration for HoneyBadger MPC over QUIC
 #[derive(Debug, Clone)]
 pub struct HoneyBadgerQuicConfig {
@@ -433,17 +435,17 @@ pub async fn spawn_receive_loops(
         loop {
             // Server-to-server connections (MPC parties)
             for (derived_id, connection) in scan_net.get_all_server_connections() {
-                let sender_id = connection.remote_party_id().unwrap_or(derived_id);
-                if sender_id >= n_parties {
+                let Some(sender_id) =
+                    mpc_protocol_sender_id(derived_id, connection.remote_party_id(), n_parties)
+                else {
                     tracing::debug!(
                         party_id = node_id,
                         derived_id,
-                        sender_id,
                         n_parties,
                         "Skipping non-party server connection"
                     );
                     continue;
-                }
+                };
 
                 if !spawned_server_ids.insert(sender_id) {
                     continue;
@@ -594,10 +596,11 @@ pub async fn spawn_receive_loops_split(
         loop {
             // Server-to-server connections (MPC parties)
             for (derived_id, connection) in scan_net.get_all_server_connections() {
-                let sender_id = connection.remote_party_id().unwrap_or(derived_id);
-                if sender_id >= n_parties {
+                let Some(sender_id) =
+                    mpc_protocol_sender_id(derived_id, connection.remote_party_id(), n_parties)
+                else {
                     continue;
-                }
+                };
                 if !spawned_server_ids.insert(sender_id) {
                     continue;
                 }
@@ -701,6 +704,7 @@ mod tests {
     use crate::net::mpc::honeybadger_node_opts;
 
     async fn test_server() -> HoneyBadgerQuicServer<Fr> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
         let (tx, _rx) = mpsc::channel(8);
         let bind_address = "127.0.0.1:0".parse().expect("valid local bind address");
         let opts = honeybadger_node_opts(4, 1, 0, 0, 0).expect("valid HB options");

--- a/crates/stoffel-vm/src/net/mod.rs
+++ b/crates/stoffel-vm/src/net/mod.rs
@@ -5,6 +5,7 @@ pub mod avss_server;
 pub(crate) mod broadcast;
 pub mod client_store;
 pub mod curve;
+pub(crate) mod deferred_mpc;
 pub mod deployment_epoch;
 pub mod deployment_manifest;
 pub mod discovery;
@@ -40,6 +41,23 @@ pub mod hb_engine {
 
 pub mod mpc_engine {
     pub use super::mpc::engine::*;
+}
+
+/// Resolve the authenticated sender identity for an MPC protocol connection.
+///
+/// Transport map keys are derived from certificates and are not necessarily in
+/// the same identity domain as the canonical `0..n_parties` IDs assigned to an
+/// MPC session. Once assigned, `remote_party_id` is authoritative. This helper
+/// deliberately retains the local party's loopback connection: reliable
+/// broadcast and other MPC protocols must process their own broadcasts just as
+/// they would with an in-memory network.
+pub fn mpc_protocol_sender_id(
+    transport_peer_id: usize,
+    remote_party_id: Option<usize>,
+    n_parties: usize,
+) -> Option<usize> {
+    let sender_id = remote_party_id.unwrap_or(transport_peer_id);
+    (sender_id < n_parties).then_some(sender_id)
 }
 
 // ---------------------------------------------------------------------------
@@ -144,8 +162,8 @@ pub use mpc_engine::{
 // Re-export MPC helpers (HB-specific helpers gated)
 pub use mpc::{
     avss_protocol_instance_id, default_node_opts, honeybadger_node_opts,
-    honeybadger_node_opts_with_truncation, honeybadger_protocol_instance_id,
-    honeybadger_protocol_timeout,
+    honeybadger_node_opts_with_truncation, honeybadger_node_opts_with_truncation_width,
+    honeybadger_protocol_instance_id, honeybadger_protocol_timeout,
 };
 // Re-export HoneyBadger QUIC server
 pub use hb_server::{
@@ -219,5 +237,25 @@ mod tests {
             .expect("multi-thread runtime should support blocking bridge");
 
         assert_eq!(result, 7);
+    }
+
+    #[test]
+    fn protocol_sender_uses_canonical_identity_instead_of_transport_identity() {
+        assert_eq!(mpc_protocol_sender_id(91, Some(2), 5), Some(2));
+    }
+
+    #[test]
+    fn protocol_sender_retains_loopback_for_identity_and_permuted_assignments() {
+        // Physical and canonical IDs coincide (the assignment that exposed the
+        // AVSS deadlock) and differ (a non-identity assignment). Both represent
+        // valid loopback protocol connections and must have receive loops.
+        assert_eq!(mpc_protocol_sender_id(2, Some(2), 5), Some(2));
+        assert_eq!(mpc_protocol_sender_id(91, Some(2), 5), Some(2));
+    }
+
+    #[test]
+    fn protocol_sender_rejects_ids_outside_the_session() {
+        assert_eq!(mpc_protocol_sender_id(91, None, 5), None);
+        assert_eq!(mpc_protocol_sender_id(91, Some(5), 5), None);
     }
 }

--- a/crates/stoffel-vm/src/net/mod.rs
+++ b/crates/stoffel-vm/src/net/mod.rs
@@ -5,6 +5,8 @@ pub mod avss_server;
 pub(crate) mod broadcast;
 pub mod client_store;
 pub mod curve;
+pub mod deployment_epoch;
+pub mod deployment_manifest;
 pub mod discovery;
 pub(crate) mod group_interpolation;
 pub mod hb_server;

--- a/crates/stoffel-vm/src/net/mpc.rs
+++ b/crates/stoffel-vm/src/net/mpc.rs
@@ -15,6 +15,6 @@ pub mod session_config;
 pub use helpers::NetEnvelope;
 pub use helpers::{
     avss_protocol_instance_id, default_node_opts, honeybadger_node_opts,
-    honeybadger_node_opts_with_truncation, honeybadger_protocol_instance_id,
-    honeybadger_protocol_timeout,
+    honeybadger_node_opts_with_truncation, honeybadger_node_opts_with_truncation_width,
+    honeybadger_protocol_instance_id, honeybadger_protocol_timeout,
 };

--- a/crates/stoffel-vm/src/net/mpc/avss.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss.rs
@@ -332,6 +332,8 @@ where
             secret_key,
             public_keys,
             deployment_mode,
+            n_random_shares,
+            n_triples,
         } = config;
         let (topology, local_identity, network, input_ids, open_message_router) =
             session.into_parts();
@@ -345,8 +347,8 @@ where
         let opts = AvssMpcNodeOpts::new(
             n_parties,
             threshold,
-            DEFAULT_N_RANDOM_SHARES,
-            DEFAULT_N_TRIPLES,
+            n_random_shares,
+            n_triples,
             secret_key,
             public_keys.clone(),
             instance_id_u32,

--- a/crates/stoffel-vm/src/net/mpc/avss.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss.rs
@@ -15,13 +15,18 @@
 // Only tested pairs from `MpcCurveConfig` should be used; arbitrary pairs are not guaranteed
 // to work correctly with the AVSS protocol.
 
-use crate::net::engine_config::MpcSessionConfig;
+use crate::net::engine_config::{DeploymentMode, MpcSessionConfig};
 use crate::net::mpc_engine::{DurableIdentityDigest, MpcPartyId, MpcSessionTopology};
 use ark_ec::CurveGroup;
 use ark_ff::{FftField, PrimeField};
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
-use std::sync::{atomic::AtomicBool, Arc};
+use std::ops::{Deref, DerefMut};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
+    Arc, RwLock as StdRwLock,
+};
+use std::time::Duration;
 use stoffelmpc_mpc::avss_mpc::{
     AvssMPCNode as AvssMpcNode, AvssMPCNodeOpts as AvssMpcNodeOpts, AvssSessionId,
 };
@@ -48,6 +53,7 @@ pub type Bls12381AvssField = ark_bls12_381::Fr;
 pub type Bls12381AvssGroup = ark_bls12_381::G1Projective;
 pub type Bls12381AvssShare = FeldmanShamirShare<Bls12381AvssField, Bls12381AvssGroup>;
 use session_ids::{field_from_usize, protocol_instance_id_u32, usize_seed, AvssSessionIds};
+const DEFAULT_RESET_DRAIN_TIMEOUT_MS: u64 = 30_000;
 
 pub fn decode_bls12381_avss_field(bytes: &[u8]) -> Result<Bls12381AvssField, String> {
     use ark_ff::PrimeField;
@@ -118,10 +124,13 @@ where
     G: CurveGroup<ScalarField = F>,
 {
     topology: MpcSessionTopology,
+    current_instance_id: AtomicU64,
     local_identity: DurableIdentityDigest,
     net: Arc<QuicNetworkManager>,
+    input_ids: Vec<ClientId>,
     /// Full AVSS MPC node (share gen, multiplication, preprocessing, message routing)
     avss_node: Arc<Mutex<AvssMpcNode<F, Avid<AvssSessionId>, G>>>,
+    in_flight: Arc<AtomicUsize>,
     /// Generated Feldman shares indexed by user-defined key name
     stored_shares: Arc<Mutex<BTreeMap<String, FeldmanShamirShare<F, G>>>>,
     /// Allocates AVSS protocol session IDs in the engine's instance namespace.
@@ -135,6 +144,7 @@ where
     /// Retained for potential node re-creation; read by the inner `AvssMpcNode`.
     #[allow(dead_code)]
     sk_i: F,
+    public_keys: Arc<Vec<G>>,
     _marker: PhantomData<G>,
     /// Persistent preprocessing store.
     preproc_store: tokio::sync::RwLock<Option<Arc<dyn crate::storage::preproc::PreprocStore>>>,
@@ -147,7 +157,50 @@ where
     /// Router that owns open-message accumulation for this AVSS runtime.
     open_message_router: Arc<crate::net::open_registry::OpenMessageRouter>,
     /// Per-instance open share accumulation registry.
-    open_registry: Arc<crate::net::open_registry::InstanceRegistry>,
+    open_registry: StdRwLock<Arc<crate::net::open_registry::InstanceRegistry>>,
+    /// Deployment lifetime semantics. OneShot preserves legacy load/delete/RAM behavior.
+    deployment_mode: DeploymentMode,
+}
+
+pub(super) struct AvssNodeLease<F, G>
+where
+    F: FftField + PrimeField,
+    G: CurveGroup<ScalarField = F>,
+{
+    node: AvssMpcNode<F, Avid<AvssSessionId>, G>,
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl<F, G> Deref for AvssNodeLease<F, G>
+where
+    F: FftField + PrimeField,
+    G: CurveGroup<ScalarField = F>,
+{
+    type Target = AvssMpcNode<F, Avid<AvssSessionId>, G>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<F, G> DerefMut for AvssNodeLease<F, G>
+where
+    F: FftField + PrimeField,
+    G: CurveGroup<ScalarField = F>,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.node
+    }
+}
+
+impl<F, G> Drop for AvssNodeLease<F, G>
+where
+    F: FftField + PrimeField,
+    G: CurveGroup<ScalarField = F>,
+{
+    fn drop(&mut self) {
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 #[derive(Clone)]
@@ -165,8 +218,111 @@ where
     F: FftField + PrimeField + Send + Sync + 'static,
     G: CurveGroup<ScalarField = F> + Send + Sync + 'static,
 {
-    pub(super) async fn clone_avss_node(&self) -> AvssMpcNode<F, Avid<AvssSessionId>, G> {
-        self.avss_node.lock().await.clone()
+    pub(super) async fn clone_avss_node(&self) -> AvssNodeLease<F, G> {
+        self.in_flight.fetch_add(1, Ordering::SeqCst);
+        let node = self.avss_node.lock().await.clone();
+        AvssNodeLease {
+            node,
+            in_flight: self.in_flight.clone(),
+        }
+    }
+
+    fn reset_drain_timeout() -> Duration {
+        let millis = std::env::var("STOFFEL_DRAIN_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_RESET_DRAIN_TIMEOUT_MS);
+        Duration::from_millis(millis)
+    }
+
+    async fn await_inflight_drained(&self) -> Result<(), String> {
+        let timeout = Self::reset_drain_timeout();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.in_flight.load(Ordering::SeqCst) == 0 {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {:?} waiting for AVSS in-flight operations to drain",
+                    timeout
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn build_node_for_instance(
+        &self,
+        new_instance_id: u64,
+    ) -> Result<AvssMpcNode<F, Avid<AvssSessionId>, G>, String> {
+        let (n_random_shares, n_triples) = {
+            let node = self.avss_node.lock().await;
+            (node.params.n_v_random_shares, node.params.n_triples)
+        };
+        let opts = AvssMpcNodeOpts::new(
+            self.topology.n_parties(),
+            self.topology.threshold(),
+            n_random_shares,
+            n_triples,
+            self.sk_i,
+            self.public_keys.clone(),
+            protocol_instance_id_u32(new_instance_id),
+            std::time::Duration::from_secs(60),
+        )
+        .map_err(|e| format!("Failed to recreate AvssMpcNodeOpts: {:?}", e))?;
+        <AvssMpcNode<F, Avid<AvssSessionId>, G> as MPCProtocol<
+            F,
+            FeldmanShamirShare<F, G>,
+            QuicNetworkManager,
+        >>::setup(self.topology.party_id(), opts, self.input_ids.clone())
+        .map_err(|e| format!("Failed to recreate AvssMpcNode: {:?}", e))
+    }
+
+    pub(crate) async fn reset_state_for_next_run(
+        &self,
+        new_instance_id: u64,
+    ) -> Result<(), String> {
+        let was_ready = self.ready.swap(false, Ordering::SeqCst);
+        self.await_inflight_drained().await?;
+
+        let new_node = self.build_node_for_instance(new_instance_id).await?;
+        {
+            let mut node = self.avss_node.lock().await;
+            *node = new_node;
+        }
+        self.session_ids.reset(new_instance_id);
+
+        let new_registry = self.open_message_router.register_instance(new_instance_id);
+        let old_registry = {
+            let mut slot = self
+                .open_registry
+                .write()
+                .expect("open registry lock poisoned");
+            std::mem::replace(&mut *slot, new_registry)
+        };
+        let old_ref_count = Arc::strong_count(&old_registry);
+        if old_ref_count > 1 {
+            tracing::warn!(
+                instance_id = old_registry.instance_id(),
+                strong_count = old_ref_count,
+                "old AVSS open registry still has external references after reset"
+            );
+        }
+        drop(old_registry);
+
+        self.current_instance_id
+            .store(new_instance_id, Ordering::SeqCst);
+        self.client_output_id_map.write().await.clear();
+        {
+            let mut capture = self.client_output_capture.lock().await;
+            if capture.is_some() {
+                *capture = Some(Vec::new());
+            }
+        }
+        self.ready.store(was_ready, Ordering::SeqCst);
+        Ok(())
     }
 
     /// Create a new AVSS engine from a named backend configuration.
@@ -175,6 +331,7 @@ where
             session,
             secret_key,
             public_keys,
+            deployment_mode,
         } = config;
         let (topology, local_identity, network, input_ids, open_message_router) =
             session.into_parts();
@@ -191,7 +348,7 @@ where
             DEFAULT_N_RANDOM_SHARES,
             DEFAULT_N_TRIPLES,
             secret_key,
-            public_keys,
+            public_keys.clone(),
             instance_id_u32,
             std::time::Duration::from_secs(60),
         )
@@ -200,26 +357,31 @@ where
             F,
             FeldmanShamirShare<F, G>,
             QuicNetworkManager,
-        >>::setup(party_id, opts, input_ids)
+        >>::setup(party_id, opts, input_ids.clone())
         .map_err(|e| format!("Failed to create AvssMpcNode: {:?}", e))?;
 
         Ok(Arc::new(Self {
             topology,
+            current_instance_id: AtomicU64::new(instance_id),
             local_identity,
             net: network,
+            input_ids: input_ids.clone(),
             avss_node: Arc::new(Mutex::new(avss_node)),
+            in_flight: Arc::new(AtomicUsize::new(0)),
             stored_shares: Arc::new(Mutex::new(BTreeMap::new())),
             session_ids: AvssSessionIds::new(instance_id, party_id, n_parties),
             ready: AtomicBool::new(false),
             share_notify: Arc::new(tokio::sync::Notify::new()),
             sk_i: secret_key,
+            public_keys,
             _marker: PhantomData,
             preproc_store: tokio::sync::RwLock::new(None),
             preproc_config: tokio::sync::RwLock::new(None),
             client_output_id_map: RwLock::new(Vec::new()),
             client_output_capture: Mutex::new(None),
             open_message_router: open_message_router.clone(),
-            open_registry: open_message_router.register_instance(instance_id),
+            open_registry: StdRwLock::new(open_message_router.register_instance(instance_id)),
+            deployment_mode,
         }))
     }
 
@@ -296,6 +458,21 @@ where
         self.open_message_router.clone()
     }
 
+    pub(crate) fn open_registry(&self) -> Arc<crate::net::open_registry::InstanceRegistry> {
+        self.open_registry
+            .read()
+            .expect("open registry lock poisoned")
+            .clone()
+    }
+
+    pub fn deployment_mode(&self) -> DeploymentMode {
+        self.deployment_mode
+    }
+
+    pub fn is_standing(&self) -> bool {
+        self.deployment_mode == DeploymentMode::Standing
+    }
+
     /// Returns a handle to the inner MPC node for direct access (e.g., InputServer init).
     pub fn node_handle(&self) -> &Arc<Mutex<AvssMpcNode<F, Avid<AvssSessionId>, G>>> {
         &self.avss_node
@@ -304,6 +481,11 @@ where
     /// Get the validated MPC session topology.
     pub fn topology(&self) -> MpcSessionTopology {
         self.topology
+            .with_instance(self.current_instance_id.load(Ordering::SeqCst))
+    }
+
+    pub fn current_instance_id(&self) -> u64 {
+        self.current_instance_id.load(Ordering::SeqCst)
     }
 
     /// Get the typed party identity.

--- a/crates/stoffel-vm/src/net/mpc/avss/capabilities.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/capabilities.rs
@@ -63,14 +63,14 @@ where
         let partial_bytes =
             Self::encode_verified_exp_contribution(&share, generator, partial_point)?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share_id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_avss_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share_id,
@@ -83,7 +83,7 @@ where
             self.topology.n_parties(),
             self.topology.threshold(),
         )?;
-        self.open_registry.exp_open_wait(
+        self.open_registry().exp_open_wait(
             ExpOpenRequest {
                 kind: ExpOpenRegistryKind::G1,
                 sequence: Some(seq),
@@ -129,14 +129,14 @@ where
         let partial_bytes =
             Self::encode_verified_exp_contribution(&share, generator, partial_point)?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share_id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_avss_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share_id,
@@ -149,7 +149,7 @@ where
             self.topology.n_parties(),
             self.topology.threshold(),
         )?;
-        self.open_registry
+        self.open_registry()
             .exp_open_async(
                 ExpOpenRequest {
                     kind: ExpOpenRegistryKind::G1,
@@ -211,14 +211,14 @@ where
         let partial_point: G2Projective = generator_g2 * share_value;
         let partial_bytes = Self::encode_verified_g2_exp_contribution(partial_point)?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G2,
             self.topology.party_id(),
             share_id,
             partial_bytes.clone(),
         )?;
         let wire_payload = crate::net::open_registry::encode_avss_g2_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share_id,
@@ -238,7 +238,7 @@ where
             self.topology.n_parties(),
             self.topology.threshold(),
         )?;
-        self.open_registry.exp_open_wait(
+        self.open_registry().exp_open_wait(
             ExpOpenRequest {
                 kind: ExpOpenRegistryKind::G2,
                 sequence: Some(seq),
@@ -302,14 +302,14 @@ where
         let partial_point: G2Projective = generator_g2 * share_value;
         let partial_bytes = Self::encode_verified_g2_exp_contribution(partial_point)?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G2,
             self.topology.party_id(),
             share_id,
             partial_bytes.clone(),
         )?;
         let wire_payload = crate::net::open_registry::encode_avss_g2_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share_id,
@@ -330,7 +330,7 @@ where
             self.topology.n_parties(),
             self.topology.threshold(),
         )?;
-        self.open_registry
+        self.open_registry()
             .exp_open_async(
                 ExpOpenRequest {
                     kind: ExpOpenRegistryKind::G2,
@@ -378,12 +378,23 @@ where
         right: &[u8],
     ) -> MpcEngineResult<ShareData> {
         (|| -> Result<ShareData, String> {
-            let avss_node = self.avss_node.clone();
-            let net = self.net.clone();
             let left_bytes = left.to_vec();
             let right_bytes = right.to_vec();
 
-            let fut = Self::run_multiply_round(avss_node, net, left_bytes, right_bytes);
+            let fut = async move {
+                if self.is_standing() {
+                    self.run_standing_multiply_round(left_bytes, right_bytes)
+                        .await
+                } else {
+                    Self::run_multiply_round(
+                        self.avss_node.clone(),
+                        self.net.clone(),
+                        left_bytes,
+                        right_bytes,
+                    )
+                    .await
+                }
+            };
 
             match tokio::runtime::Handle::try_current() {
                 Ok(handle) => {
@@ -394,15 +405,22 @@ where
                             tokio::task::block_in_place(|| handle.block_on(fut))
                         }
                         tokio::runtime::RuntimeFlavor::CurrentThread => {
-                            std::thread::spawn(move || {
-                                let rt = tokio::runtime::Builder::new_current_thread()
-                                    .enable_all()
-                                    .build()
-                                    .map_err(|e| format!("failed to create Tokio runtime: {e}"))?;
-                                rt.block_on(fut)
+                            std::thread::scope(move |scope| {
+                                scope
+                                    .spawn(move || {
+                                        let rt = tokio::runtime::Builder::new_current_thread()
+                                            .enable_all()
+                                            .build()
+                                            .map_err(|e| {
+                                                format!("failed to create Tokio runtime: {e}")
+                                            })?;
+                                        rt.block_on(fut)
+                                    })
+                                    .join()
+                                    .map_err(|_| {
+                                        "AVSS multiply worker thread panicked".to_string()
+                                    })?
                             })
-                            .join()
-                            .map_err(|_| "AVSS multiply worker thread panicked".to_string())?
                         }
                         _ => Err("operation requires a multi-thread Tokio runtime".to_string()),
                     }
@@ -455,13 +473,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_single_next(
+            let seq = self.open_registry().insert_single_next(
                 &type_key,
                 self.topology.party_id(),
                 share_bytes.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -473,7 +491,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry.open_bytes_at_wait(
+            self.open_registry().open_bytes_at_wait(
                 self.topology.party_id(),
                 &type_key,
                 seq,
@@ -507,9 +525,15 @@ where
     fn random_share(&self, _ty: ShareType) -> MpcEngineResult<ShareData> {
         (|| -> Result<ShareData, String> {
             let share = crate::net::block_on_current(async {
+                if self.is_standing() {
+                    let shares = self.reserve_random_shares(1).await?;
+                    return shares.into_iter().next().ok_or_else(|| {
+                        "standing AVSS random reservation returned no share".to_string()
+                    });
+                }
                 let mut node_clone = self.clone_avss_node().await;
                 MPCProtocol::<F, FeldmanShamirShare<F, G>, QuicNetworkManager>::rand(
-                    &mut node_clone,
+                    &mut *node_clone,
                     self.net.clone(),
                 )
                 .await
@@ -692,6 +716,12 @@ where
         Some(self)
     }
 
+    async fn reset_for_next_run(&self, new_instance_id: u64) -> MpcEngineResult<()> {
+        self.reset_state_for_next_run(new_instance_id)
+            .await
+            .map_mpc_engine_operation("reset_for_next_run")
+    }
+
     async fn input_share_async(&self, clear: ClearShareInput) -> MpcEngineResult<ShareData> {
         async {
             let secret = Self::clear_input_to_field(clear)?;
@@ -708,13 +738,18 @@ where
         left: &[u8],
         right: &[u8],
     ) -> MpcEngineResult<ShareData> {
-        Self::run_multiply_round(
-            self.avss_node.clone(),
-            self.net.clone(),
-            left.to_vec(),
-            right.to_vec(),
-        )
-        .await
+        if self.is_standing() {
+            self.run_standing_multiply_round(left.to_vec(), right.to_vec())
+                .await
+        } else {
+            Self::run_multiply_round(
+                self.avss_node.clone(),
+                self.net.clone(),
+                left.to_vec(),
+                right.to_vec(),
+            )
+            .await
+        }
         .map_mpc_engine_operation("async_multiply_share")
     }
 
@@ -732,13 +767,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_single_next(
+            let seq = self.open_registry().insert_single_next(
                 &type_key,
                 self.topology.party_id(),
                 share_bytes.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -750,7 +785,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry
+            self.open_registry()
                 .open_share_at_async(
                     self.topology.party_id(),
                     type_key,
@@ -788,13 +823,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_batch_next(
+            let seq = self.open_registry().insert_batch_next(
                 &type_key,
                 self.topology.party_id(),
                 shares.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_batch_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -806,7 +841,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry
+            self.open_registry()
                 .batch_open_at_async(
                     self.topology.party_id(),
                     type_key,
@@ -837,9 +872,16 @@ where
 
     async fn random_share_async(&self, _ty: ShareType) -> MpcEngineResult<ShareData> {
         async {
+            if self.is_standing() {
+                let shares = self.reserve_random_shares(1).await?;
+                let share = shares.into_iter().next().ok_or_else(|| {
+                    "standing AVSS random reservation returned no share".to_string()
+                })?;
+                return Self::share_to_share_data(&share);
+            }
             let mut node_clone = self.clone_avss_node().await;
             let share = MPCProtocol::<F, FeldmanShamirShare<F, G>, QuicNetworkManager>::rand(
-                &mut node_clone,
+                &mut *node_clone,
                 self.net.clone(),
             )
             .await
@@ -864,13 +906,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_single_next(
+            let seq = self.open_registry().insert_single_next(
                 &type_key,
                 self.topology.party_id(),
                 share_bytes.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -882,7 +924,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry
+            self.open_registry()
                 .open_bytes_at_async(
                     self.topology.party_id(),
                     type_key,

--- a/crates/stoffel-vm/src/net/mpc/avss/capabilities.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/capabilities.rs
@@ -436,6 +436,16 @@ where
         })()
         .map_mpc_engine_operation("multiply_share")
     }
+
+    fn batch_multiply_shares(
+        &self,
+        ty: ShareType,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> MpcEngineResult<Vec<ShareData>> {
+        let _ = ty;
+        crate::net::try_block_on_current(self.batch_multiply_share_async(pairs))
+            .map_mpc_engine_operation("batch_multiply_shares")
+    }
 }
 
 impl<F, G> MpcEnginePreprocPersistence for AvssMpcEngine<F, G>
@@ -751,6 +761,16 @@ where
             .await
         }
         .map_mpc_engine_operation("async_multiply_share")
+    }
+
+    async fn batch_multiply_share_async(
+        &self,
+        _ty: ShareType,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> MpcEngineResult<Vec<ShareData>> {
+        self.batch_multiply_share_async(pairs)
+            .await
+            .map_mpc_engine_operation("async_batch_multiply_share")
     }
 
     async fn open_share_async(

--- a/crates/stoffel-vm/src/net/mpc/avss/config.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/config.rs
@@ -15,6 +15,11 @@ where
     pub secret_key: F,
     pub public_keys: Arc<Vec<G>>,
     pub deployment_mode: DeploymentMode,
+    /// Program-visible random shares retained after preprocessing.
+    pub n_random_shares: usize,
+    /// Beaver triples requested from preprocessing. AVSS may round this up to
+    /// its party-group generation granularity.
+    pub n_triples: usize,
 }
 
 impl<F, G> AvssEngineConfig<F, G>
@@ -28,11 +33,20 @@ where
             secret_key,
             public_keys,
             deployment_mode: DeploymentMode::OneShot,
+            n_random_shares: super::DEFAULT_N_RANDOM_SHARES,
+            n_triples: super::DEFAULT_N_TRIPLES,
         }
     }
 
     pub fn with_deployment_mode(mut self, deployment_mode: DeploymentMode) -> Self {
         self.deployment_mode = deployment_mode;
+        self
+    }
+
+    /// Override in-memory preprocessing targets for this engine.
+    pub fn with_preprocessing_counts(mut self, n_random_shares: usize, n_triples: usize) -> Self {
+        self.n_random_shares = n_random_shares;
+        self.n_triples = n_triples;
         self
     }
 }

--- a/crates/stoffel-vm/src/net/mpc/avss/config.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/config.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use ark_ec::CurveGroup;
 use ark_ff::{FftField, PrimeField};
 
-use crate::net::engine_config::MpcSessionConfig;
+use crate::net::engine_config::{DeploymentMode, MpcSessionConfig};
 
 #[derive(Clone)]
 pub struct AvssEngineConfig<F, G>
@@ -14,6 +14,7 @@ where
     pub session: MpcSessionConfig,
     pub secret_key: F,
     pub public_keys: Arc<Vec<G>>,
+    pub deployment_mode: DeploymentMode,
 }
 
 impl<F, G> AvssEngineConfig<F, G>
@@ -26,6 +27,12 @@ where
             session,
             secret_key,
             public_keys,
+            deployment_mode: DeploymentMode::OneShot,
         }
+    }
+
+    pub fn with_deployment_mode(mut self, deployment_mode: DeploymentMode) -> Self {
+        self.deployment_mode = deployment_mode;
+        self
     }
 }

--- a/crates/stoffel-vm/src/net/mpc/avss/engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/engine.rs
@@ -320,6 +320,10 @@ where
         self.ready.load(Ordering::SeqCst)
     }
 
+    fn multiplication_batch_capacity(&self) -> Option<usize> {
+        None
+    }
+
     fn start(&self) -> crate::net::mpc_engine::MpcEngineResult<()> {
         self.ready.store(true, Ordering::SeqCst);
         Ok(())

--- a/crates/stoffel-vm/src/net/mpc/avss/engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/engine.rs
@@ -26,6 +26,13 @@ where
     F: SupportedMpcField,
     G: CurveGroup<ScalarField = F> + Send + Sync + 'static,
 {
+    #[cfg(all(test, feature = "avss_itest"))]
+    pub(crate) async fn multiplication_session_count(&self) -> usize {
+        let node = self.avss_node.lock().await;
+        let count = node.mul_node.mult_storage.lock().await.len();
+        count
+    }
+
     pub(super) fn clear_input_to_field(clear: ClearShareInput) -> Result<F, String> {
         match clear.into_parts() {
             (ShareType::SecretInt { .. }, ClearShareValue::Integer(v)) => {
@@ -112,6 +119,49 @@ where
         Self::share_to_share_data(&product)
     }
 
+    pub(super) async fn run_batch_multiply_round(
+        avss_node: Arc<Mutex<AvssMpcNode<F, Avid<AvssSessionId>, G>>>,
+        net: Arc<QuicNetworkManager>,
+        pairs: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> Result<Vec<ShareData>, String> {
+        if pairs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut left_shares = Vec::with_capacity(pairs.len());
+        let mut right_shares = Vec::with_capacity(pairs.len());
+        for (left, right) in pairs {
+            left_shares.push(Self::decode_feldman_share(&left)?);
+            right_shares.push(Self::decode_feldman_share(&right)?);
+        }
+
+        let mut node = {
+            let node = avss_node.lock().await;
+            node.clone()
+        };
+        Self::ensure_multiply_preprocessing_ids(&mut node, net.clone()).await?;
+        node.mul(left_shares, right_shares, net)
+            .await
+            .map_err(|e| format!("Batch multiplication failed: {:?}", e))?
+            .iter()
+            .map(Self::share_to_share_data)
+            .collect()
+    }
+
+    /// Execute one native vectorized AVSS multiplication session for all
+    /// supplied pairs. This is the async implementation shared by the async
+    /// engine capability and its synchronous compatibility adapter.
+    pub(crate) async fn batch_multiply_share_async(
+        &self,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> Result<Vec<ShareData>, String> {
+        let pairs = pairs.to_vec();
+        if self.is_standing() {
+            self.run_standing_batch_multiply_round(pairs).await
+        } else {
+            Self::run_batch_multiply_round(self.avss_node.clone(), self.net.clone(), pairs).await
+        }
+    }
+
     pub(super) async fn run_standing_multiply_round(
         &self,
         left_share_bytes: Vec<u8>,
@@ -137,6 +187,35 @@ where
             .next()
             .ok_or_else(|| "Multiplication returned no result".to_string())?;
         Self::share_to_share_data(&product)
+    }
+
+    pub(super) async fn run_standing_batch_multiply_round(
+        &self,
+        pairs: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> Result<Vec<ShareData>, String> {
+        if pairs.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut left_shares = Vec::with_capacity(pairs.len());
+        let mut right_shares = Vec::with_capacity(pairs.len());
+        for (left, right) in pairs {
+            left_shares.push(Self::decode_feldman_share(&left)?);
+            right_shares.push(Self::decode_feldman_share(&right)?);
+        }
+        let mut triples = self.reserve_beaver_triples(left_shares.len()).await?;
+        Self::normalize_multiply_triples(&mut triples);
+
+        let mut node = self.clone_avss_node().await;
+        node.preprocessing_material
+            .lock()
+            .await
+            .add(Some(triples), None);
+        node.mul(left_shares, right_shares, self.net.clone())
+            .await
+            .map_err(|e| format!("Batch multiplication failed: {:?}", e))?
+            .iter()
+            .map(Self::share_to_share_data)
+            .collect()
     }
 
     async fn ensure_multiply_preprocessing_ids(

--- a/crates/stoffel-vm/src/net/mpc/avss/engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/engine.rs
@@ -12,6 +12,7 @@ use std::sync::{atomic::Ordering, Arc};
 use stoffel_vm_types::core_types::{
     ClearShareInput, ClearShareValue, ShareData, ShareType, BOOLEAN_SECRET_INT_BITS,
 };
+use stoffelmpc_mpc::avss_mpc::triple_gen::BeaverTriple;
 use stoffelmpc_mpc::avss_mpc::{AvssMPCNode as AvssMpcNode, AvssSessionId};
 use stoffelmpc_mpc::common::rbc::rbc::Avid;
 use stoffelmpc_mpc::common::share::feldman::FeldmanShamirShare;
@@ -111,6 +112,33 @@ where
         Self::share_to_share_data(&product)
     }
 
+    pub(super) async fn run_standing_multiply_round(
+        &self,
+        left_share_bytes: Vec<u8>,
+        right_share_bytes: Vec<u8>,
+    ) -> Result<ShareData, String> {
+        let left_share = Self::decode_feldman_share(&left_share_bytes)?;
+        let right_share = Self::decode_feldman_share(&right_share_bytes)?;
+        let mut triples = self.reserve_beaver_triples(1).await?;
+        Self::normalize_multiply_triples(&mut triples);
+
+        let mut node = self.clone_avss_node().await;
+        node.preprocessing_material
+            .lock()
+            .await
+            .add(Some(triples), None);
+        let result = node
+            .mul(vec![left_share], vec![right_share], self.net.clone())
+            .await
+            .map_err(|e| format!("Multiplication failed: {:?}", e))?;
+
+        let product = result
+            .into_iter()
+            .next()
+            .ok_or_else(|| "Multiplication returned no result".to_string())?;
+        Self::share_to_share_data(&product)
+    }
+
     async fn ensure_multiply_preprocessing_ids(
         node: &mut AvssMpcNode<F, Avid<AvssSessionId>, G>,
         net: Arc<QuicNetworkManager>,
@@ -141,16 +169,20 @@ where
                 .map_err(|e| format!("take multiplication triples: {:?}", e))?
         };
 
-        for triple in &mut triples {
+        Self::normalize_multiply_triples(&mut triples);
+
+        let mut store = node.preprocessing_material.lock().await;
+        store.add(Some(triples), None);
+        Ok(())
+    }
+
+    fn normalize_multiply_triples(triples: &mut [BeaverTriple<F, G>]) {
+        for triple in triples {
             // mpc-protocols builds the triple c-share with a 0-based party id,
             // while AVSS/Feldman shares are evaluated at 1-based ids.
             let share_id = triple.a.feldmanshare.id;
             triple.c.feldmanshare.id = share_id;
         }
-
-        let mut store = node.preprocessing_material.lock().await;
-        store.add(Some(triples), None);
-        Ok(())
     }
 
     pub(super) async fn broadcast_open_registry_payload(
@@ -179,7 +211,7 @@ where
         self.ready.store(true, Ordering::SeqCst);
         info!(
             "AVSS engine started: instance={}, party={}, n={}, t={}",
-            self.topology.instance_id(),
+            self.current_instance_id(),
             self.topology.party_id(),
             self.topology.n_parties(),
             self.topology.threshold()
@@ -198,7 +230,7 @@ where
     }
 
     fn topology(&self) -> MpcSessionTopology {
-        self.topology
+        AvssMpcEngine::topology(self)
     }
 
     fn local_identity(&self) -> DurableIdentityDigest {
@@ -240,13 +272,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_single_next(
+            let seq = self.open_registry().insert_single_next(
                 &type_key,
                 self.topology.party_id(),
                 share_bytes.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -258,7 +290,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry.open_share_at_wait(
+            self.open_registry().open_share_at_wait(
                 self.topology.party_id(),
                 &type_key,
                 seq,
@@ -293,13 +325,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_batch_next(
+            let seq = self.open_registry().insert_batch_next(
                 &type_key,
                 self.topology.party_id(),
                 shares.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_batch_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -311,7 +343,7 @@ where
             let t = self.topology.threshold();
             let required = Self::byzantine_open_contribution_count(n, t)?;
 
-            self.open_registry.batch_open_at_wait(
+            self.open_registry().batch_open_at_wait(
                 self.topology.party_id(),
                 &type_key,
                 seq,

--- a/crates/stoffel-vm/src/net/mpc/avss/preprocessing.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/preprocessing.rs
@@ -1,8 +1,11 @@
 use super::AvssMpcEngine;
 use crate::net::curve::SupportedMpcField;
-use crate::storage::preproc::{self, PreprocBlob, PreprocKeyScope};
+use crate::storage::preproc::{
+    self, PoolAvailability, PreprocBlob, PreprocKeyScope, PreprocTargets, TopUpReport,
+};
 use ark_ec::CurveGroup;
 use ark_std::rand::SeedableRng;
+use stoffelmpc_mpc::avss_mpc::triple_gen::BeaverTriple;
 use stoffelmpc_mpc::common::share::feldman::FeldmanShamirShare;
 use stoffelmpc_mpc::common::PreprocessingMPCProtocol;
 use stoffelnet::transports::quic::QuicNetworkManager;
@@ -34,6 +37,10 @@ where
     /// `process()`). Both clones share `Arc<Mutex<>>` internal state
     /// (preprocessing_material, shares) so results are visible to either.
     pub async fn preprocess(&self) -> Result<(), String> {
+        if self.is_standing() {
+            return self.preprocess_standing().await;
+        }
+
         if self.try_load_preproc().await? {
             return Ok(());
         }
@@ -45,13 +52,121 @@ where
                 F,
                 FeldmanShamirShare<F, G>,
                 QuicNetworkManager,
-            >::run_preprocessing(&mut node_clone, self.net.clone(), &mut rng)
+            >::run_preprocessing(&mut *node_clone, self.net.clone(), &mut rng)
             .await
             .map_err(|e| format!("AVSS preprocessing failed: {:?}", e))?;
         }
 
         self.persist_preproc().await?;
         Ok(())
+    }
+
+    async fn preproc_scope(
+        &self,
+    ) -> Result<
+        (
+            std::sync::Arc<dyn crate::storage::preproc::PreprocStore>,
+            [u8; 32],
+            PreprocKeyScope,
+        ),
+        String,
+    > {
+        let store = self.preproc_store.read().await.clone();
+        let config = *self.preproc_config.read().await;
+        let (store, (hash, field_kind)) = match (store, config) {
+            (Some(s), Some(c)) => (s, c),
+            _ => return Err(
+                "standing AVSS preprocessing requires configured preproc store and program hash"
+                    .to_owned(),
+            ),
+        };
+        let scope = PreprocKeyScope::new(
+            hash,
+            field_kind,
+            self.topology.n_parties(),
+            self.topology.threshold(),
+            self.local_identity,
+        );
+        Ok((store, hash, scope))
+    }
+
+    async fn current_preproc_targets(&self) -> Result<PreprocTargets, String> {
+        let node = self.clone_avss_node().await;
+        Ok(PreprocTargets {
+            beaver: preproc::u32_index(node.params.n_triples as u64, "AVSS beaver target")?,
+            random: preproc::u32_index(node.params.n_v_random_shares as u64, "AVSS random target")?,
+            prand_bit: 0,
+            prand_int: 0,
+        })
+    }
+
+    async fn preprocess_standing(&self) -> Result<(), String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let targets = self.current_preproc_targets().await?;
+        let availability = store.scope_availability(&scope).await?;
+        if availability.beaver < targets.beaver || availability.random < targets.random {
+            self.top_up_to(targets).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn top_up_to(&self, targets: PreprocTargets) -> Result<TopUpReport, String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let availability = store.scope_availability(&scope).await?;
+        let needed = PoolAvailability {
+            beaver: targets.beaver.saturating_sub(availability.beaver),
+            random: targets.random.saturating_sub(availability.random),
+            prand_bit: 0,
+            prand_int: 0,
+        };
+        if needed == PoolAvailability::default() {
+            return Ok(TopUpReport {
+                generated: PoolAvailability::default(),
+                skipped: true,
+            });
+        }
+
+        let mut node_clone = self.clone_avss_node().await;
+        node_clone.params.n_triples = needed.beaver as usize;
+        node_clone.params.n_v_random_shares = needed.random as usize;
+        let mut rng = ark_std::rand::rngs::StdRng::from_entropy();
+        PreprocessingMPCProtocol::<F, FeldmanShamirShare<F, G>, QuicNetworkManager>::run_preprocessing(
+            &mut *node_clone,
+            self.net.clone(),
+            &mut rng,
+        )
+        .await
+        .map_err(|e| format!("AVSS top-up preprocessing failed: {:?}", e))?;
+
+        let mut generated = PoolAvailability::default();
+        let mut to_append = Vec::new();
+        {
+            let mut prep = node_clone.preprocessing_material.lock().await;
+            let (n_bt, n_rs) = prep.len();
+            if n_bt > 0 {
+                let items = prep.take_triples(n_bt).map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_avss_triples::<F, G>(&items)?;
+                generated.beaver = preproc::u32_index(items.len() as u64, "generated AVSS beaver")?;
+                to_append.push((scope.beaver_triple(), item_size, generated.beaver, data));
+            }
+            if n_rs > 0 {
+                let items = prep
+                    .take_v_random_shares(n_rs)
+                    .map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_feldman_shares::<F, G>(&items)?;
+                generated.random = preproc::u32_index(items.len() as u64, "generated AVSS random")?;
+                to_append.push((scope.random_share(), item_size, generated.random, data));
+            }
+        }
+
+        for (key, item_size, added, data) in to_append {
+            store.append_items(&key, item_size, added, &data).await?;
+        }
+
+        Ok(TopUpReport {
+            generated,
+            skipped: false,
+        })
     }
 
     /// Try to load AVSS preprocessing material from the persistent store.
@@ -191,5 +306,77 @@ where
             hex::encode(hash)
         );
         Ok(())
+    }
+
+    pub(super) async fn reserve_random_shares(
+        &self,
+        num_shares: usize,
+    ) -> Result<Vec<FeldmanShamirShare<F, G>>, String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let key = scope.random_share();
+        let meta = store
+            .meta(&key)
+            .await?
+            .ok_or_else(|| "no standing AVSS random shares stored".to_owned())?;
+        let count = preproc::u32_index(num_shares as u64, "standing AVSS random share count")?;
+        if meta.available() < count {
+            return Err(format!(
+                "InsufficientPreproc: AVSS random shares need {}, available {}",
+                count,
+                meta.available()
+            ));
+        }
+        let start = meta.consumed;
+        store.reserve_at(&key, start, count).await?;
+        let blob = store
+            .load(&key)
+            .await?
+            .ok_or("no standing AVSS random shares stored")?;
+        let decoded =
+            preproc::deserialize_feldman_shares::<F, G>(&blob.data, blob.meta.item_size, start)?;
+        if decoded.len() < num_shares {
+            return Err(format!(
+                "standing AVSS random decode returned {} items, expected {}",
+                decoded.len(),
+                num_shares
+            ));
+        }
+        Ok(decoded.into_iter().take(num_shares).collect())
+    }
+
+    pub(super) async fn reserve_beaver_triples(
+        &self,
+        num_triples: usize,
+    ) -> Result<Vec<BeaverTriple<F, G>>, String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let key = scope.beaver_triple();
+        let meta = store
+            .meta(&key)
+            .await?
+            .ok_or_else(|| "no standing AVSS Beaver triples stored".to_owned())?;
+        let count = preproc::u32_index(num_triples as u64, "standing AVSS Beaver triple count")?;
+        if meta.available() < count {
+            return Err(format!(
+                "InsufficientPreproc: AVSS Beaver triples need {}, available {}",
+                count,
+                meta.available()
+            ));
+        }
+        let start = meta.consumed;
+        store.reserve_at(&key, start, count).await?;
+        let blob = store
+            .load(&key)
+            .await?
+            .ok_or("no standing AVSS Beaver triples stored")?;
+        let decoded =
+            preproc::deserialize_avss_triples::<F, G>(&blob.data, blob.meta.item_size, start)?;
+        if decoded.len() < num_triples {
+            return Err(format!(
+                "standing AVSS Beaver triple decode returned {} items, expected {}",
+                decoded.len(),
+                num_triples
+            ));
+        }
+        Ok(decoded.into_iter().take(num_triples).collect())
     }
 }

--- a/crates/stoffel-vm/src/net/mpc/avss/session_ids.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/session_ids.rs
@@ -6,7 +6,7 @@ use stoffelmpc_mpc::common::ProtocolSessionId;
 use crate::net::mpc::protocol_ids::derive_protocol_instance_id_u32;
 
 pub(super) struct AvssSessionIds {
-    instance_id: u64,
+    instance_id: AtomicU64,
     party_id: usize,
     local_counter: AtomicU64,
 }
@@ -14,15 +14,24 @@ pub(super) struct AvssSessionIds {
 impl AvssSessionIds {
     pub fn new(instance_id: u64, party_id: usize, _n_parties: usize) -> Self {
         Self {
-            instance_id,
+            instance_id: AtomicU64::new(instance_id),
             party_id,
             local_counter: AtomicU64::new(0),
         }
     }
 
+    pub fn reset(&self, instance_id: u64) {
+        self.instance_id.store(instance_id, Ordering::SeqCst);
+        self.local_counter.store(0, Ordering::SeqCst);
+    }
+
     pub fn next_dealer_session(&self) -> Result<AvssSessionId, String> {
         let counter = next_u16_domain_counter(&self.local_counter, "AVSS local session counter")?;
-        allocate_local_avss_session(self.instance_id, self.party_id, counter)
+        allocate_local_avss_session(
+            self.instance_id.load(Ordering::SeqCst),
+            self.party_id,
+            counter,
+        )
     }
 }
 
@@ -120,6 +129,20 @@ mod tests {
             protocol_instance_id_u32(instance_id),
             protocol_instance_id_u32(instance_id)
         );
+    }
+
+    #[test]
+    fn reset_rotates_instance_and_restarts_local_counter() {
+        let sessions = AvssSessionIds::new(1, 2, 4);
+        let first = sessions.next_dealer_session().expect("first session");
+
+        sessions.reset(9);
+        let after_reset = sessions.next_dealer_session().expect("reset session");
+
+        assert_ne!(first.as_u128(), after_reset.as_u128());
+        assert_eq!(after_reset.exec_id(), 0);
+        assert_eq!(after_reset.round_id(), 0);
+        assert_eq!(after_reset.sub_id(), 2);
     }
 
     #[test]

--- a/crates/stoffel-vm/src/net/mpc/backend.rs
+++ b/crates/stoffel-vm/src/net/mpc/backend.rs
@@ -38,7 +38,7 @@ impl From<MpcBackendError> for String {
 }
 
 /// Available MPC backend implementations.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum MpcBackendKind {
     HoneyBadger,
     Avss,

--- a/crates/stoffel-vm/src/net/mpc/engine/identity.rs
+++ b/crates/stoffel-vm/src/net/mpc/engine/identity.rs
@@ -264,6 +264,15 @@ impl MpcSessionTopology {
     pub const fn threshold(self) -> usize {
         self.threshold.value()
     }
+
+    pub const fn with_instance(self, instance_id: u64) -> Self {
+        Self {
+            instance_id: MpcInstanceId::new(instance_id),
+            party_id: self.party_id,
+            party_count: self.party_count,
+            threshold: self.threshold,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]

--- a/crates/stoffel-vm/src/net/mpc/engine/traits/async_engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/engine/traits/async_engine.rs
@@ -105,6 +105,10 @@ pub trait AsyncMpcEngine: MpcEngine {
         None
     }
 
+    async fn reset_for_next_run(&self, _new_instance_id: u64) -> MpcEngineResult<()> {
+        Ok(())
+    }
+
     /// Obtain async consensus operations or return a capability-aware error.
     fn async_consensus_ops(&self) -> MpcEngineResult<&dyn AsyncMpcEngineConsensus> {
         self.as_async_consensus_ops().ok_or_else(|| {

--- a/crates/stoffel-vm/src/net/mpc/engine/traits/capability.rs
+++ b/crates/stoffel-vm/src/net/mpc/engine/traits/capability.rs
@@ -23,6 +23,22 @@ pub trait MpcEngineMultiplication: MpcEngine {
         right: &[u8],
     ) -> MpcEngineResult<ShareData>;
 
+    /// Perform secure multiplication for a batch of share pairs.
+    ///
+    /// Backends with a native vectorized protocol should override this method.
+    /// The default preserves compatibility by executing scalar multiplications
+    /// in order.
+    fn batch_multiply_shares(
+        &self,
+        ty: ShareType,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> MpcEngineResult<Vec<ShareData>> {
+        pairs
+            .iter()
+            .map(|(left, right)| self.multiply_share(ty, left, right))
+            .collect()
+    }
+
     /// Divide a secret fixed-point share by a public positive constant.
     ///
     /// `divisor_scaled` is the divisor already scaled into the share's

--- a/crates/stoffel-vm/src/net/mpc/engine/traits/capability.rs
+++ b/crates/stoffel-vm/src/net/mpc/engine/traits/capability.rs
@@ -4,7 +4,7 @@ use crate::net::client_store::{
     ClientInputHydrationCount, ClientInputStore, ClientOutputShareCount,
 };
 use crate::net::reservation::ReservationGrant;
-use crate::storage::preproc::PreprocStore;
+use crate::storage::preproc::{PoolAvailability, PreprocStore};
 use std::sync::Arc;
 use stoffel_vm_types::core_types::{ShareData, ShareType};
 use stoffelnet::network_utils::ClientId;
@@ -193,6 +193,20 @@ pub trait MpcEngineReservation: MpcEngine {
     /// Initialize or restore reservation state for a program.
     async fn init_reservations(&self, program_hash: [u8; 32], capacity: u64)
         -> MpcEngineResult<()>;
+
+    /// Initialize or restore reservation state for one persistent run.
+    ///
+    /// One-shot callers can use [`MpcEngineReservation::init_reservations`].
+    async fn init_reservations_for_run(
+        &self,
+        program_hash: [u8; 32],
+        capacity: u64,
+        run_id: u64,
+        preproc_offset: PoolAvailability,
+    ) -> MpcEngineResult<()> {
+        let _ = (run_id, preproc_offset);
+        self.init_reservations(program_hash, capacity).await
+    }
 
     /// Reserve `n` consecutive mask indices for a client.
     async fn reserve_masks(&self, client_id: ClientId, n: u64)

--- a/crates/stoffel-vm/src/net/mpc/engine/traits/core.rs
+++ b/crates/stoffel-vm/src/net/mpc/engine/traits/core.rs
@@ -42,6 +42,18 @@ pub trait MpcEngine: Send + Sync {
     /// Check if the engine is ready for MPC operations.
     fn is_ready(&self) -> bool;
 
+    /// Maximum number of same-type products that one native multiplication
+    /// session can execute concurrently. `None` means the backend accepts an
+    /// unbounded vector in one session.
+    ///
+    /// The conservative default is one because `AsyncMpcEngine`'s fallback
+    /// batch implementation executes scalar multiplications sequentially.
+    /// Backends with a native vector protocol must override this capability so
+    /// the VM scheduler can legally pack singular products into one round.
+    fn multiplication_batch_capacity(&self) -> Option<usize> {
+        Some(1)
+    }
+
     /// Start the engine, which may trigger preprocessing.
     fn start(&self) -> MpcEngineResult<()>;
 

--- a/crates/stoffel-vm/src/net/mpc/helpers.rs
+++ b/crates/stoffel-vm/src/net/mpc/helpers.rs
@@ -89,10 +89,57 @@ pub fn honeybadger_node_opts_with_truncation(
     n_prandint: usize,
     instance_id: u64,
 ) -> Result<HoneyBadgerMPCNodeOpts, String> {
+    honeybadger_node_opts_with_truncation_width(
+        n_parties,
+        threshold,
+        n_triples,
+        n_random_shares,
+        n_prandbit,
+        n_prandint,
+        DEFAULT_FIXED_POINT_TOTAL_BITS,
+        instance_id,
+    )
+}
+
+/// Build HoneyBadger options with the exact maximum bit width required by
+/// PRandBit/PRandInt-backed operations in this program.
+pub fn honeybadger_node_opts_with_truncation_width(
+    n_parties: usize,
+    threshold: usize,
+    n_triples: usize,
+    n_random_shares: usize,
+    n_prandbit: usize,
+    n_prandint: usize,
+    preprocessing_bit_width: usize,
+    instance_id: u64,
+) -> Result<HoneyBadgerMPCNodeOpts, String> {
     validate_honeybadger_topology(n_parties, threshold)?;
 
-    let l = DEFAULT_FIXED_POINT_TOTAL_BITS;
+    let l = preprocessing_bit_width.max(1);
     let k = DEFAULT_SECURITY_PARAMETER_K;
+
+    // stoffelcrypto's PRand protocol uses a Goldilocks subfield and requires
+    // k + l + two masking bits + ceil(log2(n)) to fit strictly below its
+    // 64-bit modulus capacity. Check the same invariant before launching a
+    // network session so unsupported widths fail deterministically.
+    if n_prandbit > 0 || n_prandint > 0 {
+        const GOLDILOCKS_MODULUS_BITS: usize = 64;
+        const MASKING_MARGIN_BITS: usize = 2;
+        let party_bits = if n_parties <= 1 {
+            0
+        } else {
+            usize::BITS as usize - (n_parties - 1).leading_zeros() as usize
+        };
+        let required = k
+            .saturating_add(l)
+            .saturating_add(MASKING_MARGIN_BITS)
+            .saturating_add(party_bits);
+        if required >= GOLDILOCKS_MODULUS_BITS {
+            return Err(format!(
+                "HoneyBadger preprocessing width {l} is unsupported for {n_parties} parties: security and masking margins require {required} bits, but PRand's Goldilocks subfield requires fewer than {GOLDILOCKS_MODULUS_BITS}"
+            ));
+        }
+    }
 
     HoneyBadgerMPCNodeOpts::new(
         n_parties,
@@ -166,6 +213,30 @@ mod tests {
 
         honeybadger_node_opts(4, 1, 0, 0, 1)
             .expect("n = 3t + 1 should be accepted for HoneyBadger");
+    }
+
+    #[test]
+    fn honeybadger_node_opts_uses_exact_preprocessing_width() {
+        let opts = honeybadger_node_opts_with_truncation_width(5, 1, 0, 2, 0, 3, 1, 1)
+            .expect("one-bit PRandInt preprocessing should fit the field");
+
+        assert_eq!(opts.n_prandint, 3);
+        assert_eq!(opts.l, 1);
+    }
+
+    #[test]
+    fn honeybadger_node_opts_rejects_preprocessing_width_beyond_field_capacity() {
+        let err = honeybadger_node_opts_with_truncation_width(5, 1, 0, 2, 0, 1, 64, 1)
+            .expect_err("unsupported preprocessing widths must fail before network startup");
+
+        assert!(
+            err.contains("preprocessing width 64"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            err.contains("requires fewer than 64"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/stoffel-vm/src/net/mpc/honeybadger.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger.rs
@@ -1,12 +1,14 @@
 use crate::net::curve::SupportedMpcField;
-use crate::net::mpc::honeybadger_node_opts;
+use crate::net::mpc::{honeybadger_node_opts, honeybadger_node_opts_with_truncation};
 use crate::net::mpc_engine::{DurableIdentityDigest, MpcPartyId, MpcSessionTopology};
 use crate::net::reservation::ReservationRegistry;
 use crate::storage::preproc::PreprocStore;
 use ark_ec::{CurveGroup, PrimeGroup};
 use std::marker::PhantomData;
-use std::sync::atomic::AtomicBool;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, RwLock as StdRwLock};
+use std::time::Duration;
 use stoffelmpc_mpc::common::MPCProtocol;
 use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
 use stoffelmpc_mpc::honeybadger::HoneyBadgerMPCNode;
@@ -30,8 +32,9 @@ pub use config::{HoneyBadgerEngineConfig, HoneyBadgerPreprocessingConfig};
 use stoffelmpc_mpc::common::rbc::rbc::Avid;
 use stoffelmpc_mpc::honeybadger::SessionId as HbSessionId;
 type RBCImpl = Avid<HbSessionId>;
+const DEFAULT_RESET_DRAIN_TIMEOUT_MS: u64 = 30_000;
 
-use crate::net::engine_config::MpcSessionConfig;
+use crate::net::engine_config::{DeploymentMode, MpcSessionConfig};
 
 /// HoneyBadger-backed MPC engine that integrates with the VM.
 /// This wraps a real HoneyBadgerMPCNode and provides MPC operations
@@ -42,9 +45,12 @@ where
     G: CurveGroup<ScalarField = F> + PrimeGroup + Send + Sync + 'static,
 {
     topology: MpcSessionTopology,
+    current_instance_id: AtomicU64,
     local_identity: DurableIdentityDigest,
     net: Arc<QuicNetworkManager>,
+    input_ids: Vec<ClientId>,
     node: Arc<Mutex<HoneyBadgerMPCNode<F, RBCImpl>>>,
+    in_flight: Arc<AtomicUsize>,
     ready: AtomicBool,
     group_marker: PhantomData<G>,
     /// Persistent preprocessing store.
@@ -62,7 +68,46 @@ where
     /// Session-local router for open-share/open-exp payloads.
     open_message_router: Arc<crate::net::open_registry::OpenMessageRouter>,
     /// Per-instance open share accumulation registry.
-    open_registry: Arc<crate::net::open_registry::InstanceRegistry>,
+    open_registry: StdRwLock<Arc<crate::net::open_registry::InstanceRegistry>>,
+    /// Deployment lifetime semantics. OneShot preserves legacy load/delete/RAM behavior.
+    deployment_mode: DeploymentMode,
+}
+
+pub(super) struct HoneyBadgerNodeLease<F>
+where
+    F: SupportedMpcField,
+{
+    node: HoneyBadgerMPCNode<F, RBCImpl>,
+    in_flight: Arc<AtomicUsize>,
+}
+
+impl<F> Deref for HoneyBadgerNodeLease<F>
+where
+    F: SupportedMpcField,
+{
+    type Target = HoneyBadgerMPCNode<F, RBCImpl>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.node
+    }
+}
+
+impl<F> DerefMut for HoneyBadgerNodeLease<F>
+where
+    F: SupportedMpcField,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.node
+    }
+}
+
+impl<F> Drop for HoneyBadgerNodeLease<F>
+where
+    F: SupportedMpcField,
+{
+    fn drop(&mut self) {
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 #[derive(Clone)]
@@ -99,16 +144,142 @@ where
         self.open_message_router.clone()
     }
 
+    pub(crate) fn open_registry(&self) -> Arc<crate::net::open_registry::InstanceRegistry> {
+        self.open_registry
+            .read()
+            .expect("open registry lock poisoned")
+            .clone()
+    }
+
     pub fn net(&self) -> Arc<QuicNetworkManager> {
         self.net.clone()
     }
 
     pub fn topology(&self) -> MpcSessionTopology {
         self.topology
+            .with_instance(self.current_instance_id.load(Ordering::SeqCst))
     }
 
-    pub(super) async fn clone_node(&self) -> HoneyBadgerMPCNode<F, RBCImpl> {
-        self.node.lock().await.clone()
+    pub fn current_instance_id(&self) -> u64 {
+        self.current_instance_id.load(Ordering::SeqCst)
+    }
+
+    pub(super) async fn clone_node(&self) -> HoneyBadgerNodeLease<F> {
+        self.in_flight.fetch_add(1, Ordering::SeqCst);
+        let node = self.node.lock().await.clone();
+        HoneyBadgerNodeLease {
+            node,
+            in_flight: self.in_flight.clone(),
+        }
+    }
+
+    fn reset_drain_timeout() -> Duration {
+        let millis = std::env::var("STOFFEL_DRAIN_TIMEOUT_MS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .filter(|value| *value > 0)
+            .unwrap_or(DEFAULT_RESET_DRAIN_TIMEOUT_MS);
+        Duration::from_millis(millis)
+    }
+
+    async fn await_inflight_drained(&self) -> Result<(), String> {
+        let timeout = Self::reset_drain_timeout();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            if self.in_flight.load(Ordering::SeqCst) == 0 {
+                return Ok(());
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return Err(format!(
+                    "timed out after {:?} waiting for HoneyBadger in-flight operations to drain",
+                    timeout
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn build_node_for_instance(
+        &self,
+        new_instance_id: u64,
+    ) -> Result<HoneyBadgerMPCNode<F, RBCImpl>, String> {
+        let (n_triples, n_random_shares, n_prandbit, n_prandint) = {
+            let node = self.node.lock().await;
+            (
+                node.params.n_triples,
+                node.params.n_random_shares,
+                node.params.n_prandbit,
+                node.params.n_prandint,
+            )
+        };
+        let mpc_opts = honeybadger_node_opts_with_truncation(
+            self.topology.n_parties(),
+            self.topology.threshold(),
+            n_triples,
+            n_random_shares,
+            n_prandbit,
+            n_prandint,
+            new_instance_id,
+        )?;
+        <HoneyBadgerMPCNode<F, RBCImpl> as MPCProtocol<
+            F,
+            RobustShare<F>,
+            QuicNetworkManager,
+        >>::setup(self.topology.party_id(), mpc_opts, self.input_ids.clone())
+        .map_err(|e| format!("Failed to recreate HoneyBadger MPC node: {:?}", e))
+    }
+
+    pub(crate) async fn reset_state_for_next_run(
+        &self,
+        new_instance_id: u64,
+    ) -> Result<(), String> {
+        let was_ready = self.ready.swap(false, Ordering::SeqCst);
+        self.await_inflight_drained().await?;
+
+        let new_node = self.build_node_for_instance(new_instance_id).await?;
+        {
+            let mut node = self.node.lock().await;
+            *node = new_node;
+        }
+
+        let new_registry = self.open_message_router.register_instance(new_instance_id);
+        let old_registry = {
+            let mut slot = self
+                .open_registry
+                .write()
+                .expect("open registry lock poisoned");
+            std::mem::replace(&mut *slot, new_registry)
+        };
+        let old_ref_count = Arc::strong_count(&old_registry);
+        if old_ref_count > 1 {
+            tracing::warn!(
+                instance_id = old_registry.instance_id(),
+                strong_count = old_ref_count,
+                "old HoneyBadger open registry still has external references after reset"
+            );
+        }
+        drop(old_registry);
+
+        self.current_instance_id
+            .store(new_instance_id, Ordering::SeqCst);
+        *self.reservation.write().await = None;
+        self.client_output_id_map.write().await.clear();
+        {
+            let mut capture = self.client_output_capture.lock().await;
+            if capture.is_some() {
+                *capture = Some(Vec::new());
+            }
+        }
+        self.ready.store(was_ready, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub fn deployment_mode(&self) -> DeploymentMode {
+        self.deployment_mode
+    }
+
+    pub fn is_standing(&self) -> bool {
+        self.deployment_mode == DeploymentMode::Standing
     }
 
     pub fn party(&self) -> MpcPartyId {
@@ -133,6 +304,7 @@ where
         let HoneyBadgerEngineConfig {
             session,
             preprocessing,
+            deployment_mode,
         } = config;
         let (topology, local_identity, network, input_ids, open_message_router) =
             session.into_parts();
@@ -155,14 +327,17 @@ where
             F,
             RobustShare<F>,
             QuicNetworkManager,
-        >>::setup(party_id, mpc_opts, input_ids)
+        >>::setup(party_id, mpc_opts, input_ids.clone())
         .map_err(|e| format!("Failed to create MPC node: {:?}", e))?;
 
         Ok(Arc::new(Self {
             topology,
+            current_instance_id: AtomicU64::new(instance_id),
             local_identity,
             net: network,
+            input_ids: input_ids.clone(),
             node: Arc::new(Mutex::new(node)),
+            in_flight: Arc::new(AtomicUsize::new(0)),
             ready: AtomicBool::new(false),
             group_marker: PhantomData,
             preproc_store: tokio::sync::RwLock::new(None),
@@ -171,8 +346,9 @@ where
             reservation: tokio::sync::RwLock::new(None),
             client_output_capture: Mutex::new(None),
             client_output_id_map: RwLock::new(Vec::new()),
-            open_registry: open_message_router.register_instance(instance_id),
+            open_registry: StdRwLock::new(open_message_router.register_instance(instance_id)),
             open_message_router,
+            deployment_mode,
         }))
     }
 
@@ -275,13 +451,34 @@ where
         net: Arc<QuicNetworkManager>,
         node: HoneyBadgerMPCNode<F, RBCImpl>,
     ) -> Arc<Self> {
-        let instance_id = topology.instance_id();
-        let node = Arc::new(Mutex::new(node));
-        Arc::new(Self {
+        Self::from_existing_node_with_router_topology_and_mode(
+            open_message_router,
             topology,
             local_identity,
             net,
             node,
+            DeploymentMode::OneShot,
+        )
+    }
+
+    pub fn from_existing_node_with_router_topology_and_mode(
+        open_message_router: Arc<crate::net::open_registry::OpenMessageRouter>,
+        topology: MpcSessionTopology,
+        local_identity: DurableIdentityDigest,
+        net: Arc<QuicNetworkManager>,
+        node: HoneyBadgerMPCNode<F, RBCImpl>,
+        deployment_mode: DeploymentMode,
+    ) -> Arc<Self> {
+        let instance_id = topology.instance_id();
+        let node = Arc::new(Mutex::new(node));
+        Arc::new(Self {
+            topology,
+            current_instance_id: AtomicU64::new(instance_id),
+            local_identity,
+            net,
+            input_ids: Vec::new(),
+            node,
+            in_flight: Arc::new(AtomicUsize::new(0)),
             ready: AtomicBool::new(true),
             group_marker: PhantomData,
             preproc_store: tokio::sync::RwLock::new(None),
@@ -290,8 +487,9 @@ where
             reservation: tokio::sync::RwLock::new(None),
             client_output_capture: Mutex::new(None),
             client_output_id_map: RwLock::new(Vec::new()),
-            open_registry: open_message_router.register_instance(instance_id),
+            open_registry: StdRwLock::new(open_message_router.register_instance(instance_id)),
             open_message_router,
+            deployment_mode,
         })
     }
 

--- a/crates/stoffel-vm/src/net/mpc/honeybadger.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger.rs
@@ -1,5 +1,5 @@
 use crate::net::curve::SupportedMpcField;
-use crate::net::mpc::{honeybadger_node_opts, honeybadger_node_opts_with_truncation};
+use crate::net::mpc::{honeybadger_node_opts, honeybadger_node_opts_with_truncation_width};
 use crate::net::mpc_engine::{DurableIdentityDigest, MpcPartyId, MpcSessionTopology};
 use crate::net::reservation::ReservationRegistry;
 use crate::storage::preproc::PreprocStore;
@@ -203,22 +203,24 @@ where
         &self,
         new_instance_id: u64,
     ) -> Result<HoneyBadgerMPCNode<F, RBCImpl>, String> {
-        let (n_triples, n_random_shares, n_prandbit, n_prandint) = {
+        let (n_triples, n_random_shares, n_prandbit, n_prandint, preprocessing_bit_width) = {
             let node = self.node.lock().await;
             (
                 node.params.n_triples,
                 node.params.n_random_shares,
                 node.params.n_prandbit,
                 node.params.n_prandint,
+                node.params.l,
             )
         };
-        let mpc_opts = honeybadger_node_opts_with_truncation(
+        let mpc_opts = honeybadger_node_opts_with_truncation_width(
             self.topology.n_parties(),
             self.topology.threshold(),
             n_triples,
             n_random_shares,
             n_prandbit,
             n_prandint,
+            preprocessing_bit_width,
             new_instance_id,
         )?;
         <HoneyBadgerMPCNode<F, RBCImpl> as MPCProtocol<

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/capabilities.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/capabilities.rs
@@ -175,6 +175,12 @@ where
         Some(self)
     }
 
+    async fn reset_for_next_run(&self, new_instance_id: u64) -> MpcEngineResult<()> {
+        self.reset_state_for_next_run(new_instance_id)
+            .await
+            .map_mpc_engine_operation("reset_for_next_run")
+    }
+
     async fn input_share_async(&self, clear: ClearShareInput) -> MpcEngineResult<ShareData> {
         self.input_share(clear)
     }

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/capabilities.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/capabilities.rs
@@ -31,6 +31,15 @@ where
             .map_mpc_engine_operation("multiply_share")
     }
 
+    fn batch_multiply_shares(
+        &self,
+        ty: ShareType,
+        pairs: &[(Vec<u8>, Vec<u8>)],
+    ) -> MpcEngineResult<Vec<ShareData>> {
+        crate::net::try_block_on_current(self.batch_multiply_share_async(ty, pairs))
+            .map_mpc_engine_operation("batch_multiply_shares")
+    }
+
     fn divide_fixed_by_constant(
         &self,
         ty: ShareType,

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/config.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/config.rs
@@ -1,4 +1,4 @@
-use crate::net::engine_config::MpcSessionConfig;
+use crate::net::engine_config::{DeploymentMode, MpcSessionConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct HoneyBadgerPreprocessingConfig {
@@ -19,6 +19,7 @@ impl HoneyBadgerPreprocessingConfig {
 pub struct HoneyBadgerEngineConfig {
     pub session: MpcSessionConfig,
     pub preprocessing: HoneyBadgerPreprocessingConfig,
+    pub deployment_mode: DeploymentMode,
 }
 
 impl HoneyBadgerEngineConfig {
@@ -29,6 +30,12 @@ impl HoneyBadgerEngineConfig {
         Self {
             session,
             preprocessing,
+            deployment_mode: DeploymentMode::OneShot,
         }
+    }
+
+    pub const fn with_deployment_mode(mut self, deployment_mode: DeploymentMode) -> Self {
+        self.deployment_mode = deployment_mode;
+        self
     }
 }

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/consensus.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/consensus.rs
@@ -17,11 +17,11 @@ where
 {
     fn rbc_broadcast(&self, message: &[u8]) -> MpcEngineResult<RbcSessionId> {
         let session_id = self
-            .open_registry
+            .open_registry()
             .rbc_broadcast(self.topology.party_id(), message)
             .map_mpc_engine_operation("rbc_broadcast")?;
         let wire_message = crate::net::open_registry::encode_rbc_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             session_id,
             self.topology.party_id(),
             message,
@@ -35,13 +35,13 @@ where
     }
 
     fn rbc_receive(&self, from_party: MpcPartyId, timeout_ms: u64) -> MpcEngineResult<Vec<u8>> {
-        self.open_registry
+        self.open_registry()
             .rbc_receive(self.topology.party_id(), from_party.id(), timeout_ms)
             .map_mpc_engine_operation("rbc_receive")
     }
 
     fn rbc_receive_any(&self, timeout_ms: u64) -> MpcEngineResult<(MpcPartyId, Vec<u8>)> {
-        self.open_registry
+        self.open_registry()
             .rbc_receive_any(self.topology.party_id(), timeout_ms)
             .map(|(party_id, message)| (MpcPartyId::new(party_id), message))
             .map_mpc_engine_operation("rbc_receive_any")
@@ -56,12 +56,12 @@ where
 {
     async fn rbc_broadcast_async(&self, message: &[u8]) -> MpcEngineResult<RbcSessionId> {
         let session_id = self
-            .open_registry
+            .open_registry()
             .rbc_broadcast_async(self.topology.party_id(), message)
             .await
             .map_mpc_engine_operation("async_rbc_broadcast")?;
         let wire_message = crate::net::open_registry::encode_rbc_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             session_id,
             self.topology.party_id(),
             message,
@@ -80,7 +80,7 @@ where
         from_party: MpcPartyId,
         timeout_ms: u64,
     ) -> MpcEngineResult<Vec<u8>> {
-        self.open_registry
+        self.open_registry()
             .rbc_receive_async(self.topology.party_id(), from_party.id(), timeout_ms)
             .await
             .map_mpc_engine_operation("async_rbc_receive")
@@ -90,7 +90,7 @@ where
         &self,
         timeout_ms: u64,
     ) -> MpcEngineResult<(MpcPartyId, Vec<u8>)> {
-        self.open_registry
+        self.open_registry()
             .rbc_receive_any_async(self.topology.party_id(), timeout_ms)
             .await
             .map(|(party_id, message)| (MpcPartyId::new(party_id), message))

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/engine.rs
@@ -36,6 +36,12 @@ where
         self.ready.load(Ordering::SeqCst)
     }
 
+    fn multiplication_batch_capacity(&self) -> Option<usize> {
+        Some(super::operations::max_honeybadger_mul_pairs_per_session(
+            self.topology.threshold(),
+        ))
+    }
+
     fn start(&self) -> crate::net::mpc_engine::MpcEngineResult<()> {
         // Mark engine as ready in test/single-process scenarios. Real deployments should call `preprocess()`.
         self.ready.store(true, Ordering::SeqCst);

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/engine.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/engine.rs
@@ -25,7 +25,7 @@ where
     }
 
     fn topology(&self) -> MpcSessionTopology {
-        self.topology
+        HoneyBadgerMpcEngine::topology(self)
     }
 
     fn local_identity(&self) -> DurableIdentityDigest {
@@ -110,13 +110,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_single_next(
+            let seq = self.open_registry().insert_single_next(
                 &type_key,
                 self.topology.party_id(),
                 share_bytes.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -128,7 +128,7 @@ where
             let n = self.topology.n_parties();
             let t = self.topology.threshold();
 
-            self.open_registry.open_share_at_wait(
+            self.open_registry().open_share_at_wait(
                 self.topology.party_id(),
                 &type_key,
                 seq,
@@ -170,13 +170,13 @@ where
                 }
             };
 
-            let seq = self.open_registry.insert_batch_next(
+            let seq = self.open_registry().insert_batch_next(
                 &type_key,
                 self.topology.party_id(),
                 shares.to_vec(),
             )?;
             let wire_message = crate::net::open_registry::encode_batch_share_wire_message(
-                self.topology.instance_id(),
+                self.current_instance_id(),
                 seq,
                 &type_key,
                 self.topology.party_id(),
@@ -188,7 +188,7 @@ where
             let n = self.topology.n_parties();
             let t = self.topology.threshold();
 
-            self.open_registry.batch_open_at_wait(
+            self.open_registry().batch_open_at_wait(
                 self.topology.party_id(),
                 &type_key,
                 seq,

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
@@ -103,13 +103,27 @@ where
             let y = SecretFixedPoint::new_with_precision(right_share, proto_precision);
 
             let mut node = self.clone_node().await;
-            const PRANDBIT_POOL_MULS: usize = 16;
             let f = precision.fractional_bits();
-            let pool = f.saturating_mul(PRANDBIT_POOL_MULS);
-            node.params.n_prandbit = node.params.n_prandbit.max(pool);
-            node.params.n_prandint = node.params.n_prandint.max(PRANDBIT_POOL_MULS);
-            node.params.n_triples = node.params.n_triples.saturating_add(pool);
-            node.params.n_random_shares = node.params.n_random_shares.saturating_add(pool);
+            if self.is_standing() {
+                let triples = self.reserve_beaver_triples(1).await?;
+                let prandbits = self.reserve_prandbit_shares(f).await?;
+                let prandints = self.reserve_prandint_shares(1, ty).await?;
+                node.preprocessing_material.lock().await.add(
+                    Some(triples),
+                    None,
+                    None,
+                    None,
+                    Some(prandbits),
+                    Some(prandints),
+                );
+            } else {
+                const PRANDBIT_POOL_MULS: usize = 16;
+                let pool = f.saturating_mul(PRANDBIT_POOL_MULS);
+                node.params.n_prandbit = node.params.n_prandbit.max(pool);
+                node.params.n_prandint = node.params.n_prandint.max(PRANDBIT_POOL_MULS);
+                node.params.n_triples = node.params.n_triples.saturating_add(pool);
+                node.params.n_random_shares = node.params.n_random_shares.saturating_add(pool);
+            }
 
             let result = node
                 .mul_fixed(x, y, self.net.clone())
@@ -133,8 +147,20 @@ where
                 // regenerates from params on demand; `.max` never shrinks an
                 // already-sized estimate (e.g. AES/CBC). Triple generation pulls
                 // 2 randoms each, which run_preprocessing adds automatically.
-                const TRIPLE_POOL_MULS: usize = 64;
-                node.params.n_triples = node.params.n_triples.max(TRIPLE_POOL_MULS);
+                if self.is_standing() {
+                    let triples = self.reserve_beaver_triples(1).await?;
+                    node.preprocessing_material.lock().await.add(
+                        Some(triples),
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
+                    );
+                } else {
+                    const TRIPLE_POOL_MULS: usize = 64;
+                    node.params.n_triples = node.params.n_triples.max(TRIPLE_POOL_MULS);
+                }
                 let trace = Self::trace_multiply_enabled();
                 let started_at = Instant::now();
                 if trace {
@@ -215,28 +241,29 @@ where
         let y = ClearFixedPoint::new_with_precision(divisor_field, proto_precision);
 
         let mut node = self.clone_node().await;
-        // Each division's truncation consumes `f` random bits and one random
-        // integer, which the VM's baseline preprocessing does not generate
-        // (`honeybadger_node_opts` requests zero prandbit/prandint). The
-        // protocol regenerates them on demand, but re-running that per division
-        // collides across parties; so on the first division (empty pool) we
-        // provision a pool covering several divisions in one preprocessing pass.
-        // The preprocessing-material store is shared across node clones, so
-        // later divisions consume from the pool and skip regeneration.
-        //
-        // Crucially, prandbit generation itself consumes one beaver triple and
-        // one random share per bit, and the protocol's preprocessing budget does
-        // NOT account for that. So we must also grow the triple/random targets
-        // by the pool size; otherwise prandbit generation exhausts the triples
-        // the computation needs (or fails outright). Configuring the demand here
-        // is what makes division self-sufficient without any protocol change.
-        const PRANDBIT_POOL_DIVS: usize = 16;
         let f = precision.fractional_bits();
-        let pool = f.saturating_mul(PRANDBIT_POOL_DIVS);
-        node.params.n_prandbit = node.params.n_prandbit.max(pool);
-        node.params.n_prandint = node.params.n_prandint.max(PRANDBIT_POOL_DIVS);
-        node.params.n_triples = node.params.n_triples.saturating_add(pool);
-        node.params.n_random_shares = node.params.n_random_shares.saturating_add(pool);
+        if self.is_standing() {
+            let prandbits = self.reserve_prandbit_shares(f).await?;
+            let prandints = self.reserve_prandint_shares(1, ty).await?;
+            node.preprocessing_material.lock().await.add(
+                None,
+                None,
+                None,
+                None,
+                Some(prandbits),
+                Some(prandints),
+            );
+        } else {
+            // Each division's truncation consumes `f` random bits and one random
+            // integer. One-shot mode preserves the legacy behavior of
+            // provisioning a local pool and letting the protocol regenerate it.
+            const PRANDBIT_POOL_DIVS: usize = 16;
+            let pool = f.saturating_mul(PRANDBIT_POOL_DIVS);
+            node.params.n_prandbit = node.params.n_prandbit.max(pool);
+            node.params.n_prandint = node.params.n_prandint.max(PRANDBIT_POOL_DIVS);
+            node.params.n_triples = node.params.n_triples.saturating_add(pool);
+            node.params.n_random_shares = node.params.n_random_shares.saturating_add(pool);
+        }
         let result = node
             .div_with_const_fixed(x, y, self.net.clone())
             .await
@@ -277,7 +304,9 @@ where
 
                 let mut encoded_results = Vec::with_capacity(pairs.len());
                 let mut node = self.clone_node().await;
-                node.params.n_triples = node.params.n_triples.max(max_pairs_per_session);
+                if !self.is_standing() {
+                    node.params.n_triples = node.params.n_triples.max(max_pairs_per_session);
+                }
                 for (chunk_index, chunk) in pairs.chunks(max_pairs_per_session).enumerate() {
                     let mut left_shares = Vec::with_capacity(chunk.len());
                     let mut right_shares = Vec::with_capacity(chunk.len());
@@ -285,6 +314,18 @@ where
                     for (left, right) in chunk {
                         left_shares.push(Self::decode_share(left)?);
                         right_shares.push(Self::decode_share(right)?);
+                    }
+
+                    if self.is_standing() {
+                        let triples = self.reserve_beaver_triples(chunk.len()).await?;
+                        node.preprocessing_material.lock().await.add(
+                            Some(triples),
+                            None,
+                            None,
+                            None,
+                            None,
+                            None,
+                        );
                     }
 
                     let chunk_started_at = Instant::now();
@@ -366,13 +407,13 @@ where
             }
         };
 
-        let seq = self.open_registry.insert_single_next(
+        let seq = self.open_registry().insert_single_next(
             &type_key,
             self.topology.party_id(),
             share_bytes.to_vec(),
         )?;
         let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             &type_key,
             self.topology.party_id(),
@@ -384,7 +425,7 @@ where
         let n = self.topology.n_parties();
         let t = self.topology.threshold();
 
-        self.open_registry
+        self.open_registry()
             .open_share_at_async(
                 self.topology.party_id(),
                 type_key,
@@ -427,13 +468,13 @@ where
             }
         };
 
-        let seq = self.open_registry.insert_single_next(
+        let seq = self.open_registry().insert_single_next(
             &type_key,
             self.topology.party_id(),
             share_bytes.to_vec(),
         )?;
         let wire_message = crate::net::open_registry::encode_single_share_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             &type_key,
             self.topology.party_id(),
@@ -445,7 +486,7 @@ where
         let n = self.topology.n_parties();
         let t = self.topology.threshold();
 
-        self.open_registry
+        self.open_registry()
             .open_bytes_at_async(
                 self.topology.party_id(),
                 type_key,
@@ -487,13 +528,13 @@ where
             }
         };
 
-        let seq = self.open_registry.insert_batch_next(
+        let seq = self.open_registry().insert_batch_next(
             &type_key,
             self.topology.party_id(),
             shares.to_vec(),
         )?;
         let wire_message = crate::net::open_registry::encode_batch_share_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             &type_key,
             self.topology.party_id(),
@@ -505,7 +546,7 @@ where
         let n = self.topology.n_parties();
         let t = self.topology.threshold();
 
-        self.open_registry
+        self.open_registry()
             .batch_open_at_async(
                 self.topology.party_id(),
                 type_key,
@@ -584,14 +625,14 @@ where
             .serialize_compressed(&mut partial_bytes)
             .map_err(|e| format!("serialize partial point: {}", e))?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share.id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_hb_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share.id,
@@ -604,7 +645,7 @@ where
         let domain = GeneralEvaluationDomain::<F>::new(n)
             .ok_or_else(|| "No suitable FFT domain".to_string())?;
 
-        self.open_registry.exp_open_wait(
+        self.open_registry().exp_open_wait(
             ExpOpenRequest {
                 kind: ExpOpenRegistryKind::G1,
                 sequence: Some(seq),
@@ -643,14 +684,14 @@ where
             .serialize_compressed(&mut partial_bytes)
             .map_err(|e| format!("serialize partial point: {}", e))?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share.id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_hb_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share.id,
@@ -663,7 +704,7 @@ where
         let domain = GeneralEvaluationDomain::<F>::new(n)
             .ok_or_else(|| "No suitable FFT domain".to_string())?;
 
-        self.open_registry
+        self.open_registry()
             .exp_open_async(
                 ExpOpenRequest {
                     kind: ExpOpenRegistryKind::G1,
@@ -720,14 +761,14 @@ where
             .serialize_compressed(&mut partial_bytes)
             .map_err(|e| format!("serialize G2 partial point: {}", e))?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share.id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_hb_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share.id,
@@ -740,7 +781,7 @@ where
         let domain = GeneralEvaluationDomain::<Fr>::new(n)
             .ok_or_else(|| "No suitable FFT domain".to_string())?;
 
-        self.open_registry.exp_open_wait(
+        self.open_registry().exp_open_wait(
             ExpOpenRequest {
                 kind: ExpOpenRegistryKind::G1,
                 sequence: Some(seq),
@@ -799,14 +840,14 @@ where
             .serialize_compressed(&mut partial_bytes)
             .map_err(|e| format!("serialize G2 partial point: {}", e))?;
 
-        let seq = self.open_registry.insert_exp_next(
+        let seq = self.open_registry().insert_exp_next(
             ExpOpenRegistryKind::G1,
             self.topology.party_id(),
             share.id,
             partial_bytes.clone(),
         )?;
         let wire_message = crate::net::open_registry::encode_hb_open_exp_wire_message(
-            self.topology.instance_id(),
+            self.current_instance_id(),
             seq,
             self.topology.party_id(),
             share.id,
@@ -819,7 +860,7 @@ where
         let domain = GeneralEvaluationDomain::<Fr>::new(n)
             .ok_or_else(|| "No suitable FFT domain".to_string())?;
 
-        self.open_registry
+        self.open_registry()
             .exp_open_async(
                 ExpOpenRequest {
                     kind: ExpOpenRegistryKind::G1,

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/operations.rs
@@ -8,6 +8,9 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use std::any::TypeId;
 use std::time::Instant;
 use stoffel_vm_types::core_types::{ClearShareValue, ShareData, ShareType};
+use stoffel_vm_types::mpc::{
+    honeybadger_mul_batch_capacity, HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV,
+};
 use stoffelmpc_mpc::common::types::fixed::{
     ClearFixedPoint, FixedPointPrecision, SecretFixedPoint,
 };
@@ -16,14 +19,6 @@ use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustS
 
 /// Env var overriding how many secret-pair multiply operands are fed to a
 /// single HoneyBadger `mul()` session. See [`max_honeybadger_mul_pairs_per_session`].
-const STOFFEL_HB_MUL_MAX_PAIRS_PER_SESSION_ENV: &str = "STOFFEL_HB_MUL_MAX_PAIRS_PER_SESSION";
-
-/// Default multiplier on `(threshold + 1)` for the pairs fed to one `mul()`
-/// session. Matches `mpc-protocols`' own per-session deserialization bound
-/// (`128 * (t+1)`), so the default stays within what the protocol already
-/// supports without a change. See [`max_honeybadger_mul_pairs_per_session`].
-const DEFAULT_MAX_HONEYBADGER_MUL_BATCH_RECON_CHUNKS: usize = 128;
-
 /// Maximum secret-pair multiply operands fed to a single HoneyBadger `mul()`
 /// session.
 ///
@@ -48,7 +43,7 @@ const DEFAULT_MAX_HONEYBADGER_MUL_BATCH_RECON_CHUNKS: usize = 128;
 /// The `(t+1)` factor only keeps the count a clean multiple so there is no RBC
 /// remainder; an explicit override (below) is used as-is.
 pub(crate) fn max_honeybadger_mul_pairs_per_session(threshold: usize) -> usize {
-    let from_env = std::env::var(STOFFEL_HB_MUL_MAX_PAIRS_PER_SESSION_ENV)
+    let from_env = std::env::var(HONEYBADGER_MUL_MAX_PAIRS_PER_SESSION_ENV)
         .ok()
         .and_then(|raw| raw.parse::<usize>().ok().map(|v| v.max(1)));
     from_env.unwrap_or_else(|| max_honeybadger_mul_pairs_per_session_with(threshold, None))
@@ -61,10 +56,7 @@ pub(crate) fn max_honeybadger_mul_pairs_per_session_with(
     threshold: usize,
     override_pairs: Option<usize>,
 ) -> usize {
-    if let Some(value) = override_pairs {
-        return value.max(1);
-    }
-    DEFAULT_MAX_HONEYBADGER_MUL_BATCH_RECON_CHUNKS.saturating_mul(threshold.saturating_add(1))
+    honeybadger_mul_batch_capacity(threshold, override_pairs)
 }
 
 impl<F, G> HoneyBadgerMpcEngine<F, G>

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/preprocessing.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/preprocessing.rs
@@ -1,6 +1,8 @@
 use super::HoneyBadgerMpcEngine;
 use crate::net::curve::SupportedMpcField;
-use crate::storage::preproc::{self, PreprocBlob, PreprocKeyScope};
+use crate::storage::preproc::{
+    self, PoolAvailability, PreprocBlob, PreprocKeyScope, PreprocTargets, TopUpReport,
+};
 use ark_ec::{CurveGroup, PrimeGroup};
 use ark_std::rand::SeedableRng;
 use std::sync::{
@@ -10,7 +12,9 @@ use std::sync::{
 use std::time::{Duration, Instant};
 use stoffel_vm_types::core_types::{ShareData, ShareType};
 use stoffelmpc_mpc::common::PreprocessingMPCProtocol;
+use stoffelmpc_mpc::honeybadger::fpmul::f256::Gf256;
 use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
+use stoffelmpc_mpc::honeybadger::triple_gen::ShamirBeaverTriple;
 use stoffelmpc_mpc::honeybadger::HoneyBadgerError;
 
 fn ensure_decoded_count(label: &str, actual: usize, expected: u32) -> Result<(), String> {
@@ -43,6 +47,10 @@ where
     }
 
     pub async fn preprocess(&self) -> Result<(), String> {
+        if self.is_standing() {
+            return self.preprocess_standing().await;
+        }
+
         if self.try_load_preproc().await? {
             self.ready.store(true, Ordering::SeqCst);
             return Ok(());
@@ -83,6 +91,138 @@ where
 
         self.ready.store(true, Ordering::SeqCst);
         Ok(())
+    }
+
+    async fn preproc_scope(
+        &self,
+    ) -> Result<
+        (
+            Arc<dyn crate::storage::preproc::PreprocStore>,
+            [u8; 32],
+            PreprocKeyScope,
+        ),
+        String,
+    > {
+        let store = self.preproc_store.read().await.clone();
+        let hash = *self.program_hash.read().await;
+        let (store, hash) = match (store, hash) {
+            (Some(s), Some(h)) => (s, h),
+            _ => {
+                return Err(
+                    "standing preprocessing requires configured preproc store and program hash"
+                        .to_owned(),
+                )
+            }
+        };
+        let scope = PreprocKeyScope::new(
+            hash,
+            F::field_kind(),
+            self.topology.n_parties(),
+            self.topology.threshold(),
+            self.persistent_identity(),
+        );
+        Ok((store, hash, scope))
+    }
+
+    async fn current_preproc_targets(&self) -> Result<PreprocTargets, String> {
+        let node = self.clone_node().await;
+        Ok(PreprocTargets {
+            beaver: preproc::u32_index(node.params.n_triples as u64, "HB beaver target")?,
+            random: preproc::u32_index(node.params.n_random_shares as u64, "HB random target")?,
+            prand_bit: preproc::u32_index(node.params.n_prandbit as u64, "HB prandbit target")?,
+            prand_int: preproc::u32_index(node.params.n_prandint as u64, "HB prandint target")?,
+        })
+    }
+
+    async fn preprocess_standing(&self) -> Result<(), String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let targets = self.current_preproc_targets().await?;
+        let availability = store.scope_availability(&scope).await?;
+        if availability.beaver < targets.beaver
+            || availability.random < targets.random
+            || availability.prand_bit < targets.prand_bit
+            || availability.prand_int < targets.prand_int
+        {
+            self.top_up_to(targets).await?;
+        }
+        self.ready.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub async fn top_up_to(&self, targets: PreprocTargets) -> Result<TopUpReport, String> {
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let availability = store.scope_availability(&scope).await?;
+        let needed = PoolAvailability {
+            beaver: targets.beaver.saturating_sub(availability.beaver),
+            random: targets.random.saturating_sub(availability.random),
+            prand_bit: targets.prand_bit.saturating_sub(availability.prand_bit),
+            prand_int: targets.prand_int.saturating_sub(availability.prand_int),
+        };
+        if needed == PoolAvailability::default() {
+            return Ok(TopUpReport {
+                generated: PoolAvailability::default(),
+                skipped: true,
+            });
+        }
+
+        let mut node = self.clone_node().await;
+        node.params.n_triples = needed.beaver as usize;
+        node.params.n_random_shares = needed.random as usize;
+        node.params.n_prandbit = needed.prand_bit as usize;
+        node.params.n_prandint = needed.prand_int as usize;
+
+        let mut rng = ark_std::rand::rngs::StdRng::from_entropy();
+        node.run_preprocessing(self.net.clone(), &mut rng)
+            .await
+            .map_err(|e| format!("Failed to top up preprocessing material: {:?}", e))?;
+
+        let mut generated = PoolAvailability::default();
+        let mut to_append = Vec::new();
+        {
+            let mut prep = node.preprocessing_material.lock().await;
+            let lengths = prep.length();
+            if lengths.beaver_triples > 0 {
+                let items = prep
+                    .take_beaver_triples(lengths.beaver_triples)
+                    .map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_beaver_triples::<F>(&items)?;
+                generated.beaver = preproc::u32_index(items.len() as u64, "generated beaver")?;
+                to_append.push((scope.beaver_triple(), item_size, generated.beaver, data));
+            }
+            if lengths.random_shr > 0 {
+                let items = prep
+                    .take_random_shares(lengths.random_shr)
+                    .map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_robust_shares::<F>(&items)?;
+                generated.random = preproc::u32_index(items.len() as u64, "generated random")?;
+                to_append.push((scope.random_share(), item_size, generated.random, data));
+            }
+            if lengths.prandbit > 0 {
+                let items = prep
+                    .take_prandbit_shares(lengths.prandbit)
+                    .map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_prandbit_shares::<F>(&items)?;
+                generated.prand_bit = preproc::u32_index(items.len() as u64, "generated prandbit")?;
+                to_append.push((scope.prand_bit(), item_size, generated.prand_bit, data));
+            }
+            if lengths.prandint > 0 {
+                let items = prep
+                    .take_prandint_shares(lengths.prandint)
+                    .map_err(|e| format!("{e:?}"))?;
+                let (data, item_size) = preproc::serialize_robust_shares::<F>(&items)?;
+                generated.prand_int = preproc::u32_index(items.len() as u64, "generated prandint")?;
+                to_append.push((scope.prand_int(), item_size, generated.prand_int, data));
+            }
+        }
+
+        for (key, item_size, added, data) in to_append {
+            store.append_items(&key, item_size, added, &data).await?;
+        }
+
+        Ok(TopUpReport {
+            generated,
+            skipped: false,
+        })
     }
 
     /// Try to load preprocessing material from the persistent store.
@@ -367,6 +507,32 @@ where
         &self,
         num_shares: usize,
     ) -> Result<Vec<RobustShare<F>>, String> {
+        if self.is_standing() {
+            let (store, _hash, scope) = self.preproc_scope().await?;
+            let key = scope.random_share();
+            let meta = store
+                .meta(&key)
+                .await?
+                .ok_or_else(|| "no standing random shares stored".to_owned())?;
+            let count = preproc::u32_index(num_shares as u64, "standing random share count")?;
+            if meta.available() < count {
+                return Err(format!(
+                    "InsufficientPreproc: random shares need {}, available {}",
+                    count,
+                    meta.available()
+                ));
+            }
+            let start = meta.consumed;
+            store.reserve_at(&key, start, count).await?;
+            let blob = store
+                .load(&key)
+                .await?
+                .ok_or("no standing random shares stored")?;
+            let decoded =
+                preproc::deserialize_robust_shares::<F>(&blob.data, blob.meta.item_size, start)?;
+            return Ok(decoded.into_iter().take(num_shares).collect());
+        }
+
         loop {
             let attempt = {
                 let node = self.clone_node().await;
@@ -392,6 +558,33 @@ where
         num_shares: usize,
         ty: ShareType,
     ) -> Result<Vec<RobustShare<F>>, String> {
+        if self.is_standing() {
+            let _ = ty;
+            let (store, _hash, scope) = self.preproc_scope().await?;
+            let key = scope.prand_int();
+            let meta = store
+                .meta(&key)
+                .await?
+                .ok_or_else(|| "no standing PRandInt shares stored".to_owned())?;
+            let count = preproc::u32_index(num_shares as u64, "standing PRandInt share count")?;
+            if meta.available() < count {
+                return Err(format!(
+                    "InsufficientPreproc: PRandInt shares need {}, available {}",
+                    count,
+                    meta.available()
+                ));
+            }
+            let start = meta.consumed;
+            store.reserve_at(&key, start, count).await?;
+            let blob = store
+                .load(&key)
+                .await?
+                .ok_or("no standing PRandInt shares stored")?;
+            let decoded =
+                preproc::deserialize_robust_shares::<F>(&blob.data, blob.meta.item_size, start)?;
+            return Ok(decoded.into_iter().take(num_shares).collect());
+        }
+
         loop {
             let attempt = {
                 let node = self.clone_node().await;
@@ -410,6 +603,98 @@ where
                 }
             }
         }
+    }
+
+    pub(super) async fn reserve_beaver_triples(
+        &self,
+        num_triples: usize,
+    ) -> Result<Vec<ShamirBeaverTriple<F>>, String> {
+        if !self.is_standing() {
+            let node = self.clone_node().await;
+            return node
+                .preprocessing_material
+                .lock()
+                .await
+                .take_beaver_triples(num_triples)
+                .map_err(|e| format!("Failed to take Beaver triples: {:?}", e));
+        }
+
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let key = scope.beaver_triple();
+        let meta = store
+            .meta(&key)
+            .await?
+            .ok_or_else(|| "no standing Beaver triples stored".to_owned())?;
+        let count = preproc::u32_index(num_triples as u64, "standing Beaver triple count")?;
+        if meta.available() < count {
+            return Err(format!(
+                "InsufficientPreproc: Beaver triples need {}, available {}",
+                count,
+                meta.available()
+            ));
+        }
+        let start = meta.consumed;
+        store.reserve_at(&key, start, count).await?;
+        let blob = store
+            .load(&key)
+            .await?
+            .ok_or("no standing Beaver triples stored")?;
+        let decoded =
+            preproc::deserialize_beaver_triples::<F>(&blob.data, blob.meta.item_size, start)?;
+        if decoded.len() < num_triples {
+            return Err(format!(
+                "standing Beaver triple decode returned {} items, expected {}",
+                decoded.len(),
+                num_triples
+            ));
+        }
+        Ok(decoded.into_iter().take(num_triples).collect())
+    }
+
+    pub(super) async fn reserve_prandbit_shares(
+        &self,
+        num_shares: usize,
+    ) -> Result<Vec<(RobustShare<F>, Gf256)>, String> {
+        if !self.is_standing() {
+            let node = self.clone_node().await;
+            return node
+                .preprocessing_material
+                .lock()
+                .await
+                .take_prandbit_shares(num_shares)
+                .map_err(|e| format!("Failed to take PRandBit shares: {:?}", e));
+        }
+
+        let (store, _hash, scope) = self.preproc_scope().await?;
+        let key = scope.prand_bit();
+        let meta = store
+            .meta(&key)
+            .await?
+            .ok_or_else(|| "no standing PRandBit shares stored".to_owned())?;
+        let count = preproc::u32_index(num_shares as u64, "standing PRandBit share count")?;
+        if meta.available() < count {
+            return Err(format!(
+                "InsufficientPreproc: PRandBit shares need {}, available {}",
+                count,
+                meta.available()
+            ));
+        }
+        let start = meta.consumed;
+        store.reserve_at(&key, start, count).await?;
+        let blob = store
+            .load(&key)
+            .await?
+            .ok_or("no standing PRandBit shares stored")?;
+        let decoded =
+            preproc::deserialize_prandbit_shares::<F>(&blob.data, blob.meta.item_size, start)?;
+        if decoded.len() < num_shares {
+            return Err(format!(
+                "standing PRandBit decode returned {} items, expected {}",
+                decoded.len(),
+                num_shares
+            ));
+        }
+        Ok(decoded.into_iter().take(num_shares).collect())
     }
 
     async fn regenerate_random_shares(&self, needed: usize) -> Result<(), String> {

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/reservation.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/reservation.rs
@@ -2,7 +2,7 @@ use super::HoneyBadgerMpcEngine;
 use crate::net::curve::SupportedMpcField;
 use crate::net::mpc_engine::{MpcEngineOperationResultExt, MpcEngineReservation, MpcEngineResult};
 use crate::net::reservation::{ReservationGrant, ReservationRegistry};
-use crate::storage::preproc::{self, PreprocKeyScope};
+use crate::storage::preproc::{self, PoolAvailability, PreprocKeyScope};
 use ark_ec::{CurveGroup, PrimeGroup};
 use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
 use stoffelnet::network_utils::ClientId;
@@ -38,6 +38,17 @@ where
         program_hash: [u8; 32],
         capacity: u64,
     ) -> MpcEngineResult<()> {
+        self.init_reservations_for_run(program_hash, capacity, 0, PoolAvailability::default())
+            .await
+    }
+
+    async fn init_reservations_for_run(
+        &self,
+        program_hash: [u8; 32],
+        capacity: u64,
+        run_id: u64,
+        mut preproc_offset: PoolAvailability,
+    ) -> MpcEngineResult<()> {
         async {
             let store = self.preproc_store.read().await.clone();
             let persistent_identity = self.persistent_identity();
@@ -47,15 +58,56 @@ where
                         .await
                         .map_err(|e| e.to_string())?
                 {
-                    *self.reservation.write().await = Some(restored);
-                    return Ok::<(), String>(());
+                    if restored.run_id().await == run_id {
+                        *self.reservation.write().await = Some(restored);
+                        return Ok::<(), String>(());
+                    }
+                }
+
+                if preproc_offset == PoolAvailability::default() && self.is_standing() {
+                    let scope = PreprocKeyScope::new(
+                        program_hash,
+                        F::field_kind(),
+                        self.topology.n_parties(),
+                        self.topology.threshold(),
+                        persistent_identity,
+                    );
+                    preproc_offset = PoolAvailability {
+                        beaver: store
+                            .meta(&scope.beaver_triple())
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .map(|meta| meta.consumed)
+                            .unwrap_or(0),
+                        random: store
+                            .meta(&scope.random_share())
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .map(|meta| meta.consumed)
+                            .unwrap_or(0),
+                        prand_bit: store
+                            .meta(&scope.prand_bit())
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .map(|meta| meta.consumed)
+                            .unwrap_or(0),
+                        prand_int: store
+                            .meta(&scope.prand_int())
+                            .await
+                            .map_err(|e| e.to_string())?
+                            .map(|meta| meta.consumed)
+                            .unwrap_or(0),
+                    };
                 }
             }
-            *self.reservation.write().await = Some(ReservationRegistry::new(
+            *self.reservation.write().await = Some(ReservationRegistry::new_for_run(
                 program_hash,
                 persistent_identity,
                 capacity,
+                run_id,
+                preproc_offset,
             ));
+            self.persist_reservation_state_if_configured().await?;
             Ok::<(), String>(())
         }
         .await
@@ -101,7 +153,19 @@ where
             )
             .random_share();
             let blob = store.load(&key).await?.ok_or("no random shares stored")?;
-            let index = preproc::u32_index(index, "preprocessing random share index")?;
+            let preproc_offset = {
+                let guard = self.reservation.read().await;
+                let offset = guard
+                    .as_ref()
+                    .map(|reg| reg.preproc_offset())
+                    .ok_or("reservations not initialized")?
+                    .await;
+                offset
+            };
+            let physical = index
+                .checked_add(u64::from(preproc_offset.random))
+                .ok_or_else(|| "preprocessing random share physical index overflow".to_owned())?;
+            let index = preproc::u32_index(physical, "preprocessing random share index")?;
             store.reserve_at(&key, index, 1).await?;
             let share =
                 preproc::deserialize_one_robust_share::<F>(&blob.data, blob.meta.item_size, index)?;
@@ -166,10 +230,23 @@ where
             )
             .random_share();
             let blob = store.load(&key).await?.ok_or("no random shares stored")?;
+            let preproc_offset = {
+                let reg_guard = self.reservation.read().await;
+                reg_guard
+                    .as_ref()
+                    .ok_or("reservations not initialized")?
+                    .preproc_offset()
+                    .await
+            };
 
             let mut result = Vec::with_capacity(indices.len());
             for (idx, masked_input_bytes) in &masked_inputs {
-                let mask_index = preproc::u32_index(*idx, "preprocessing masked input index")?;
+                let physical = idx
+                    .checked_add(u64::from(preproc_offset.random))
+                    .ok_or_else(|| {
+                        "preprocessing masked input physical index overflow".to_owned()
+                    })?;
+                let mask_index = preproc::u32_index(physical, "preprocessing masked input index")?;
                 let mask_share = preproc::deserialize_one_robust_share::<F>(
                     &blob.data,
                     blob.meta.item_size,
@@ -194,7 +271,10 @@ where
                 reg.all_reserved_slots_consumed().await
             };
             // Keep the mask blob while any allocated slot may still need it for unmasking.
-            if all_reserved_slots_consumed && store.available(&key).await? == 0 {
+            if !self.is_standing()
+                && all_reserved_slots_consumed
+                && store.available(&key).await? == 0
+            {
                 store.delete(&key).await?;
             }
             Ok::<Vec<(u64, Vec<u8>)>, String>(result)

--- a/crates/stoffel-vm/src/net/mpc/honeybadger/tests.rs
+++ b/crates/stoffel-vm/src/net/mpc/honeybadger/tests.rs
@@ -196,6 +196,10 @@ async fn get_mask_share_reserves_requested_persistent_index_once() {
         .unwrap();
 
     let reservation = engine.reservation_ops().unwrap();
+    reservation
+        .init_reservations(program_hash, shares.len() as u64)
+        .await
+        .unwrap();
     let first = reservation.get_mask_share(0).await.unwrap();
     assert!(!first.is_empty());
     assert_eq!(store.available(&key).await.unwrap(), 1);

--- a/crates/stoffel-vm/src/net/mpc/session_config.rs
+++ b/crates/stoffel-vm/src/net/mpc/session_config.rs
@@ -7,6 +7,13 @@ use std::sync::Arc;
 use stoffelnet::network_utils::ClientId;
 use stoffelnet::transports::quic::QuicNetworkManager;
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum DeploymentMode {
+    #[default]
+    OneShot,
+    Standing,
+}
+
 /// Common MPC engine session wiring shared by backend implementations.
 ///
 /// Backend constructors should take this named config instead of long

--- a/crates/stoffel-vm/src/net/mpc_runner/runner.rs
+++ b/crates/stoffel-vm/src/net/mpc_runner/runner.rs
@@ -355,6 +355,16 @@ where
         })
     }
 
+    /// Rotate the MPC engine to a new instance id and clear per-run VM scratch.
+    pub async fn reset_for_next_run(&self, new_instance_id: u64) -> MpcRunnerResult<()> {
+        self.mpc_engine
+            .reset_for_next_run(new_instance_id)
+            .await
+            .map_mpc_runner_backend_err("reset_for_next_run")?;
+        self.try_with_vm_mut_result(|vm| vm.clear_local_storage())?;
+        Ok(())
+    }
+
     /// Execute multiple VM entry-point invocations concurrently.
     ///
     /// The managed VM is used as a template. Each invocation receives an

--- a/crates/stoffel-vm/src/net/mpc_runner/tests.rs
+++ b/crates/stoffel-vm/src/net/mpc_runner/tests.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use parking_lot::Mutex;
@@ -16,6 +16,7 @@ use crate::net::mpc_engine::{
     AsyncMpcEngine, AsyncMpcEngineClientOps, MpcCapabilities, MpcEngine, MpcEngineResult,
     MpcSessionTopology, MpcSessionTopologyError,
 };
+use crate::storage::RedbLocalStorage;
 use crate::VirtualMachineErrorKind;
 
 use super::guard::RunnerVmGuard;
@@ -81,12 +82,16 @@ impl AsyncMpcEngine for SyncOnlyEngine {
 
 struct AsyncHydratingEngine {
     hydrate_calls: AtomicUsize,
+    reset_calls: AtomicUsize,
+    instance_id: AtomicU64,
 }
 
 impl Default for AsyncHydratingEngine {
     fn default() -> Self {
         Self {
             hydrate_calls: AtomicUsize::new(0),
+            reset_calls: AtomicUsize::new(0),
+            instance_id: AtomicU64::new(8),
         }
     }
 }
@@ -97,7 +102,8 @@ impl MpcEngine for AsyncHydratingEngine {
     }
 
     fn topology(&self) -> MpcSessionTopology {
-        MpcSessionTopology::try_new(8, 2, 3, 1).expect("test topology should be valid")
+        MpcSessionTopology::try_new(self.instance_id.load(Ordering::SeqCst), 2, 3, 1)
+            .expect("test topology should be valid")
     }
 
     fn is_ready(&self) -> bool {
@@ -146,6 +152,12 @@ impl AsyncMpcEngine for AsyncHydratingEngine {
             "async_open_share",
             "not used",
         ))
+    }
+
+    async fn reset_for_next_run(&self, new_instance_id: u64) -> MpcEngineResult<()> {
+        self.reset_calls.fetch_add(1, Ordering::SeqCst);
+        self.instance_id.store(new_instance_id, Ordering::SeqCst);
+        Ok(())
     }
 }
 
@@ -432,4 +444,46 @@ async fn async_execute_function_uses_async_client_input_hydration() {
         .expect("inspect hydrated VM input")
         .expect("client input should be hydrated");
     assert_eq!(hydrated_share.data(), &ShareData::Opaque(vec![9].into()));
+}
+
+#[tokio::test]
+async fn reset_for_next_run_rotates_engine_and_clears_local_storage() {
+    let dir = tempfile::tempdir().expect("temp dir");
+    let path = dir.path().join("local.redb");
+    let storage = RedbLocalStorage::new(&path).expect("open local storage");
+    let mut vm = VirtualMachine::builder()
+        .with_local_storage(storage)
+        .try_build()
+        .expect("build VM");
+    vm.execute_with_args(
+        "LocalStorage.store",
+        &[Value::String("key".to_owned()), Value::I64(7)],
+    )
+    .expect("store local value");
+    assert_eq!(
+        vm.execute_with_args("LocalStorage.exists", &[Value::String("key".to_owned())])
+            .expect("local value exists"),
+        Value::Bool(true)
+    );
+
+    let engine = Arc::new(AsyncHydratingEngine::default());
+    let runner = MpcRunner::with_config(
+        vm,
+        engine.clone(),
+        MpcRunnerConfig {
+            execution_timeout: std::time::Duration::from_secs(1),
+            auto_hydrate: false,
+        },
+    );
+
+    runner.reset_for_next_run(99).await.expect("reset runner");
+
+    assert_eq!(engine.reset_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(runner.instance().id(), 99);
+    let exists = runner
+        .try_with_vm_mut_result(|vm| {
+            vm.execute_with_args("LocalStorage.exists", &[Value::String("key".to_owned())])
+        })
+        .expect("inspect cleared local storage");
+    assert_eq!(exists, Value::Bool(false));
 }

--- a/crates/stoffel-vm/src/net/open_registry/instance.rs
+++ b/crates/stoffel-vm/src/net/open_registry/instance.rs
@@ -59,6 +59,16 @@ impl InstanceRegistry {
         self.instance_id
     }
 
+    #[cfg(all(test, feature = "avss_itest"))]
+    pub(crate) fn protocol_session_counts(&self) -> (usize, usize, usize, usize) {
+        (
+            self.single.lock().len(),
+            self.batch.lock().len(),
+            self.exp.lock().len(),
+            self.exp_g2.lock().len(),
+        )
+    }
+
     fn missing_sequence_error(operation: &str) -> String {
         format!("{operation} registry sequence was not assigned after local insertion")
     }

--- a/crates/stoffel-vm/src/net/reservation.rs
+++ b/crates/stoffel-vm/src/net/reservation.rs
@@ -5,7 +5,7 @@
 //! sequential index allocation via an advancing cursor.
 
 use crate::net::mpc_engine::DurableIdentityDigest;
-use crate::storage::preproc::{PreprocStore, PreprocStoreError};
+use crate::storage::preproc::{PoolAvailability, PreprocStore, PreprocStoreError};
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use tokio::sync::RwLock;
@@ -42,6 +42,10 @@ impl ReservationGrant {
 pub struct RegistryState {
     pub program_hash: [u8; 32],
     pub node_identity: DurableIdentityDigest,
+    #[serde(default)]
+    pub run_id: u64,
+    #[serde(default)]
+    pub preproc_offset: PoolAvailability,
     pub capacity: u64,
     pub next_index: u64,
     pub slots: BTreeMap<u64, SlotStatus>,
@@ -151,6 +155,29 @@ impl ReservationRegistry {
             state: RwLock::new(RegistryState {
                 program_hash,
                 node_identity,
+                run_id: 0,
+                preproc_offset: PoolAvailability::default(),
+                capacity,
+                next_index: 0,
+                slots: BTreeMap::new(),
+                masked_inputs: BTreeMap::new(),
+            }),
+        }
+    }
+
+    pub fn new_for_run(
+        program_hash: [u8; 32],
+        node_identity: DurableIdentityDigest,
+        capacity: u64,
+        run_id: u64,
+        preproc_offset: PoolAvailability,
+    ) -> Self {
+        Self {
+            state: RwLock::new(RegistryState {
+                program_hash,
+                node_identity,
+                run_id,
+                preproc_offset,
                 capacity,
                 next_index: 0,
                 slots: BTreeMap::new(),
@@ -248,6 +275,14 @@ impl ReservationRegistry {
     pub async fn available(&self) -> u64 {
         let s = self.state.read().await;
         s.capacity.saturating_sub(s.next_index)
+    }
+
+    pub async fn run_id(&self) -> u64 {
+        self.state.read().await.run_id
+    }
+
+    pub async fn preproc_offset(&self) -> PoolAvailability {
+        self.state.read().await.preproc_offset
     }
 
     pub async fn all_reserved_slots_consumed(&self) -> bool {
@@ -414,6 +449,8 @@ mod tests {
         let reg = ReservationRegistry::from_state(RegistryState {
             program_hash: [0; 32],
             node_identity: identity(0),
+            run_id: 0,
+            preproc_offset: PoolAvailability::default(),
             capacity: 1,
             next_index: 2,
             slots: BTreeMap::new(),
@@ -432,6 +469,8 @@ mod tests {
         let state = RegistryState {
             program_hash,
             node_identity: identity(0),
+            run_id: 0,
+            preproc_offset: PoolAvailability::default(),
             capacity: 1,
             next_index: 2,
             slots: BTreeMap::new(),
@@ -455,6 +494,8 @@ mod tests {
         let state = RegistryState {
             program_hash: [0; 32],
             node_identity: identity(0),
+            run_id: 0,
+            preproc_offset: PoolAvailability::default(),
             capacity: 1,
             next_index: 0,
             slots: BTreeMap::new(),

--- a/crates/stoffel-vm/src/net/share_algebra/codec.rs
+++ b/crates/stoffel-vm/src/net/share_algebra/codec.rs
@@ -57,9 +57,11 @@ pub(crate) fn preserve_share_data_format_for_curve(
     template: &ShareData,
     result_bytes: Vec<u8>,
 ) -> ShareAlgebraResult<ShareData> {
-    match template {
-        ShareData::Opaque(_) => Ok(ShareData::Opaque(result_bytes.into())),
-        ShareData::Feldman { .. } => {
+    match template.format() {
+        stoffel_vm_types::core_types::ShareDataFormat::Opaque => {
+            Ok(ShareData::Opaque(result_bytes.into()))
+        }
+        stoffel_vm_types::core_types::ShareDataFormat::Feldman => {
             dispatch_share_curve_config!(
                 curve_config,
                 feldman_share_data_from_bytes_typed(result_bytes)

--- a/crates/stoffel-vm/src/net/share_runtime/format.rs
+++ b/crates/stoffel-vm/src/net/share_runtime/format.rs
@@ -6,6 +6,12 @@ pub(crate) fn ensure_matching_share_data_format(
     left: &ShareData,
     right: &ShareData,
 ) -> VmResult<()> {
+    // Public-domain shares have no backend representation until an operation
+    // actually needs bytes. They are compatible with either representation;
+    // the materializer will produce the configured engine's native format.
+    if left.public_input().is_some() || right.public_input().is_some() {
+        return Ok(());
+    }
     let left = left.format();
     let right = right.format();
     if left == right {
@@ -23,18 +29,22 @@ pub(super) fn ensure_homogeneous_share_data_format(
     operation: &'static str,
     shares: &[ShareData],
 ) -> VmResult<()> {
-    let Some((first, rest)) = shares.split_first() else {
+    let mut represented = shares
+        .iter()
+        .enumerate()
+        .filter(|(_, share)| share.public_input().is_none());
+    let Some((_, first)) = represented.next() else {
         return Ok(());
     };
     let expected = first.format();
-    for (offset, share) in rest.iter().enumerate() {
+    for (index, share) in represented {
         let actual = share.format();
         if actual != expected {
             return Err(VmError::ShareDataBatchFormatMismatch {
                 operation,
                 expected: expected.as_str(),
                 actual: actual.as_str(),
-                index: offset + 1,
+                index,
             });
         }
     }

--- a/crates/stoffel-vm/src/net/share_runtime/lifecycle.rs
+++ b/crates/stoffel-vm/src/net/share_runtime/lifecycle.rs
@@ -28,8 +28,26 @@ impl<'engine> MpcShareRuntime<'engine> {
 
     pub(crate) fn input_share(&self, clear: ClearShareInput) -> VmResult<ShareData> {
         self.ensure_ready()?;
-        self.engine
-            .input_share(clear)
-            .map_mpc_backend_err("input_share")
+        Ok(ShareData::public(clear))
+    }
+
+    /// Obtain backend bytes for a public-domain share only when an operation
+    /// cannot remain symbolic. The `OnceLock` on `PublicShare` guarantees stable
+    /// backend identity for repeated observers without eagerly discarding public
+    /// provenance at construction time.
+    pub(crate) fn materialize_public_share(&self, share: &ShareData) -> VmResult<ShareData> {
+        let ShareData::Public(public) = share else {
+            return Ok(share.materialized().unwrap_or(share).clone());
+        };
+        if let Some(materialized) = public.materialized() {
+            return Ok(materialized.clone());
+        }
+        self.ensure_ready()?;
+        let materialized = self
+            .engine
+            .input_share(public.input())
+            .map_mpc_backend_err("input_share")?;
+        let _ = public.set_materialized(materialized.clone());
+        Ok(public.materialized().unwrap_or(&materialized).clone())
     }
 }

--- a/crates/stoffel-vm/src/net/share_runtime/local_ops.rs
+++ b/crates/stoffel-vm/src/net/share_runtime/local_ops.rs
@@ -20,6 +20,28 @@ impl MpcShareRuntime<'_> {
             .map_mpc_backend_err("multiply_share")
     }
 
+    pub(crate) fn batch_multiply_share_data(
+        &self,
+        share_type: ShareType,
+        left_data: &[ShareData],
+        right_data: &[ShareData],
+    ) -> VmResult<Vec<ShareData>> {
+        self.ensure_ready()?;
+        if left_data.len() != right_data.len() {
+            return Err("batch multiplication requires matching input lengths".into());
+        }
+        let mut pairs = Vec::with_capacity(left_data.len());
+        for (left, right) in left_data.iter().zip(right_data) {
+            ensure_matching_share_data_format("batch_multiply_shares", left, right)?;
+            pairs.push((left.as_bytes().to_vec(), right.as_bytes().to_vec()));
+        }
+        self.engine
+            .multiplication_ops()
+            .map_mpc_backend_err("multiplication_ops")?
+            .batch_multiply_shares(share_type, &pairs)
+            .map_mpc_backend_err("batch_multiply_shares")
+    }
+
     pub(crate) fn add_data(
         &self,
         ty: ShareType,

--- a/crates/stoffel-vm/src/net/share_runtime/local_ops.rs
+++ b/crates/stoffel-vm/src/net/share_runtime/local_ops.rs
@@ -2,7 +2,143 @@ use super::format::{ensure_homogeneous_share_data_format, ensure_matching_share_
 use super::MpcShareRuntime;
 use crate::error::{MpcBackendResultExt, VmResult};
 use crate::net::share_algebra;
-use stoffel_vm_types::core_types::{ShareData, ShareType, Value};
+use stoffel_vm_types::core_types::{
+    ClearShareInput, ClearShareValue, DeferredShareOperation, ShareData, ShareType, Value,
+};
+
+#[derive(Clone, Copy)]
+enum PublicBinaryOperation {
+    Add,
+    Sub,
+    Multiply,
+}
+
+fn public_scalar(input: ClearShareInput) -> Option<i64> {
+    match input.value() {
+        ClearShareValue::Integer(value) => Some(value),
+        ClearShareValue::UnsignedInteger(value) => i64::try_from(value).ok(),
+        ClearShareValue::Boolean(value) => Some(i64::from(value)),
+        ClearShareValue::FixedPoint(_) => None,
+    }
+}
+
+fn checked_i64_binary(left: i64, right: i64, operation: PublicBinaryOperation) -> Option<i64> {
+    match operation {
+        PublicBinaryOperation::Add => left.checked_add(right),
+        PublicBinaryOperation::Sub => left.checked_sub(right),
+        PublicBinaryOperation::Multiply => left.checked_mul(right),
+    }
+}
+
+fn checked_u64_binary(left: u64, right: u64, operation: PublicBinaryOperation) -> Option<u64> {
+    match operation {
+        PublicBinaryOperation::Add => left.checked_add(right),
+        PublicBinaryOperation::Sub => left.checked_sub(right),
+        PublicBinaryOperation::Multiply => left.checked_mul(right),
+    }
+}
+
+fn public_bool_result(ty: ShareType, value: i64) -> Option<ShareData> {
+    if ty != ShareType::boolean() {
+        return None;
+    }
+    let value = match value {
+        0 => false,
+        1 => true,
+        _ => return None,
+    };
+    Some(ShareData::public(ClearShareInput::new(
+        ty,
+        ClearShareValue::Boolean(value),
+    )))
+}
+
+fn public_binary_result(
+    ty: ShareType,
+    left: ClearShareInput,
+    right: ClearShareInput,
+    operation: PublicBinaryOperation,
+) -> Option<ShareData> {
+    if left.share_type() != ty || right.share_type() != ty {
+        return None;
+    }
+    match (left.value(), right.value()) {
+        (ClearShareValue::Integer(left), ClearShareValue::Integer(right)) => {
+            if ty == ShareType::boolean() {
+                return None;
+            }
+            let value = checked_i64_binary(left, right, operation)?;
+            Some(ShareData::public(ClearShareInput::new(
+                ty,
+                ClearShareValue::Integer(value),
+            )))
+        }
+        (ClearShareValue::Boolean(left), ClearShareValue::Boolean(right)) => {
+            let value = checked_i64_binary(i64::from(left), i64::from(right), operation)?;
+            public_bool_result(ty, value)
+        }
+        (ClearShareValue::UnsignedInteger(left), ClearShareValue::UnsignedInteger(right)) => {
+            let value = checked_u64_binary(left, right, operation)?;
+            Some(ShareData::public(ClearShareInput::new(
+                ty,
+                ClearShareValue::UnsignedInteger(value),
+            )))
+        }
+        _ => None,
+    }
+}
+
+fn public_unary_scalar_result(
+    ty: ShareType,
+    input: ClearShareInput,
+    scalar: i64,
+    operation: PublicBinaryOperation,
+) -> Option<ShareData> {
+    if input.share_type() != ty {
+        return None;
+    }
+    let value = match input.value() {
+        ClearShareValue::Integer(value) if ty != ShareType::boolean() => {
+            ClearShareValue::Integer(checked_i64_binary(value, scalar, operation)?)
+        }
+        ClearShareValue::UnsignedInteger(value) => {
+            let scalar = u64::try_from(scalar).ok()?;
+            ClearShareValue::UnsignedInteger(checked_u64_binary(value, scalar, operation)?)
+        }
+        ClearShareValue::Boolean(value) => {
+            let result = checked_i64_binary(i64::from(value), scalar, operation)?;
+            return public_bool_result(ty, result);
+        }
+        ClearShareValue::Integer(_) | ClearShareValue::FixedPoint(_) => return None,
+    };
+    Some(ShareData::public(ClearShareInput::new(ty, value)))
+}
+
+fn public_scalar_left_result(
+    ty: ShareType,
+    scalar: i64,
+    input: ClearShareInput,
+    operation: PublicBinaryOperation,
+) -> Option<ShareData> {
+    if input.share_type() != ty {
+        return None;
+    }
+    let value = match input.value() {
+        ClearShareValue::Integer(value) if ty != ShareType::boolean() => {
+            ClearShareValue::Integer(checked_i64_binary(scalar, value, operation)?)
+        }
+        ClearShareValue::UnsignedInteger(value) => {
+            let scalar = u64::try_from(scalar).ok()?;
+            ClearShareValue::UnsignedInteger(checked_u64_binary(scalar, value, operation)?)
+        }
+        ClearShareValue::Boolean(value) => {
+            let result = checked_i64_binary(scalar, i64::from(value), operation)?;
+            return public_bool_result(ty, result);
+        }
+        ClearShareValue::Integer(_) | ClearShareValue::FixedPoint(_) => return None,
+    };
+    Some(ShareData::public(ClearShareInput::new(ty, value)))
+}
 
 impl MpcShareRuntime<'_> {
     pub(crate) fn multiply_share_data(
@@ -12,11 +148,39 @@ impl MpcShareRuntime<'_> {
         right_data: &ShareData,
     ) -> VmResult<ShareData> {
         self.ensure_ready()?;
-        ensure_matching_share_data_format("multiply_share", left_data, right_data)?;
+        if let (Some(left), Some(right)) = (left_data.public_input(), right_data.public_input()) {
+            if let Some(result) =
+                public_binary_result(share_type, left, right, PublicBinaryOperation::Multiply)
+            {
+                return Ok(result);
+            }
+        }
+        if let Some(left) = left_data.public_input().and_then(public_scalar) {
+            return self.mul_scalar_data(share_type, right_data, left);
+        }
+        if let Some(right) = right_data.public_input().and_then(public_scalar) {
+            return self.mul_scalar_data(share_type, left_data, right);
+        }
+        let left_materialized = self.materialize_public_share(left_data)?;
+        let right_materialized = self.materialize_public_share(right_data)?;
+        ensure_matching_share_data_format(
+            "multiply_share",
+            &left_materialized,
+            &right_materialized,
+        )?;
+        if left_materialized.is_deferred() || right_materialized.is_deferred() {
+            return Err(
+                "synchronous share multiplication cannot consume unresolved deferred shares".into(),
+            );
+        }
         self.engine
             .multiplication_ops()
             .map_mpc_backend_err("multiplication_ops")?
-            .multiply_share(share_type, left_data.as_bytes(), right_data.as_bytes())
+            .multiply_share(
+                share_type,
+                left_materialized.as_bytes(),
+                right_materialized.as_bytes(),
+            )
             .map_mpc_backend_err("multiply_share")
     }
 
@@ -30,16 +194,73 @@ impl MpcShareRuntime<'_> {
         if left_data.len() != right_data.len() {
             return Err("batch multiplication requires matching input lengths".into());
         }
-        let mut pairs = Vec::with_capacity(left_data.len());
-        for (left, right) in left_data.iter().zip(right_data) {
-            ensure_matching_share_data_format("batch_multiply_shares", left, right)?;
+        let mut output = vec![None; left_data.len()];
+        let mut interactive_indices = Vec::new();
+        let mut pairs = Vec::new();
+        for (index, (left, right)) in left_data.iter().zip(right_data).enumerate() {
+            if let (Some(left_public), Some(right_public)) =
+                (left.public_input(), right.public_input())
+            {
+                if let Some(result) = public_binary_result(
+                    share_type,
+                    left_public,
+                    right_public,
+                    PublicBinaryOperation::Multiply,
+                ) {
+                    output[index] = Some(result);
+                    continue;
+                }
+            }
+            if let Some(scalar) = left.public_input().and_then(public_scalar) {
+                output[index] = Some(self.mul_scalar_data(share_type, right, scalar)?);
+                continue;
+            }
+            if let Some(scalar) = right.public_input().and_then(public_scalar) {
+                output[index] = Some(self.mul_scalar_data(share_type, left, scalar)?);
+                continue;
+            }
+
+            let left = self.materialize_public_share(left)?;
+            let right = self.materialize_public_share(right)?;
+            if left.is_deferred() || right.is_deferred() {
+                return Err(
+                    "synchronous batch multiplication cannot consume unresolved deferred shares"
+                        .into(),
+                );
+            }
+            ensure_matching_share_data_format("batch_multiply_shares", &left, &right)?;
+            interactive_indices.push(index);
             pairs.push((left.as_bytes().to_vec(), right.as_bytes().to_vec()));
         }
-        self.engine
-            .multiplication_ops()
-            .map_mpc_backend_err("multiplication_ops")?
-            .batch_multiply_shares(share_type, &pairs)
-            .map_mpc_backend_err("batch_multiply_shares")
+        let products = if pairs.is_empty() {
+            Vec::new()
+        } else {
+            self.engine
+                .multiplication_ops()
+                .map_mpc_backend_err("multiplication_ops")?
+                .batch_multiply_shares(share_type, &pairs)
+                .map_mpc_backend_err("batch_multiply_shares")?
+        };
+        if products.len() != interactive_indices.len() {
+            return Err(format!(
+                "MPC backend returned {} products for a batch of {}",
+                products.len(),
+                interactive_indices.len()
+            )
+            .into());
+        }
+        for (index, product) in interactive_indices.into_iter().zip(products) {
+            output[index] = Some(product);
+        }
+        output
+            .into_iter()
+            .enumerate()
+            .map(|(index, product)| {
+                product.ok_or_else(|| {
+                    format!("batch multiplication did not produce lane {index}").into()
+                })
+            })
+            .collect()
     }
 
     pub(crate) fn add_data(
@@ -48,12 +269,36 @@ impl MpcShareRuntime<'_> {
         lhs_data: &ShareData,
         rhs_data: &ShareData,
     ) -> VmResult<ShareData> {
-        ensure_matching_share_data_format("add_share_local", lhs_data, rhs_data)?;
+        if let (Some(left), Some(right)) = (lhs_data.public_input(), rhs_data.public_input()) {
+            if let Some(result) = public_binary_result(ty, left, right, PublicBinaryOperation::Add)
+            {
+                return Ok(result);
+            }
+        }
+        if let Some(left) = lhs_data.public_input().and_then(public_scalar) {
+            return self.add_scalar_data(ty, rhs_data, left);
+        }
+        if let Some(right) = rhs_data.public_input().and_then(public_scalar) {
+            return self.add_scalar_data(ty, lhs_data, right);
+        }
+        let lhs_data = self.materialize_public_share(lhs_data)?;
+        let rhs_data = self.materialize_public_share(rhs_data)?;
+        ensure_matching_share_data_format("add_share_local", &lhs_data, &rhs_data)?;
+        if lhs_data.is_deferred() || rhs_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                lhs_data.format(),
+                DeferredShareOperation::Add {
+                    left: lhs_data.clone(),
+                    right: rhs_data.clone(),
+                },
+            ));
+        }
         let result = self
             .engine
             .add_share_local(ty, lhs_data.as_bytes(), rhs_data.as_bytes())
             .map_mpc_backend_err("add_share_local")?;
-        self.preserve_share_data_format(lhs_data, result)
+        self.preserve_share_data_format(&lhs_data, result)
     }
 
     pub(crate) fn sub_data(
@@ -62,20 +307,61 @@ impl MpcShareRuntime<'_> {
         lhs_data: &ShareData,
         rhs_data: &ShareData,
     ) -> VmResult<ShareData> {
-        ensure_matching_share_data_format("sub_share_local", lhs_data, rhs_data)?;
+        if let (Some(left), Some(right)) = (lhs_data.public_input(), rhs_data.public_input()) {
+            if let Some(result) = public_binary_result(ty, left, right, PublicBinaryOperation::Sub)
+            {
+                return Ok(result);
+            }
+        }
+        if let Some(right) = rhs_data.public_input().and_then(public_scalar) {
+            return self.sub_scalar_data(ty, lhs_data, right);
+        }
+        if let Some(left) = lhs_data.public_input().and_then(public_scalar) {
+            return self.scalar_sub_data(ty, left, rhs_data);
+        }
+        let lhs_data = self.materialize_public_share(lhs_data)?;
+        let rhs_data = self.materialize_public_share(rhs_data)?;
+        ensure_matching_share_data_format("sub_share_local", &lhs_data, &rhs_data)?;
+        if lhs_data.is_deferred() || rhs_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                lhs_data.format(),
+                DeferredShareOperation::Sub {
+                    left: lhs_data.clone(),
+                    right: rhs_data.clone(),
+                },
+            ));
+        }
         let result = self
             .engine
             .sub_share_local(ty, lhs_data.as_bytes(), rhs_data.as_bytes())
             .map_mpc_backend_err("sub_share_local")?;
-        self.preserve_share_data_format(lhs_data, result)
+        self.preserve_share_data_format(&lhs_data, result)
     }
 
     pub(crate) fn neg_data(&self, ty: ShareType, share_data: &ShareData) -> VmResult<ShareData> {
+        if let Some(input) = share_data.public_input() {
+            if let Some(result) =
+                public_unary_scalar_result(ty, input, -1, PublicBinaryOperation::Multiply)
+            {
+                return Ok(result);
+            }
+        }
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::Neg {
+                    share: share_data.clone(),
+                },
+            ));
+        }
         let result = self
             .engine
             .neg_share_local(ty, share_data.as_bytes())
             .map_mpc_backend_err("neg_share_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn add_scalar_data(
@@ -84,11 +370,29 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         scalar: i64,
     ) -> VmResult<ShareData> {
+        if let Some(input) = share_data.public_input() {
+            if let Some(result) =
+                public_unary_scalar_result(ty, input, scalar, PublicBinaryOperation::Add)
+            {
+                return Ok(result);
+            }
+        }
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::AddScalar {
+                    share: share_data.clone(),
+                    scalar,
+                },
+            ));
+        }
         let result = self
             .engine
             .add_share_scalar_local(ty, share_data.as_bytes(), scalar)
             .map_mpc_backend_err("add_share_scalar_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn sub_scalar_data(
@@ -97,11 +401,29 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         scalar: i64,
     ) -> VmResult<ShareData> {
+        if let Some(input) = share_data.public_input() {
+            if let Some(result) =
+                public_unary_scalar_result(ty, input, scalar, PublicBinaryOperation::Sub)
+            {
+                return Ok(result);
+            }
+        }
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::SubScalar {
+                    share: share_data.clone(),
+                    scalar,
+                },
+            ));
+        }
         let result = self
             .engine
             .sub_share_scalar_local(ty, share_data.as_bytes(), scalar)
             .map_mpc_backend_err("sub_share_scalar_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn scalar_sub_data(
@@ -110,11 +432,29 @@ impl MpcShareRuntime<'_> {
         scalar: i64,
         share_data: &ShareData,
     ) -> VmResult<ShareData> {
+        if let Some(input) = share_data.public_input() {
+            if let Some(result) =
+                public_scalar_left_result(ty, scalar, input, PublicBinaryOperation::Sub)
+            {
+                return Ok(result);
+            }
+        }
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::ScalarSub {
+                    scalar,
+                    share: share_data.clone(),
+                },
+            ));
+        }
         let result = self
             .engine
             .scalar_sub_share_local(ty, scalar, share_data.as_bytes())
             .map_mpc_backend_err("scalar_sub_share_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn div_scalar_data(
@@ -123,11 +463,22 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         scalar: i64,
     ) -> VmResult<ShareData> {
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::DivScalar {
+                    share: share_data.clone(),
+                    scalar,
+                },
+            ));
+        }
         let result = self
             .engine
             .div_share_scalar_local(ty, share_data.as_bytes(), scalar)
             .map_mpc_backend_err("div_share_scalar_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     /// Divide a secret fixed-point share by a public positive constant using the
@@ -141,6 +492,10 @@ impl MpcShareRuntime<'_> {
         divisor_scaled: i64,
     ) -> VmResult<ShareData> {
         self.ensure_ready()?;
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Err("fixed-point division cannot consume an unresolved deferred share".into());
+        }
         self.engine
             .multiplication_ops()
             .map_mpc_backend_err("multiplication_ops")?
@@ -154,11 +509,29 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         scalar: i64,
     ) -> VmResult<ShareData> {
+        if let Some(input) = share_data.public_input() {
+            if let Some(result) =
+                public_unary_scalar_result(ty, input, scalar, PublicBinaryOperation::Multiply)
+            {
+                return Ok(result);
+            }
+        }
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::MulScalar {
+                    share: share_data.clone(),
+                    scalar,
+                },
+            ));
+        }
         let result = self
             .engine
             .mul_share_scalar_local(ty, share_data.as_bytes(), scalar)
             .map_mpc_backend_err("mul_share_scalar_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn mul_field_data(
@@ -167,11 +540,22 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         scalar_bytes: &[u8],
     ) -> VmResult<ShareData> {
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::MulField {
+                    share: share_data.clone(),
+                    scalar: scalar_bytes.into(),
+                },
+            ));
+        }
         let result = self
             .engine
             .mul_share_field_local(ty, share_data.as_bytes(), scalar_bytes)
             .map_mpc_backend_err("mul_share_field_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     pub(crate) fn add_field_data(
@@ -180,11 +564,22 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
         field_bytes: &[u8],
     ) -> VmResult<ShareData> {
+        let share_data = self.materialize_public_share(share_data)?;
+        if share_data.is_deferred() {
+            return Ok(ShareData::deferred(
+                ty,
+                share_data.format(),
+                DeferredShareOperation::AddField {
+                    share: share_data.clone(),
+                    field: field_bytes.into(),
+                },
+            ));
+        }
         let result = self
             .engine
             .add_share_field_local(ty, share_data.as_bytes(), field_bytes)
             .map_mpc_backend_err("add_share_field_local")?;
-        self.preserve_share_data_format(share_data, result)
+        self.preserve_share_data_format(&share_data, result)
     }
 
     #[cfg(test)]
@@ -241,7 +636,14 @@ impl MpcShareRuntime<'_> {
         shares: &[ShareData],
     ) -> VmResult<Value> {
         self.ensure_ready()?;
-        ensure_homogeneous_share_data_format("interpolate_shares_local", shares)?;
+        let shares = shares
+            .iter()
+            .map(|share| self.materialize_public_share(share))
+            .collect::<VmResult<Vec<_>>>()?;
+        ensure_homogeneous_share_data_format("interpolate_shares_local", &shares)?;
+        if shares.iter().any(ShareData::is_deferred) {
+            return Err("local interpolation cannot consume unresolved deferred shares".into());
+        }
         let share_bytes: Vec<Vec<u8>> = shares
             .iter()
             .map(|share_data| share_data.as_bytes().to_vec())

--- a/crates/stoffel-vm/src/net/share_runtime/openings.rs
+++ b/crates/stoffel-vm/src/net/share_runtime/openings.rs
@@ -25,6 +25,15 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
     ) -> VmResult<ClearShareValue> {
         self.ensure_ready()?;
+        if let Some(public) = share_data.public_input() {
+            if public.share_type() != ty {
+                return Err(VmError::Message(format!(
+                    "public share type mismatch: expected {ty:?}, got {:?}",
+                    public.share_type()
+                )));
+            }
+            return Ok(public.value());
+        }
         self.engine
             .open_share(ty, share_data.as_bytes())
             .map_mpc_backend_err("open_share")
@@ -37,13 +46,48 @@ impl MpcShareRuntime<'_> {
     ) -> VmResult<Vec<ClearShareValue>> {
         self.ensure_ready()?;
         ensure_homogeneous_share_data_format("batch_open_shares", shares)?;
-        let share_bytes: Vec<Vec<u8>> = shares
-            .iter()
-            .map(|share_data| share_data.as_bytes().to_vec())
-            .collect();
-        self.engine
-            .batch_open_shares(ty, &share_bytes)
-            .map_mpc_backend_err("batch_open_shares")
+        let mut output = vec![None; shares.len()];
+        let mut secret_indices = Vec::new();
+        let mut share_bytes = Vec::new();
+        for (index, share) in shares.iter().enumerate() {
+            if let Some(public) = share.public_input() {
+                if public.share_type() != ty {
+                    return Err(VmError::Message(format!(
+                        "public share type mismatch in batch lane {index}: expected {ty:?}, got {:?}",
+                        public.share_type()
+                    )));
+                }
+                output[index] = Some(public.value());
+            } else {
+                secret_indices.push(index);
+                share_bytes.push(share.as_bytes().to_vec());
+            }
+        }
+        if !share_bytes.is_empty() {
+            let values = self
+                .engine
+                .batch_open_shares(ty, &share_bytes)
+                .map_mpc_backend_err("batch_open_shares")?;
+            if values.len() != secret_indices.len() {
+                return Err(VmError::Message(format!(
+                    "MPC backend returned {} openings for a batch of {}",
+                    values.len(),
+                    secret_indices.len()
+                )));
+            }
+            for (index, value) in secret_indices.into_iter().zip(values) {
+                output[index] = Some(value);
+            }
+        }
+        output
+            .into_iter()
+            .enumerate()
+            .map(|(index, value)| {
+                value.ok_or_else(|| {
+                    VmError::Message(format!("batch opening did not produce lane {index}"))
+                })
+            })
+            .collect()
     }
 
     pub(crate) fn random_share_data(&self, ty: ShareType) -> VmResult<ShareData> {
@@ -70,6 +114,7 @@ impl MpcShareRuntime<'_> {
         share_data: &ShareData,
     ) -> VmResult<Vec<u8>> {
         self.ensure_ready()?;
+        let share_data = self.materialize_public_share(share_data)?;
         self.engine
             .field_open_ops()
             .map_mpc_backend_err("field_open_ops")?
@@ -84,6 +129,7 @@ impl MpcShareRuntime<'_> {
         generator_bytes: &[u8],
     ) -> VmResult<Vec<u8>> {
         self.ensure_ready()?;
+        let share_data = self.materialize_public_share(share_data)?;
         self.engine
             .open_in_exp_ops()
             .map_mpc_backend_err("open_in_exp_ops")?
@@ -99,6 +145,7 @@ impl MpcShareRuntime<'_> {
         generator_bytes: &[u8],
     ) -> VmResult<Vec<u8>> {
         self.ensure_ready()?;
+        let share_data = self.materialize_public_share(share_data)?;
         self.engine
             .open_in_exp_ops()
             .map_mpc_backend_err("open_in_exp_ops")?

--- a/crates/stoffel-vm/src/storage/local.rs
+++ b/crates/stoffel-vm/src/storage/local.rs
@@ -66,6 +66,9 @@ pub trait LocalStorage: Send + Sync {
 
     /// Checks if a key exists.
     fn exists(&self, key: &[u8]) -> LocalStorageResult<bool>;
+
+    /// Removes all data from this storage namespace.
+    fn clear(&mut self) -> LocalStorageResult<()>;
 }
 
 /// Value-oriented extension methods for [`LocalStorage`] implementations.
@@ -250,6 +253,37 @@ impl LocalStorage for RedbLocalStorage {
     fn exists(&self, key: &[u8]) -> LocalStorageResult<bool> {
         self.retrieve(key).map(|opt| opt.is_some())
     }
+
+    fn clear(&mut self) -> LocalStorageResult<()> {
+        let write_txn = self
+            .db
+            .begin_write()
+            .map_err(|error| LocalStorageError::Transaction {
+                operation: "begin clear",
+                reason: error.to_string(),
+            })?;
+        write_txn
+            .delete_table(DATA_TABLE)
+            .map_err(|error| LocalStorageError::Table {
+                operation: "delete data table",
+                reason: error.to_string(),
+            })?;
+        {
+            let _ = write_txn
+                .open_table(DATA_TABLE)
+                .map_err(|error| LocalStorageError::Table {
+                    operation: "recreate data table",
+                    reason: error.to_string(),
+                })?;
+        }
+        write_txn
+            .commit()
+            .map_err(|error| LocalStorageError::Transaction {
+                operation: "commit clear",
+                reason: error.to_string(),
+            })?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -306,6 +340,25 @@ mod tests {
             storage.retrieve(b"key").expect("retrieve"),
             Some(b"value".to_vec())
         );
+    }
+
+    #[test]
+    fn redb_storage_clear_removes_all_entries() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let path = dir.path().join("local.redb");
+        let mut storage = RedbLocalStorage::new(&path).expect("open storage");
+
+        storage.store(b"a", b"1").expect("store a");
+        storage.store(b"b", b"2").expect("store b");
+        storage.clear().expect("clear storage");
+
+        assert_eq!(storage.retrieve(b"a").expect("retrieve a"), None);
+        assert_eq!(storage.retrieve(b"b").expect("retrieve b"), None);
+
+        drop(storage);
+        let storage = RedbLocalStorage::new(&path).expect("reopen storage");
+        assert_eq!(storage.retrieve(b"a").expect("retrieve a"), None);
+        assert_eq!(storage.retrieve(b"b").expect("retrieve b"), None);
     }
 
     #[test]

--- a/crates/stoffel-vm/src/storage/preproc.rs
+++ b/crates/stoffel-vm/src/storage/preproc.rs
@@ -35,6 +35,12 @@ pub enum PreprocStoreError {
     Insufficient { need: u32, available: u32 },
     #[error("preprocessing cursor mismatch: expected consumed {expected}, actual {actual}")]
     CursorMismatch { expected: u32, actual: u32 },
+    #[error("preprocessing item size mismatch: expected {expected}, actual {actual}")]
+    ItemSizeMismatch { expected: u32, actual: u32 },
+    #[error("partial preprocessing item write: data length {data_len} is not divisible by item size {item_size}")]
+    PartialItem { data_len: usize, item_size: u32 },
+    #[error("preprocessing store() is forbidden in standing deployment mode")]
+    StoreForbiddenInStandingMode,
     #[error("{field} value {value} exceeds u32::MAX")]
     U32Overflow { field: &'static str, value: u64 },
     #[error("task join: {0}")]
@@ -244,6 +250,22 @@ pub struct PreprocBlob {
     pub data: Vec<u8>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoolAvailability {
+    pub beaver: u32,
+    pub random: u32,
+    pub prand_bit: u32,
+    pub prand_int: u32,
+}
+
+pub type PreprocTargets = PoolAvailability;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TopUpReport {
+    pub generated: PoolAvailability,
+    pub skipped: bool,
+}
+
 impl PreprocBlob {
     pub fn new(data: Vec<u8>, item_size: u32, count: u32) -> Self {
         Self {
@@ -352,6 +374,14 @@ fn has_nonzero_item_size(
 pub trait PreprocStore: Send + Sync + 'static {
     async fn store(&self, key: &PreprocKey, blob: &PreprocBlob) -> Result<(), PreprocStoreError>;
     async fn load(&self, key: &PreprocKey) -> Result<Option<PreprocBlob>, PreprocStoreError>;
+    async fn meta(&self, key: &PreprocKey) -> Result<Option<PreprocMeta>, PreprocStoreError>;
+    async fn append_items(
+        &self,
+        key: &PreprocKey,
+        item_size: u32,
+        added: u32,
+        data: &[u8],
+    ) -> Result<u32, PreprocStoreError>;
 
     /// Atomically advance the consumed cursor. Returns new consumed count.
     async fn reserve(&self, key: &PreprocKey, n: u32) -> Result<u32, PreprocStoreError>;
@@ -367,8 +397,14 @@ pub trait PreprocStore: Send + Sync + 'static {
 
     /// Items available (count - consumed). Returns 0 if not stored.
     async fn available(&self, key: &PreprocKey) -> Result<u32, PreprocStoreError>;
+    async fn scope_availability(
+        &self,
+        scope: &PreprocKeyScope,
+    ) -> Result<PoolAvailability, PreprocStoreError>;
     async fn exists(&self, key: &PreprocKey) -> Result<bool, PreprocStoreError>;
     async fn delete(&self, key: &PreprocKey) -> Result<(), PreprocStoreError>;
+    async fn compact(&self, key: &PreprocKey) -> Result<(), PreprocStoreError>;
+    async fn atomic_increment(&self, ns: &[u8], key: &[u8]) -> Result<u64, PreprocStoreError>;
 
     /// Store an opaque byte blob under a namespaced key (for reservations etc.).
     async fn store_blob(&self, ns: &[u8], key: &[u8], data: &[u8])
@@ -400,6 +436,23 @@ enum DbRequest {
         expected_consumed: Option<u32>,
         n: u32,
         reply: tokio::sync::oneshot::Sender<Result<u32, PreprocStoreError>>,
+    },
+    Append {
+        meta_key: Vec<u8>,
+        data_key: Vec<u8>,
+        item_size: u32,
+        added: u32,
+        data: Vec<u8>,
+        reply: tokio::sync::oneshot::Sender<Result<u32, PreprocStoreError>>,
+    },
+    Compact {
+        meta_key: Vec<u8>,
+        data_key: Vec<u8>,
+        reply: tokio::sync::oneshot::Sender<Result<(), PreprocStoreError>>,
+    },
+    AtomicIncrement {
+        key: Vec<u8>,
+        reply: tokio::sync::oneshot::Sender<Result<u64, PreprocStoreError>>,
     },
 }
 
@@ -527,6 +580,155 @@ impl LmdbPreprocStore {
                     })();
                     let _ = reply.send(r);
                 }
+                DbRequest::Append {
+                    meta_key,
+                    data_key,
+                    item_size,
+                    added,
+                    data,
+                    reply,
+                } => {
+                    let r = (|| {
+                        let item_size_usize =
+                            u32_to_usize(item_size, "append preprocessing item size")?;
+                        if item_size_usize == 0 && (!data.is_empty() || added > 0) {
+                            return Err(PreprocStoreError::PartialItem {
+                                data_len: data.len(),
+                                item_size,
+                            });
+                        }
+                        if item_size_usize != 0 && data.len() % item_size_usize != 0 {
+                            return Err(PreprocStoreError::PartialItem {
+                                data_len: data.len(),
+                                item_size,
+                            });
+                        }
+                        let expected_len = u32_to_usize(added, "append preprocessing count")?
+                            .checked_mul(item_size_usize)
+                            .ok_or_else(|| {
+                                PreprocStoreError::Serialization(format!(
+                                    "append data length overflows usize: added={added}, item_size={item_size}"
+                                ))
+                            })?;
+                        if data.len() != expected_len {
+                            return Err(PreprocStoreError::Serialization(format!(
+                                "append data length {} does not match added*item_size {}",
+                                data.len(),
+                                expected_len
+                            )));
+                        }
+
+                        let mut wtxn = env.write_txn()?;
+                        let mut meta = match db.get(&wtxn, &meta_key)? {
+                            Some(raw) => {
+                                let meta: PreprocMeta = bincode::deserialize(raw)?;
+                                if meta.item_size != item_size {
+                                    return Err(PreprocStoreError::ItemSizeMismatch {
+                                        expected: meta.item_size,
+                                        actual: item_size,
+                                    });
+                                }
+                                meta
+                            }
+                            None => PreprocMeta {
+                                count: 0,
+                                consumed: 0,
+                                item_size,
+                            },
+                        };
+                        let mut blob = db
+                            .get(&wtxn, &data_key)?
+                            .map(|raw| raw.to_vec())
+                            .unwrap_or_default();
+                        blob.extend_from_slice(&data);
+                        meta.count = meta.count.checked_add(added).ok_or(
+                            PreprocStoreError::U32Overflow {
+                                field: "preprocessing item count",
+                                value: u64::from(meta.count) + u64::from(added),
+                            },
+                        )?;
+                        let meta_v = bincode::serialize(&meta)?;
+                        db.put(&mut wtxn, &data_key, &blob)?;
+                        db.put(&mut wtxn, &meta_key, &meta_v)?;
+                        wtxn.commit()?;
+                        Ok(meta.count)
+                    })();
+                    let _ = reply.send(r);
+                }
+                DbRequest::Compact {
+                    meta_key,
+                    data_key,
+                    reply,
+                } => {
+                    let r = (|| {
+                        let mut wtxn = env.write_txn()?;
+                        let raw = match db.get(&wtxn, &meta_key)? {
+                            Some(raw) => raw,
+                            None => {
+                                wtxn.commit()?;
+                                return Ok(());
+                            }
+                        };
+                        let mut meta: PreprocMeta = bincode::deserialize(raw)?;
+                        if meta.consumed == 0 {
+                            wtxn.commit()?;
+                            return Ok(());
+                        }
+                        let data = db
+                            .get(&wtxn, &data_key)?
+                            .ok_or(PreprocStoreError::NotFound)?;
+                        let offset = byte_offset(
+                            meta.consumed,
+                            meta.item_size,
+                            "compact preprocessing consumed offset",
+                        )?;
+                        if offset > data.len() {
+                            return Err(PreprocStoreError::Deserialization(format!(
+                                "compact offset {offset} exceeds data len {}",
+                                data.len()
+                            )));
+                        }
+                        let compacted = data[offset..].to_vec();
+                        meta.count = meta.count.saturating_sub(meta.consumed);
+                        meta.consumed = 0;
+                        let meta_v = bincode::serialize(&meta)?;
+                        db.put(&mut wtxn, &data_key, &compacted)?;
+                        db.put(&mut wtxn, &meta_key, &meta_v)?;
+                        wtxn.commit()?;
+                        Ok(())
+                    })();
+                    let _ = reply.send(r);
+                }
+                DbRequest::AtomicIncrement { key, reply } => {
+                    let r = (|| {
+                        let mut wtxn = env.write_txn()?;
+                        let current = match db.get(&wtxn, &key)? {
+                            Some(raw) => {
+                                if raw.len() != 8 {
+                                    return Err(PreprocStoreError::Deserialization(format!(
+                                        "atomic increment value has {} bytes, expected 8",
+                                        raw.len()
+                                    )));
+                                }
+                                u64::from_le_bytes(raw.try_into().map_err(|_| {
+                                    PreprocStoreError::Deserialization(
+                                        "bad atomic increment bytes".into(),
+                                    )
+                                })?)
+                            }
+                            None => 0,
+                        };
+                        let next = current.checked_add(1).ok_or_else(|| {
+                            PreprocStoreError::Serialization(
+                                "atomic increment overflowed u64".to_owned(),
+                            )
+                        })?;
+                        db.put(&mut wtxn, &key, &next.to_le_bytes())?;
+                        wtxn.commit()?;
+                        Ok(next)
+                    })();
+                    let _ = reply.send(r);
+                }
             }
         }
     }
@@ -591,6 +793,58 @@ impl LmdbPreprocStore {
             .await
             .map_err(|_| PreprocStoreError::Lmdb("actor reply dropped".into()))?
     }
+
+    async fn append_keys(
+        &self,
+        meta_key: Vec<u8>,
+        data_key: Vec<u8>,
+        item_size: u32,
+        added: u32,
+        data: Vec<u8>,
+    ) -> Result<u32, PreprocStoreError> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        self.send(DbRequest::Append {
+            meta_key,
+            data_key,
+            item_size,
+            added,
+            data,
+            reply: reply_tx,
+        })
+        .await?;
+        reply_rx
+            .await
+            .map_err(|_| PreprocStoreError::Lmdb("actor reply dropped".into()))?
+    }
+
+    async fn compact_keys(
+        &self,
+        meta_key: Vec<u8>,
+        data_key: Vec<u8>,
+    ) -> Result<(), PreprocStoreError> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        self.send(DbRequest::Compact {
+            meta_key,
+            data_key,
+            reply: reply_tx,
+        })
+        .await?;
+        reply_rx
+            .await
+            .map_err(|_| PreprocStoreError::Lmdb("actor reply dropped".into()))?
+    }
+
+    async fn atomic_increment_key(&self, key: Vec<u8>) -> Result<u64, PreprocStoreError> {
+        let (reply_tx, reply_rx) = tokio::sync::oneshot::channel();
+        self.send(DbRequest::AtomicIncrement {
+            key,
+            reply: reply_tx,
+        })
+        .await?;
+        reply_rx
+            .await
+            .map_err(|_| PreprocStoreError::Lmdb("actor reply dropped".into()))?
+    }
 }
 
 #[async_trait::async_trait]
@@ -617,6 +871,30 @@ impl PreprocStore for LmdbPreprocStore {
         Ok(Some(PreprocBlob { meta, data }))
     }
 
+    async fn meta(&self, key: &PreprocKey) -> Result<Option<PreprocMeta>, PreprocStoreError> {
+        self.get(key.meta_key()?)
+            .await?
+            .map(|raw| bincode::deserialize(&raw).map_err(PreprocStoreError::from))
+            .transpose()
+    }
+
+    async fn append_items(
+        &self,
+        key: &PreprocKey,
+        item_size: u32,
+        added: u32,
+        data: &[u8],
+    ) -> Result<u32, PreprocStoreError> {
+        self.append_keys(
+            key.meta_key()?,
+            key.encode()?,
+            item_size,
+            added,
+            data.to_vec(),
+        )
+        .await
+    }
+
     async fn reserve(&self, key: &PreprocKey, n: u32) -> Result<u32, PreprocStoreError> {
         self.reserve_keys(key.meta_key()?, None, n).await
     }
@@ -632,13 +910,29 @@ impl PreprocStore for LmdbPreprocStore {
     }
 
     async fn available(&self, key: &PreprocKey) -> Result<u32, PreprocStoreError> {
-        match self.get(key.meta_key()?).await? {
-            Some(raw) => {
-                let meta: PreprocMeta = bincode::deserialize(&raw)?;
-                Ok(meta.available())
-            }
-            None => Ok(0),
-        }
+        Ok(self.meta(key).await?.map_or(0, |meta| meta.available()))
+    }
+
+    async fn scope_availability(
+        &self,
+        scope: &PreprocKeyScope,
+    ) -> Result<PoolAvailability, PreprocStoreError> {
+        let beaver_key = scope.beaver_triple();
+        let random_key = scope.random_share();
+        let prand_bit_key = scope.prand_bit();
+        let prand_int_key = scope.prand_int();
+        let (beaver, random, prand_bit, prand_int) = tokio::try_join!(
+            self.available(&beaver_key),
+            self.available(&random_key),
+            self.available(&prand_bit_key),
+            self.available(&prand_int_key),
+        )?;
+        Ok(PoolAvailability {
+            beaver,
+            random,
+            prand_bit,
+            prand_int,
+        })
     }
 
     async fn exists(&self, key: &PreprocKey) -> Result<bool, PreprocStoreError> {
@@ -647,6 +941,16 @@ impl PreprocStore for LmdbPreprocStore {
 
     async fn delete(&self, key: &PreprocKey) -> Result<(), PreprocStoreError> {
         self.delete_keys(vec![key.meta_key()?, key.encode()?]).await
+    }
+
+    async fn compact(&self, key: &PreprocKey) -> Result<(), PreprocStoreError> {
+        self.compact_keys(key.meta_key()?, key.encode()?).await
+    }
+
+    async fn atomic_increment(&self, ns: &[u8], key: &[u8]) -> Result<u64, PreprocStoreError> {
+        let mut full_key = ns.to_vec();
+        full_key.extend_from_slice(key);
+        self.atomic_increment_key(full_key).await
     }
 
     async fn store_blob(
@@ -683,8 +987,29 @@ fn write_robust_share<F: FftField>(
     Ok(())
 }
 
-fn robust_share_size<F: FftField>() -> usize {
+pub fn robust_share_size<F: FftField>() -> usize {
     F::default().serialized_size(Compress::Yes) + 16
+}
+
+pub fn robust_share_item_size<F: FftField>() -> Result<u32, PreprocStoreError> {
+    usize_to_u32(robust_share_size::<F>(), "robust share item size")
+}
+
+pub fn beaver_triple_size<F: FftField>() -> Result<u32, PreprocStoreError> {
+    let share_size = robust_share_size::<F>();
+    let triple_size = share_size.checked_mul(3).ok_or_else(|| {
+        PreprocStoreError::Serialization(format!(
+            "beaver triple item size overflows usize: share_size={share_size}"
+        ))
+    })?;
+    usize_to_u32(triple_size, "beaver triple item size")
+}
+
+pub fn prandbit_share_size<F: FftField>() -> Result<u32, PreprocStoreError> {
+    let item_size = robust_share_size::<F>()
+        .checked_add(1)
+        .ok_or_else(|| PreprocStoreError::Serialization("prandbit item size overflow".into()))?;
+    usize_to_u32(item_size, "prandbit item size")
 }
 
 fn read_robust_share<F: FftField>(
@@ -770,12 +1095,7 @@ pub fn deserialize_one_robust_share<F: FftField>(
 pub fn serialize_beaver_triples<F: FftField>(
     triples: &[ShamirBeaverTriple<F>],
 ) -> Result<(Vec<u8>, u32), PreprocStoreError> {
-    let share_size = robust_share_size::<F>();
-    let triple_size = share_size.checked_mul(3).ok_or_else(|| {
-        PreprocStoreError::Serialization(format!(
-            "beaver triple item size overflows usize: share_size={share_size}"
-        ))
-    })?;
+    let triple_size = u32_to_usize(beaver_triple_size::<F>()?, "beaver triple item size")?;
     let mut buf = Vec::with_capacity(triples.len() * triple_size);
     for t in triples {
         write_robust_share(&t.a, &mut buf)?;
@@ -811,8 +1131,7 @@ pub fn deserialize_beaver_triples<F: FftField>(
 pub fn serialize_prandbit_shares<F: FftField>(
     shares: &[(RobustShare<F>, Gf256)],
 ) -> Result<(Vec<u8>, u32), PreprocStoreError> {
-    let share_size = robust_share_size::<F>();
-    let item_size = share_size + 1;
+    let item_size = u32_to_usize(prandbit_share_size::<F>()?, "prandbit item size")?;
     let mut buf = Vec::with_capacity(shares.len() * item_size);
     for (s, f) in shares {
         write_robust_share(s, &mut buf)?;
@@ -1238,6 +1557,120 @@ mod tests {
         let consumed = store.reserve_at(&key, 1, 2).await.unwrap();
         assert_eq!(consumed, 3);
         assert_eq!(store.available(&key).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn lmdb_append_preserves_cursor_and_reports_scope_availability() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LmdbPreprocStore::open(dir.path()).unwrap();
+        let scope =
+            PreprocKeyScope::new([0x05; 32], MpcFieldKind::Bn254Fr, 4, 1, legacy_identity(0));
+        let key = scope.random_share();
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(7);
+        let shares_a: Vec<_> = (0..3).map(|_| random_share(&mut rng)).collect();
+        let shares_b: Vec<_> = (0..2).map(|_| random_share(&mut rng)).collect();
+        let (data_a, item_size) = serialize_robust_shares::<Fr>(&shares_a).unwrap();
+        let (data_b, item_size_b) = serialize_robust_shares::<Fr>(&shares_b).unwrap();
+        assert_eq!(item_size, item_size_b);
+
+        assert_eq!(
+            store
+                .append_items(&key, item_size, shares_a.len() as u32, &data_a)
+                .await
+                .unwrap(),
+            3
+        );
+        assert_eq!(store.reserve_at(&key, 0, 2).await.unwrap(), 2);
+        assert_eq!(
+            store
+                .append_items(&key, item_size, shares_b.len() as u32, &data_b)
+                .await
+                .unwrap(),
+            5
+        );
+
+        let meta = store.meta(&key).await.unwrap().unwrap();
+        assert_eq!(meta.count, 5);
+        assert_eq!(meta.consumed, 2);
+        assert_eq!(meta.available(), 3);
+        let availability = store.scope_availability(&scope).await.unwrap();
+        assert_eq!(availability.random, 3);
+        assert_eq!(availability.beaver, 0);
+        assert_eq!(availability.prand_bit, 0);
+        assert_eq!(availability.prand_int, 0);
+    }
+
+    #[tokio::test]
+    async fn lmdb_append_rejects_partial_and_item_size_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LmdbPreprocStore::open(dir.path()).unwrap();
+        let key = PreprocKey::new(
+            [0x06; 32],
+            MpcFieldKind::Bn254Fr,
+            4,
+            1,
+            legacy_identity(0),
+            MaterialKind::RandomShare,
+        );
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(8);
+        let shares: Vec<_> = (0..2).map(|_| random_share(&mut rng)).collect();
+        let (data, item_size) = serialize_robust_shares::<Fr>(&shares).unwrap();
+
+        let err = store
+            .append_items(&key, item_size, 1, &data[..data.len() - 1])
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PreprocStoreError::PartialItem { .. }));
+
+        store.append_items(&key, item_size, 2, &data).await.unwrap();
+        let wrong_size_data = vec![0u8; usize::try_from((item_size + 1) * 2).unwrap()];
+        let err = store
+            .append_items(&key, item_size + 1, 2, &wrong_size_data)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, PreprocStoreError::ItemSizeMismatch { .. }));
+    }
+
+    #[tokio::test]
+    async fn lmdb_compact_preserves_alignment() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LmdbPreprocStore::open(dir.path()).unwrap();
+        let key = PreprocKey::new(
+            [0x07; 32],
+            MpcFieldKind::Bn254Fr,
+            4,
+            1,
+            legacy_identity(0),
+            MaterialKind::RandomShare,
+        );
+        let mut rng = ark_std::rand::rngs::StdRng::seed_from_u64(9);
+        let shares: Vec<_> = (0..5).map(|_| random_share(&mut rng)).collect();
+        let (data, item_size) = serialize_robust_shares::<Fr>(&shares).unwrap();
+        store.append_items(&key, item_size, 5, &data).await.unwrap();
+        store.reserve_at(&key, 0, 2).await.unwrap();
+        store.compact(&key).await.unwrap();
+
+        let blob = store.load(&key).await.unwrap().unwrap();
+        assert_eq!(blob.meta.count, 3);
+        assert_eq!(blob.meta.consumed, 0);
+        let decoded = deserialize_robust_shares::<Fr>(&blob.data, blob.meta.item_size, 0).unwrap();
+        assert_eq!(decoded[0].share[0], shares[2].share[0]);
+    }
+
+    #[tokio::test]
+    async fn lmdb_atomic_increment_is_unique() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = LmdbPreprocStore::open(dir.path()).unwrap();
+        let mut values = Vec::new();
+        for _ in 0..8 {
+            values.push(
+                store
+                    .atomic_increment(b"epoch:", b"deployment")
+                    .await
+                    .unwrap(),
+            );
+        }
+        assert_eq!(values, vec![1, 2, 3, 4, 5, 6, 7, 8]);
     }
 
     #[tokio::test]

--- a/crates/stoffel-vm/src/storage/value_codec.rs
+++ b/crates/stoffel-vm/src/storage/value_codec.rs
@@ -360,6 +360,9 @@ impl Encoder<'_> {
     }
 
     fn write_share_envelope(&mut self, share_data: &ShareData) -> PersistentValueResult<()> {
+        let share_data = share_data
+            .materialized()
+            .ok_or_else(|| invalid_data("cannot persist an unresolved deferred MPC share"))?;
         let context = self
             .share_context
             .ok_or(PersistentValueError::MissingShareContext)?;
@@ -378,6 +381,9 @@ impl Encoder<'_> {
     }
 
     fn write_share_data(&mut self, share_data: &ShareData) -> PersistentValueResult<()> {
+        let share_data = share_data
+            .materialized()
+            .ok_or_else(|| invalid_data("cannot persist an unresolved deferred MPC share"))?;
         match share_data {
             ShareData::Opaque(bytes) => {
                 self.write_u8(SHARE_DATA_OPAQUE);
@@ -390,6 +396,9 @@ impl Encoder<'_> {
                 for commitment in commitments.iter() {
                     self.write_bytes(commitment)?;
                 }
+            }
+            ShareData::Public(_) | ShareData::Deferred(_) => {
+                unreachable!("materialized shares carry backend data")
             }
         }
         Ok(())
@@ -830,6 +839,9 @@ fn digest_bytes(bytes: &[u8]) -> [u8; 32] {
 }
 
 fn share_commitment_digest(share_data: &ShareData) -> PersistentValueResult<Option<[u8; 32]>> {
+    let share_data = share_data
+        .materialized()
+        .ok_or_else(|| invalid_data("cannot inspect an unresolved deferred MPC share"))?;
     match share_data {
         ShareData::Opaque(_) => Ok(None),
         ShareData::Feldman { commitments, .. } => {
@@ -837,6 +849,9 @@ fn share_commitment_digest(share_data: &ShareData) -> PersistentValueResult<Opti
                 .first()
                 .ok_or_else(|| invalid_data("Feldman share is missing commitment[0]"))?;
             Ok(Some(digest_bytes(commitment)))
+        }
+        ShareData::Public(_) | ShareData::Deferred(_) => {
+            unreachable!("materialized shares carry backend data")
         }
     }
 }

--- a/crates/stoffel-vm/src/tests/threshold_signatures.rs
+++ b/crates/stoffel-vm/src/tests/threshold_signatures.rs
@@ -36,8 +36,9 @@ use ark_std::{UniformRand, Zero};
 use sha2::Digest as _;
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use stoffel_vm_types::compiled_binary::{MpcBackend, MpcCurve};
 use stoffel_vm_types::core_types::Value;
 use stoffel_vm_types::functions::VMFunction;
 use stoffel_vm_types::instructions::Instruction;
@@ -52,6 +53,7 @@ use crate::core_vm::VirtualMachine;
 use crate::net::avss_engine::{AvssEngineConfig, AvssMpcEngine};
 use crate::net::curve::SupportedMpcField;
 use crate::net::MpcSessionConfig;
+use crate::runtime_hooks::HookEvent;
 use crate::tests::avss_certificate_programs::{
     build_threshold_ecdsa_program, THRESHOLD_ECDSA_DEMO_MESSAGE_INPUT,
 };
@@ -680,6 +682,185 @@ where
     results
 }
 
+#[derive(Clone, Copy, Default)]
+struct EcdsaStageMarks {
+    random_calls: usize,
+    call_started: Option<Instant>,
+    offline_start: Option<Instant>,
+    offline_end: Option<Instant>,
+    online_end: Option<Instant>,
+    gamma_random: Duration,
+    nonce_random: Duration,
+    batch_mul: Duration,
+    delta_open: Duration,
+    nonce_commitment: Duration,
+    point_x: Duration,
+}
+
+#[derive(Clone, Copy)]
+struct EcdsaStageDurations {
+    offline: Duration,
+    online: Duration,
+    gamma_random: Duration,
+    nonce_random: Duration,
+    batch_mul: Duration,
+    delta_open: Duration,
+    nonce_commitment: Duration,
+    point_x: Duration,
+}
+
+/// Run the optimized Stoffel source and time the protocol boundary on every
+/// party. Key generation is deliberately excluded: offline starts at gamma
+/// generation and ends once public r is available; online ends when s opens.
+async fn run_timed_ecdsa_program<F, G>(
+    engines: &[Arc<AvssMpcEngine<F, G>>],
+    function: &VMFunction,
+) -> (Vec<(VirtualMachine, Value)>, Vec<EcdsaStageDurations>)
+where
+    F: ark_ff::FftField + PrimeField + Send + Sync + 'static,
+    G: CurveGroup<ScalarField = F> + Send + Sync + 'static,
+    AvssMpcEngine<F, G>: crate::net::mpc_engine::MpcEngine,
+{
+    let mut handles = Vec::with_capacity(engines.len());
+
+    for engine in engines {
+        let engine: Arc<dyn crate::net::mpc_engine::MpcEngine> = engine.clone();
+        let function = function.clone();
+        handles.push(tokio::task::spawn_blocking(move || {
+            let marks = Arc::new(Mutex::new(EcdsaStageMarks::default()));
+            let hook_marks = marks.clone();
+            let mut vm = VirtualMachine::builder().with_mpc_engine(engine).build();
+            vm.register_hook(
+                |event| {
+                    matches!(
+                        event,
+                        HookEvent::BeforeInstructionExecute(Instruction::CALL(_))
+                            | HookEvent::AfterInstructionExecute(Instruction::CALL(_))
+                    )
+                },
+                move |event, _| {
+                    let mut marks = hook_marks.lock().expect("timing marks lock");
+                    match event {
+                        HookEvent::BeforeInstructionExecute(Instruction::CALL(_)) => {
+                            marks.call_started = Some(Instant::now());
+                        }
+                        _ => {}
+                    }
+                    match event {
+                        HookEvent::BeforeInstructionExecute(Instruction::CALL(name))
+                            if name == "Share.random_int"
+                                || name == "Share.random_field"
+                                || name == "Share.random" =>
+                        {
+                            marks.random_calls += 1;
+                            // The first random is key generation. Gamma is the
+                            // second random and begins per-signature offline work.
+                            if marks.random_calls == 2 {
+                                marks.offline_start = Some(Instant::now());
+                            }
+                        }
+                        HookEvent::AfterInstructionExecute(Instruction::CALL(name)) => {
+                            let elapsed = marks
+                                .call_started
+                                .take()
+                                .expect("ECDSA call start mark")
+                                .elapsed();
+                            match name.as_str() {
+                                "Share.random_int" | "Share.random_field" | "Share.random" => {
+                                    if marks.random_calls == 2 {
+                                        marks.gamma_random = elapsed;
+                                    } else if marks.random_calls == 3 {
+                                        marks.nonce_random = elapsed;
+                                    }
+                                }
+                                "Share.batch_mul" => marks.batch_mul = elapsed,
+                                "open_field" | "Share.open_field"
+                                    if marks.offline_end.is_none() =>
+                                {
+                                    marks.delta_open = elapsed;
+                                }
+                                "get_commitment" | "Share.get_commitment"
+                                    if marks.offline_start.is_some()
+                                        && marks.offline_end.is_none() =>
+                                {
+                                    marks.nonce_commitment = elapsed;
+                                }
+                                "Crypto.point_x_to_field" => {
+                                    marks.point_x = elapsed;
+                                    marks.offline_end = Some(Instant::now());
+                                }
+                                "open_field" | "Share.open_field"
+                                    if marks.offline_end.is_some()
+                                        && marks.online_end.is_none() =>
+                                {
+                                    marks.online_end = Some(Instant::now());
+                                }
+                                _ => {}
+                            }
+                        }
+                        _ => {}
+                    }
+                    Ok(())
+                },
+                0,
+            );
+            vm.register_function(function);
+            let result = vm.execute("main").expect("VM execution failed");
+            let marks = *marks.lock().expect("timing marks lock");
+            let offline_start = marks.offline_start.expect("offline start mark");
+            let offline_end = marks.offline_end.expect("offline end mark");
+            let online_end = marks.online_end.expect("online end mark");
+            (
+                vm,
+                result,
+                EcdsaStageDurations {
+                    offline: offline_end.duration_since(offline_start),
+                    online: online_end.duration_since(offline_end),
+                    gamma_random: marks.gamma_random,
+                    nonce_random: marks.nonce_random,
+                    batch_mul: marks.batch_mul,
+                    delta_open: marks.delta_open,
+                    nonce_commitment: marks.nonce_commitment,
+                    point_x: marks.point_x,
+                },
+            )
+        }));
+    }
+
+    let completed = futures::future::join_all(handles)
+        .await
+        .into_iter()
+        .map(|result| result.expect("timed party task panicked"))
+        .collect::<Vec<_>>();
+    let timings = completed.iter().map(|(_, _, timing)| *timing).collect();
+    let results = completed
+        .into_iter()
+        .map(|(vm, value, _)| (vm, value))
+        .collect();
+    (results, timings)
+}
+
+fn compile_optimized_secp256k1_ecdsa_source() -> VMFunction {
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../stoffel-lang/examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl");
+    let source = std::fs::read_to_string(&path).expect("read optimized threshold ECDSA source");
+    let options = stoffellang::CompilerOptions {
+        optimize: true,
+        optimization_level: 3,
+        mpc_backend: MpcBackend::Avss,
+        mpc_curve: MpcCurve::Secp256k1,
+        ..Default::default()
+    };
+    let program = stoffellang::compile_file(&path, &source, &options)
+        .expect("compile optimized threshold ECDSA source");
+    stoffellang::convert_to_binary(&program)
+        .try_to_vm_functions()
+        .expect("lower optimized threshold ECDSA bytecode")
+        .into_iter()
+        .find(|function| function.name() == "main")
+        .expect("optimized threshold ECDSA has main")
+}
+
 async fn run_threshold_ecdsa_case<F, G>(
     curve_name: &str,
     instance_id: u64,
@@ -879,6 +1060,177 @@ async fn test_threshold_ecdsa_secp256k1() {
         EcdsaThirdPartyVerifier::Secp256k1,
     )
     .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "release-only protocol latency benchmark"]
+async fn benchmark_optimized_threshold_ecdsa_secp256k1() {
+    use ark_secp256k1::{Fr, Projective};
+
+    init_crypto_provider();
+    setup_test_tracing();
+
+    const N: usize = 5;
+    const T: usize = 1;
+    // Preprocessing below yields 20 triples after five-party AVSS rounding and
+    // 32 retained random shares. A complete demo execution consumes two
+    // triples and three random shares, so ten runs consume the full triple
+    // allocation without triggering a refill.
+    const RUNS: usize = 10;
+    let mut nodes = setup_test_network::<Fr, Projective>(N, 13500)
+        .await
+        .expect("create benchmark network");
+    let pk_maps = exchange_ecdh_keys(&mut nodes)
+        .await
+        .expect("benchmark PK exchange");
+    let mut engines = Vec::with_capacity(N);
+    for (i, node) in nodes.iter().enumerate() {
+        let session = MpcSessionConfig::try_new(
+            900_103,
+            node.node_id,
+            N,
+            T,
+            node.network.clone().expect("benchmark network manager"),
+        )
+        .expect("benchmark topology");
+        let engine = AvssMpcEngine::from_config(
+            AvssEngineConfig::new(session, node.sk_i, pk_maps[i].clone())
+                .with_preprocessing_counts(32, 16),
+        )
+        .await
+        .expect("create benchmark engine");
+        engine.start_async().await.expect("start benchmark engine");
+        engines.push(engine);
+    }
+    spawn_message_processors(&mut nodes, &engines);
+
+    // Literal MPCNode preprocessing: all parties cooperatively generate the
+    // complete pool before any Share.random_field() or multiplication consumes
+    // it. Wall time is the all-party critical path; divide by RUNS to report
+    // the amortized generation cost of one signature's material.
+    let preprocessing_started = Instant::now();
+    futures::future::try_join_all(engines.iter().map(|engine| engine.preprocess()))
+        .await
+        .expect("generate benchmark preprocessing pool");
+    let preprocessing_elapsed = preprocessing_started.elapsed();
+    println!(
+        "ECDSA_PREPROCESSING signature_batches={} requested_triples={} generated_triples={} retained_randoms={} total_ms={:.3} amortized_per_signature_ms={:.3}",
+        RUNS,
+        16,
+        20,
+        32,
+        preprocessing_elapsed.as_secs_f64() * 1e3,
+        preprocessing_elapsed.as_secs_f64() * 1e3 / RUNS as f64,
+    );
+
+    let function = compile_optimized_secp256k1_ecdsa_source();
+    let mut offline = Vec::with_capacity(RUNS);
+    let mut online = Vec::with_capacity(RUNS);
+    let mut gamma_random = Vec::with_capacity(RUNS);
+    let mut nonce_random = Vec::with_capacity(RUNS);
+    let mut batch_mul = Vec::with_capacity(RUNS);
+    let mut delta_open = Vec::with_capacity(RUNS);
+    let mut nonce_commitment = Vec::with_capacity(RUNS);
+    let mut point_x = Vec::with_capacity(RUNS);
+    for run in 0..RUNS {
+        let (mut results, party_timings) = run_timed_ecdsa_program(&engines, &function).await;
+        // Attribute the stage breakdown to the same critical-path party that
+        // determines offline latency, so the stage values are comparable.
+        let critical_timing = party_timings
+            .iter()
+            .max_by_key(|timing| timing.offline)
+            .expect("offline party timing");
+        let run_offline = critical_timing.offline;
+        let run_online = party_timings
+            .iter()
+            .map(|timing| timing.online)
+            .max()
+            .expect("online party timing");
+        let run_gamma_random = critical_timing.gamma_random;
+        let run_nonce_random = critical_timing.nonce_random;
+        let run_batch_mul = critical_timing.batch_mul;
+        let run_delta_open = critical_timing.delta_open;
+        let run_nonce_commitment = critical_timing.nonce_commitment;
+        let run_point_x = critical_timing.point_x;
+
+        // Validate the measured execution, not a separate hand-built fixture.
+        let (vm, value) = &mut results[0];
+        let bytes = extract_vm_byte_array(vm, value);
+        let r: [u8; 32] = bytes[..32].try_into().expect("benchmark r");
+        let s: [u8; 32] = bytes[32..64].try_into().expect("benchmark s");
+        let digest = sha2::Sha256::digest(THRESHOLD_ECDSA_DEMO_MESSAGE_INPUT.as_bytes());
+        verify_secp256k1_ecdsa(&digest, &bytes[64..], &r, &s);
+
+        println!(
+            "ECDSA_TIMING run={} presign_ms={:.3} online_ms={:.3} gamma_random_ms={:.3} nonce_random_ms={:.3} batch_mul_ms={:.3} delta_open_ms={:.3} nonce_commitment_ms={:.3} point_x_ms={:.3}",
+            run,
+            run_offline.as_secs_f64() * 1e3,
+            run_online.as_secs_f64() * 1e3,
+            run_gamma_random.as_secs_f64() * 1e3,
+            run_nonce_random.as_secs_f64() * 1e3,
+            run_batch_mul.as_secs_f64() * 1e3,
+            run_delta_open.as_secs_f64() * 1e3,
+            run_nonce_commitment.as_secs_f64() * 1e3,
+            run_point_x.as_secs_f64() * 1e3,
+        );
+        offline.push(run_offline);
+        online.push(run_online);
+        gamma_random.push(run_gamma_random);
+        nonce_random.push(run_nonce_random);
+        batch_mul.push(run_batch_mul);
+        delta_open.push(run_delta_open);
+        nonce_commitment.push(run_nonce_commitment);
+        point_x.push(run_point_x);
+    }
+
+    for engine in &engines {
+        assert_eq!(
+            engine.multiplication_session_count().await,
+            RUNS,
+            "each two-product Share.batch_mul must use one AVSS multiplication session"
+        );
+    }
+
+    offline.sort_unstable();
+    online.sort_unstable();
+    gamma_random.sort_unstable();
+    nonce_random.sort_unstable();
+    batch_mul.sort_unstable();
+    delta_open.sort_unstable();
+    nonce_commitment.sort_unstable();
+    point_x.sort_unstable();
+    let median = |samples: &[Duration]| {
+        let middle = samples.len() / 2;
+        if samples.len() % 2 == 0 {
+            (samples[middle - 1] + samples[middle]) / 2
+        } else {
+            samples[middle]
+        }
+    };
+    let mean =
+        |samples: &[Duration]| samples.iter().copied().sum::<Duration>() / samples.len() as u32;
+    println!(
+        "ECDSA_TIMING summary measured_runs={} presign_median_ms={:.3} presign_mean_ms={:.3} presign_min_ms={:.3} presign_max_ms={:.3} online_median_ms={:.3} online_mean_ms={:.3} online_min_ms={:.3} online_max_ms={:.3}",
+        offline.len(),
+        median(&offline).as_secs_f64() * 1e3,
+        mean(&offline).as_secs_f64() * 1e3,
+        offline[0].as_secs_f64() * 1e3,
+        offline[offline.len() - 1].as_secs_f64() * 1e3,
+        median(&online).as_secs_f64() * 1e3,
+        mean(&online).as_secs_f64() * 1e3,
+        online[0].as_secs_f64() * 1e3,
+        online[online.len() - 1].as_secs_f64() * 1e3,
+    );
+    println!(
+        "ECDSA_SUBPROTOCOL summary measured_runs={} gamma_random_median_ms={:.3} nonce_random_median_ms={:.3} batch_mul_median_ms={:.3} delta_open_median_ms={:.3} nonce_commitment_median_ms={:.3} point_x_median_ms={:.3}",
+        offline.len(),
+        median(&gamma_random).as_secs_f64() * 1e3,
+        median(&nonce_random).as_secs_f64() * 1e3,
+        median(&batch_mul).as_secs_f64() * 1e3,
+        median(&delta_open).as_secs_f64() * 1e3,
+        median(&nonce_commitment).as_secs_f64() * 1e3,
+        median(&point_x).as_secs_f64() * 1e3,
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/stoffel-vm/src/tests/threshold_signatures.rs
+++ b/crates/stoffel-vm/src/tests/threshold_signatures.rs
@@ -38,7 +38,7 @@ use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
-use stoffel_vm_types::compiled_binary::{MpcBackend, MpcCurve};
+use stoffel_vm_types::compiled_binary::{MpcBackend, MpcCurve, PreprocessingDemand};
 use stoffel_vm_types::core_types::Value;
 use stoffel_vm_types::functions::VMFunction;
 use stoffel_vm_types::instructions::Instruction;
@@ -682,6 +682,39 @@ where
     results
 }
 
+/// Run an already-compiled function on every party. This is the source-example
+/// counterpart of `run_program_on_all_parties`, which builds a hand-authored
+/// instruction fixture.
+async fn run_function_on_all_parties<F, G>(
+    engines: &[Arc<AvssMpcEngine<F, G>>],
+    function: &VMFunction,
+) -> Vec<(VirtualMachine, Value)>
+where
+    F: ark_ff::FftField + PrimeField + Send + Sync + 'static,
+    G: CurveGroup<ScalarField = F> + Send + Sync + 'static,
+    AvssMpcEngine<F, G>: crate::net::mpc_engine::MpcEngine,
+{
+    let handles = engines
+        .iter()
+        .map(|engine| {
+            let engine: Arc<dyn crate::net::mpc_engine::MpcEngine> = engine.clone();
+            let function = function.clone();
+            tokio::task::spawn_blocking(move || {
+                let mut vm = VirtualMachine::builder().with_mpc_engine(engine).build();
+                vm.register_function(function);
+                let result = vm.execute("main").expect("VM execution failed");
+                (vm, result)
+            })
+        })
+        .collect::<Vec<_>>();
+
+    futures::future::join_all(handles)
+        .await
+        .into_iter()
+        .map(|result| result.expect("compiled threshold-signature party task panicked"))
+        .collect()
+}
+
 #[derive(Clone, Copy, Default)]
 struct EcdsaStageMarks {
     random_calls: usize,
@@ -840,25 +873,216 @@ where
     (results, timings)
 }
 
-fn compile_optimized_secp256k1_ecdsa_source() -> VMFunction {
+fn compile_optimized_threshold_source(
+    directory: &str,
+    curve: MpcCurve,
+) -> (VMFunction, PreprocessingDemand) {
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("../stoffel-lang/examples/threshold_signatures/threshold_ecdsa_secp256k1/main.stfl");
-    let source = std::fs::read_to_string(&path).expect("read optimized threshold ECDSA source");
+        .join("../stoffel-lang/examples/threshold_signatures")
+        .join(directory)
+        .join("main.stfl");
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("read optimized {directory} source: {error}"));
     let options = stoffellang::CompilerOptions {
         optimize: true,
         optimization_level: 3,
         mpc_backend: MpcBackend::Avss,
-        mpc_curve: MpcCurve::Secp256k1,
+        mpc_curve: curve,
         ..Default::default()
     };
     let program = stoffellang::compile_file(&path, &source, &options)
-        .expect("compile optimized threshold ECDSA source");
-    stoffellang::convert_to_binary(&program)
+        .unwrap_or_else(|errors| panic!("compile optimized {directory} source: {errors:#?}"));
+    let binary = stoffellang::convert_to_binary(&program);
+    assert_eq!(binary.client_io_manifest.mpc_backend, MpcBackend::Avss);
+    assert_eq!(binary.client_io_manifest.mpc_curve, curve);
+    let demand = binary.client_io_manifest.preprocessing_demand;
+    let function = binary
         .try_to_vm_functions()
-        .expect("lower optimized threshold ECDSA bytecode")
+        .unwrap_or_else(|error| panic!("lower optimized {directory} bytecode: {error:?}"))
         .into_iter()
         .find(|function| function.name() == "main")
-        .expect("optimized threshold ECDSA has main")
+        .unwrap_or_else(|| panic!("optimized {directory} program has main"));
+    (function, demand)
+}
+
+fn compile_optimized_secp256k1_ecdsa_source() -> VMFunction {
+    compile_optimized_threshold_source("threshold_ecdsa_secp256k1", MpcCurve::Secp256k1).0
+}
+
+#[derive(Clone, Copy)]
+struct ExpectedAvssExecution {
+    triples: u64,
+    randoms: u64,
+    multiplication_sessions: usize,
+    single_open_sessions: usize,
+    batch_open_sessions: usize,
+    g1_exponent_open_sessions: usize,
+    g2_exponent_open_sessions: usize,
+    output_bytes: usize,
+}
+
+async fn avss_preprocessing_pool_counts<F, G>(engine: &AvssMpcEngine<F, G>) -> (usize, usize)
+where
+    F: SupportedMpcField,
+    G: CurveGroup<ScalarField = F> + Send + Sync + 'static,
+{
+    let node = engine.node_handle().lock().await;
+    let counts = node.preprocessing_material.lock().await.len();
+    counts
+}
+
+/// Compile and execute one real source example with exactly the material from
+/// its manifest. Pool accounting proves that the AVSS protocol did not invoke
+/// its automatic refill path during online execution; registry accounting
+/// proves the concrete protocol-session shape produced by O3.
+async fn run_compiled_threshold_example_with_exact_preprocessing<F, G>(
+    directory: &str,
+    curve: MpcCurve,
+    instance_id: u64,
+    base_port: u16,
+    expected: ExpectedAvssExecution,
+) -> Vec<u8>
+where
+    F: SupportedMpcField
+        + ark_ff::FftField
+        + PrimeField
+        + UniformRand
+        + CanonicalDeserialize
+        + CanonicalSerialize
+        + Send
+        + Sync
+        + 'static,
+    G: CurveGroup<ScalarField = F>
+        + PrimeGroup
+        + CanonicalSerialize
+        + CanonicalDeserialize
+        + std::ops::Mul<F, Output = G>
+        + Send
+        + Sync
+        + 'static,
+    G::Affine: CanonicalDeserialize + CanonicalSerialize + AffineRepr,
+    AvssMpcEngine<F, G>: crate::net::mpc_engine::MpcEngine,
+{
+    init_crypto_provider();
+    setup_test_tracing();
+
+    const N: usize = 5;
+    const T: usize = 1;
+    let (function, demand) = compile_optimized_threshold_source(directory, curve);
+    assert_eq!(demand.triples, expected.triples, "{directory} triples");
+    assert_eq!(demand.randoms, expected.randoms, "{directory} randoms");
+    assert_eq!(demand.prandbits, 0, "{directory} AVSS prandbits");
+    assert_eq!(demand.prandints, 0, "{directory} AVSS prandints");
+    assert!(!demand.dynamic, "{directory} demand must be exact");
+
+    let requested_triples = usize::try_from(demand.triples).expect("triple count fits usize");
+    let requested_randoms = usize::try_from(demand.randoms).expect("random count fits usize");
+    let physically_generated_triples = if requested_triples == 0 {
+        0
+    } else {
+        requested_triples.div_ceil(N) * N
+    };
+    // RanSha emits n-2t random shares per protocol run. Triple construction
+    // consumes two random shares per physically generated (party-rounded)
+    // triple, leaving the program allocation plus at most one RanSha batch's
+    // rounding residue in the visible pool.
+    let random_batch = N - 2 * T;
+    let total_random_generation_request = requested_randoms + 2 * physically_generated_triples;
+    let physically_generated_randoms = if total_random_generation_request == 0 {
+        0
+    } else {
+        total_random_generation_request.div_ceil(random_batch) * random_batch
+    };
+    let retained_program_randoms = physically_generated_randoms - 2 * physically_generated_triples;
+
+    let mut nodes = setup_test_network::<F, G>(N, base_port)
+        .await
+        .unwrap_or_else(|error| panic!("create {directory} AVSS network: {error}"));
+    let pk_maps = exchange_ecdh_keys(&mut nodes)
+        .await
+        .unwrap_or_else(|error| panic!("exchange {directory} AVSS keys: {error}"));
+
+    let mut engines = Vec::with_capacity(N);
+    for (i, node) in nodes.iter().enumerate() {
+        let session = MpcSessionConfig::try_new(
+            instance_id,
+            node.node_id,
+            N,
+            T,
+            node.network
+                .clone()
+                .expect("threshold example network manager"),
+        )
+        .expect("threshold example topology");
+        let engine = AvssMpcEngine::from_config(
+            AvssEngineConfig::new(session, node.sk_i, pk_maps[i].clone())
+                .with_preprocessing_counts(requested_randoms, requested_triples),
+        )
+        .await
+        .unwrap_or_else(|error| panic!("create {directory} AVSS engine: {error}"));
+        engine
+            .start_async()
+            .await
+            .unwrap_or_else(|error| panic!("start {directory} AVSS engine: {error}"));
+        engines.push(engine);
+    }
+    spawn_message_processors(&mut nodes, &engines);
+
+    futures::future::try_join_all(engines.iter().map(|engine| engine.preprocess()))
+        .await
+        .unwrap_or_else(|error| panic!("preprocess {directory}: {error}"));
+    for engine in &engines {
+        assert_eq!(
+            avss_preprocessing_pool_counts(engine).await,
+            (physically_generated_triples, retained_program_randoms),
+            "{directory} must retain exactly the protocol-rounded material before execution"
+        );
+    }
+
+    let mut results = run_function_on_all_parties(&engines, &function).await;
+    let mut byte_results = Vec::with_capacity(N);
+    for (vm, result) in &mut results {
+        byte_results.push(extract_vm_byte_array(vm, result));
+    }
+    for party in 1..N {
+        assert_eq!(
+            byte_results[0], byte_results[party],
+            "{directory} party {party} output differs from party 0"
+        );
+    }
+    assert_eq!(
+        byte_results[0].len(),
+        expected.output_bytes,
+        "{directory} output length"
+    );
+
+    for engine in &engines {
+        assert_eq!(
+            avss_preprocessing_pool_counts(engine).await,
+            (
+                physically_generated_triples - requested_triples,
+                retained_program_randoms - requested_randoms,
+            ),
+            "{directory} must consume its exact manifest demand without an online refill"
+        );
+        assert_eq!(
+            engine.multiplication_session_count().await,
+            expected.multiplication_sessions,
+            "{directory} multiplication protocol sessions"
+        );
+        assert_eq!(
+            engine.open_registry().protocol_session_counts(),
+            (
+                expected.single_open_sessions,
+                expected.batch_open_sessions,
+                expected.g1_exponent_open_sessions,
+                expected.g2_exponent_open_sessions,
+            ),
+            "{directory} open protocol sessions"
+        );
+    }
+
+    byte_results.swap_remove(0)
 }
 
 async fn run_threshold_ecdsa_case<F, G>(
@@ -1244,6 +1468,190 @@ async fn test_threshold_ecdsa_p256() {
         EcdsaThirdPartyVerifier::P256,
     )
     .await;
+}
+
+/// Execute every checked-in threshold-signature source program through the O3
+/// compiler and the real AVSS backend. Unlike the hand-authored protocol tests
+/// below, this test provisions only the manifest demand and verifies both the
+/// resulting signature and the concrete online session shape.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "release-only exact AVSS preprocessing and online-session validation"]
+async fn optimized_threshold_signature_examples_use_exact_avss_preprocessing() {
+    let bls = run_compiled_threshold_example_with_exact_preprocessing::<
+        ark_bls12_381::Fr,
+        ark_bls12_381::G1Projective,
+    >(
+        "threshold_bls_bls12381",
+        MpcCurve::Bls12_381,
+        900_200,
+        13600,
+        ExpectedAvssExecution {
+            triples: 0,
+            randoms: 1,
+            multiplication_sessions: 0,
+            single_open_sessions: 0,
+            batch_open_sessions: 0,
+            g1_exponent_open_sessions: 1,
+            g2_exponent_open_sessions: 1,
+            output_bytes: 192,
+        },
+    )
+    .await;
+    {
+        use ark_bls12_381::{Bls12_381, G1Affine, G2Affine, G2Projective};
+        use ark_ec::pairing::Pairing;
+
+        let signature =
+            G1Affine::deserialize_compressed(&bls[..48]).expect("compiled BLS signature");
+        let public_key =
+            G2Affine::deserialize_compressed(&bls[48..144]).expect("compiled BLS public key");
+        let message_hash =
+            G1Affine::deserialize_compressed(&bls[144..]).expect("compiled BLS message hash");
+        assert_eq!(
+            Bls12_381::pairing(signature, G2Projective::generator().into_affine()),
+            Bls12_381::pairing(message_hash, public_key),
+            "compiled BLS signature must verify"
+        );
+    }
+
+    let p256 = run_compiled_threshold_example_with_exact_preprocessing::<
+        ark_secp256r1::Fr,
+        ark_secp256r1::Projective,
+    >(
+        "threshold_ecdsa_p256",
+        MpcCurve::Secp256r1,
+        900_201,
+        13700,
+        ExpectedAvssExecution {
+            triples: 2,
+            randoms: 3,
+            multiplication_sessions: 2,
+            single_open_sessions: 2,
+            batch_open_sessions: 0,
+            g1_exponent_open_sessions: 1,
+            g2_exponent_open_sessions: 0,
+            output_bytes: 97,
+        },
+    )
+    .await;
+    let digest = sha2::Sha256::digest(THRESHOLD_ECDSA_DEMO_MESSAGE_INPUT.as_bytes());
+    verify_p256_ecdsa(
+        &digest,
+        &p256[64..],
+        p256[..32].try_into().expect("compiled P-256 r"),
+        p256[32..64].try_into().expect("compiled P-256 s"),
+    );
+
+    let secp256k1 = run_compiled_threshold_example_with_exact_preprocessing::<
+        ark_secp256k1::Fr,
+        ark_secp256k1::Projective,
+    >(
+        "threshold_ecdsa_secp256k1",
+        MpcCurve::Secp256k1,
+        900_202,
+        13800,
+        ExpectedAvssExecution {
+            triples: 2,
+            randoms: 3,
+            multiplication_sessions: 1,
+            single_open_sessions: 2,
+            batch_open_sessions: 0,
+            g1_exponent_open_sessions: 0,
+            g2_exponent_open_sessions: 0,
+            output_bytes: 97,
+        },
+    )
+    .await;
+    verify_secp256k1_ecdsa(
+        &digest,
+        &secp256k1[64..],
+        secp256k1[..32].try_into().expect("compiled secp256k1 r"),
+        secp256k1[32..64].try_into().expect("compiled secp256k1 s"),
+    );
+
+    let eddsa = run_compiled_threshold_example_with_exact_preprocessing::<
+        ark_ed25519::Fr,
+        ark_ed25519::EdwardsProjective,
+    >(
+        "threshold_eddsa_ed25519",
+        MpcCurve::Ed25519,
+        900_203,
+        13900,
+        ExpectedAvssExecution {
+            triples: 0,
+            randoms: 2,
+            multiplication_sessions: 0,
+            single_open_sessions: 1,
+            batch_open_sessions: 0,
+            g1_exponent_open_sessions: 0,
+            g2_exponent_open_sessions: 0,
+            output_bytes: 96,
+        },
+    )
+    .await;
+    {
+        use ark_ed25519::{EdwardsAffine, EdwardsProjective, Fr};
+
+        let nonce: EdwardsProjective = EdwardsAffine::deserialize_compressed(&eddsa[..32])
+            .expect("compiled EdDSA nonce")
+            .into();
+        let response = Fr::deserialize_compressed(&eddsa[32..64]).expect("compiled EdDSA response");
+        let public_key: EdwardsProjective = EdwardsAffine::deserialize_compressed(&eddsa[64..])
+            .expect("compiled EdDSA public key")
+            .into();
+        let mut challenge_input = Vec::new();
+        challenge_input.extend_from_slice(&eddsa[..32]);
+        challenge_input.extend_from_slice(&eddsa[64..]);
+        challenge_input.extend_from_slice(b"test message for eddsa");
+        let challenge = Fr::from_le_bytes_mod_order(&sha2::Sha512::digest(challenge_input));
+        assert_eq!(
+            EdwardsProjective::generator() * response,
+            nonce + public_key * challenge,
+            "compiled EdDSA signature must verify"
+        );
+    }
+
+    let schnorr = run_compiled_threshold_example_with_exact_preprocessing::<
+        ark_ed25519::Fr,
+        ark_ed25519::EdwardsProjective,
+    >(
+        "threshold_schnorr_ed25519",
+        MpcCurve::Ed25519,
+        900_204,
+        14000,
+        ExpectedAvssExecution {
+            triples: 0,
+            randoms: 2,
+            multiplication_sessions: 0,
+            single_open_sessions: 1,
+            batch_open_sessions: 0,
+            g1_exponent_open_sessions: 0,
+            g2_exponent_open_sessions: 0,
+            output_bytes: 96,
+        },
+    )
+    .await;
+    {
+        use ark_ed25519::{EdwardsAffine, EdwardsProjective, Fr};
+
+        let nonce: EdwardsProjective = EdwardsAffine::deserialize_compressed(&schnorr[..32])
+            .expect("compiled Schnorr nonce")
+            .into();
+        let response =
+            Fr::deserialize_compressed(&schnorr[32..64]).expect("compiled Schnorr response");
+        let public_key: EdwardsProjective = EdwardsAffine::deserialize_compressed(&schnorr[64..])
+            .expect("compiled Schnorr public key")
+            .into();
+        let mut challenge_input = Vec::new();
+        challenge_input.extend_from_slice(&schnorr[..32]);
+        challenge_input.extend_from_slice(b"test message for schnorr");
+        let challenge = Fr::from_le_bytes_mod_order(&sha2::Sha256::digest(challenge_input));
+        assert_eq!(
+            EdwardsProjective::generator() * response,
+            nonce + public_key * challenge,
+            "compiled Schnorr signature must verify"
+        );
+    }
 }
 
 // ===========================================================================

--- a/crates/stoffel-vm/src/vm_state/calls.rs
+++ b/crates/stoffel-vm/src/vm_state/calls.rs
@@ -12,10 +12,10 @@ use crate::net::share_runtime::ensure_matching_share_data_format;
 use crate::program::{CallTarget, VmCallTarget};
 use crate::runtime_hooks::{HookCallTarget, HookEvent};
 use crate::runtime_instruction::RuntimeRegister;
-use crate::standard_library::encode_output_share_list;
 use crate::value_conversions::value_to_usize;
 use crate::vm_state::mpc_operation::{
-    PendingMpcBuiltinCall, PendingMpcBuiltinOperation, PendingMpcOperation,
+    PendingMpcBuiltinCall, PendingMpcBuiltinOperation, PendingMpcOperation, TypedShareBatch,
+    TypedSharePairBatch,
 };
 use smallvec::SmallVec;
 use std::sync::Arc;
@@ -569,47 +569,66 @@ impl VMState {
                     return Err("Share.batch_mul requires arrays with the same length".into());
                 }
 
-                // Pairs with a clear integer operand are local scalings and
-                // are computed immediately; only share-by-share pairs go to
-                // the engine.
-                let mut share_type: Option<ShareType> = None;
-                let mut precomputed: Vec<Option<ShareData>> = Vec::with_capacity(lefts.len());
-                let mut left_data: Vec<ShareData> = Vec::new();
-                let mut right_data: Vec<ShareData> = Vec::new();
+                // Compiler fusion is allowed to combine independent scalar
+                // operations. Preserve that legality even when their runtime
+                // widths differ: partition interactive pairs by exact
+                // `ShareType`, while keeping one result slot per source lane.
+                let output_len = lefts.len();
+                let mut precomputed: Vec<Option<(ShareType, ShareData)>> = vec![None; output_len];
+                let mut groups: Vec<TypedSharePairBatch> = Vec::new();
+                let mut first_type = None;
+                let mut homogeneous = true;
 
-                let mut require_type = |ty: ShareType| -> Result<(), ForeignFunctionCallbackError> {
-                    match share_type {
-                        None => {
-                            share_type = Some(ty);
-                            Ok(())
-                        }
-                        Some(existing) if existing == ty => Ok(()),
-                        Some(_) => {
-                            Err("Share.batch_mul requires arrays with matching share types".into())
-                        }
+                let mut observe_type = |ty: ShareType| {
+                    if let Some(first) = first_type {
+                        homogeneous &= first == ty;
+                    } else {
+                        first_type = Some(ty);
                     }
                 };
 
-                let mut local_products: Vec<(usize, ShareType, ShareData, i64)> = Vec::new();
                 for (index, (left, right)) in lefts.into_iter().zip(rights).enumerate() {
                     match (left, right) {
                         (ShareOrScalar::Share(lt, ld), ShareOrScalar::Share(rt, rd)) => {
-                            require_type(lt)?;
-                            require_type(rt)?;
+                            if lt != rt {
+                                return Err(format!(
+                                    "Share.batch_mul pair {index} has mismatched share types: {lt:?} and {rt:?}"
+                                )
+                                .into());
+                            }
+                            observe_type(lt);
                             ensure_matching_share_data_format(
                                 "async_batch_multiply_share",
                                 &ld,
                                 &rd,
                             )?;
-                            precomputed.push(None);
-                            left_data.push(ld);
-                            right_data.push(rd);
+                            let group = if let Some(group) = groups.iter_mut().find(|group| {
+                                group.share_type == lt
+                                    && group
+                                        .left_data
+                                        .first()
+                                        .is_none_or(|data| data.format() == ld.format())
+                            }) {
+                                group
+                            } else {
+                                groups.push(TypedSharePairBatch {
+                                    share_type: lt,
+                                    output_indices: Vec::new(),
+                                    left_data: Vec::new(),
+                                    right_data: Vec::new(),
+                                });
+                                groups.last_mut().expect("just inserted a type group")
+                            };
+                            group.output_indices.push(index);
+                            group.left_data.push(ld);
+                            group.right_data.push(rd);
                         }
                         (ShareOrScalar::Share(ty, data), ShareOrScalar::Scalar(scalar))
                         | (ShareOrScalar::Scalar(scalar), ShareOrScalar::Share(ty, data)) => {
-                            require_type(ty)?;
-                            precomputed.push(None); // placeholder, filled below
-                            local_products.push((index, ty, data, scalar));
+                            observe_type(ty);
+                            let scaled =
+                                self.share_runtime()?.mul_scalar_data(ty, &data, scalar)?;
+                            precomputed[index] = Some((ty, scaled));
                         }
                         (ShareOrScalar::Scalar(_), ShareOrScalar::Scalar(_)) => {
                             return Err(
@@ -619,29 +638,42 @@ impl VMState {
                     }
                 }
 
-                for (index, ty, data, scalar) in local_products {
-                    let scaled = self.share_runtime()?.mul_scalar_data(ty, &data, scalar)?;
-                    precomputed[index] = Some(scaled);
-                }
-
-                let share_type =
-                    share_type.expect("non-empty batch always sees at least one share");
-
-                if precomputed.iter().all(Option::is_none) {
-                    // Pure share-by-share batch: keep the original operation
-                    // shape (and its effect accounting).
-                    return Ok(PendingMpcBuiltinOperation::BatchMul {
+                if homogeneous && groups.len() <= 1 {
+                    // Preserve the compact fast path used by ordinary
+                    // single-type batches.
+                    let share_type =
+                        first_type.expect("non-empty batch always sees at least one share");
+                    let (left_data, right_data) = groups
+                        .pop()
+                        .map(|group| (group.left_data, group.right_data))
+                        .unwrap_or_default();
+                    let precomputed: Vec<Option<ShareData>> = precomputed
+                        .into_iter()
+                        .map(|slot| {
+                            slot.map(|(ty, data)| {
+                                debug_assert_eq!(ty, share_type);
+                                data
+                            })
+                        })
+                        .collect();
+                    if precomputed.iter().all(Option::is_none) {
+                        return Ok(PendingMpcBuiltinOperation::BatchMul {
+                            share_type,
+                            left_data,
+                            right_data,
+                        });
+                    }
+                    return Ok(PendingMpcBuiltinOperation::BatchMulMixed {
                         share_type,
+                        precomputed,
                         left_data,
                         right_data,
                     });
                 }
 
-                Ok(PendingMpcBuiltinOperation::BatchMulMixed {
-                    share_type,
+                Ok(PendingMpcBuiltinOperation::BatchMulHeterogeneous {
                     precomputed,
-                    left_data,
-                    right_data,
+                    groups,
                 })
             }
             MpcOnlineBuiltin::Open => {
@@ -656,20 +688,45 @@ impl VMState {
             MpcOnlineBuiltin::BatchOpen => {
                 args.require_exact(1, "1 argument: shares_array")?;
                 let shares_arg = args.cloned(0)?;
-                let Some((share_type, share_data)) = self.extract_homogeneous_share_array(
-                    &shares_arg,
-                    "Share.batch_open shares_array",
-                )?
-                else {
+                let shares =
+                    self.extract_share_array(&shares_arg, "Share.batch_open shares_array")?;
+                if shares.is_empty() {
                     return Ok(PendingMpcBuiltinOperation::BatchOpen {
                         share_type: ShareType::default_secret_int(),
                         share_data: Vec::new(),
                     });
-                };
-                Ok(PendingMpcBuiltinOperation::BatchOpen {
-                    share_type,
-                    share_data,
-                })
+                }
+                let output_len = shares.len();
+                let mut groups: Vec<TypedShareBatch> = Vec::new();
+                for (index, (share_type, share_data)) in shares.into_iter().enumerate() {
+                    let group = if let Some(group) = groups.iter_mut().find(|group| {
+                        group.share_type == share_type
+                            && group
+                                .share_data
+                                .first()
+                                .is_none_or(|data| data.format() == share_data.format())
+                    }) {
+                        group
+                    } else {
+                        groups.push(TypedShareBatch {
+                            share_type,
+                            output_indices: Vec::new(),
+                            share_data: Vec::new(),
+                        });
+                        groups.last_mut().expect("just inserted a type group")
+                    };
+                    group.output_indices.push(index);
+                    group.share_data.push(share_data);
+                }
+                if groups.len() == 1 {
+                    let group = groups.pop().expect("one group");
+                    Ok(PendingMpcBuiltinOperation::BatchOpen {
+                        share_type: group.share_type,
+                        share_data: group.share_data,
+                    })
+                } else {
+                    Ok(PendingMpcBuiltinOperation::BatchOpenHeterogeneous { output_len, groups })
+                }
             }
             MpcOnlineBuiltin::SendToClient => {
                 args.require_min(2, "2 arguments: share, client_id")?;
@@ -679,7 +736,8 @@ impl VMState {
                 let client_id = value_to_usize(&client_id_value, "client_id")?;
                 Ok(PendingMpcBuiltinOperation::SendToClient {
                     client_id,
-                    share_bytes: share_data.as_bytes().to_vec(),
+                    share_data: vec![share_data],
+                    encode_share_list: false,
                     output_share_count: ClientOutputShareCount::one(),
                 })
             }
@@ -688,7 +746,7 @@ impl VMState {
                 let client_id = args.usize(0, "client_id")?;
                 let output_value = args.cloned(1)?;
 
-                let (share_bytes, output_share_count) = match &output_value {
+                let (share_data, encode_share_list, output_share_count) = match &output_value {
                     Value::Array(_) => {
                         let Some((_share_type, share_data)) = self
                             .extract_homogeneous_share_array(
@@ -703,20 +761,18 @@ impl VMState {
                         };
                         let output_share_count = ClientOutputShareCount::try_new(share_data.len())
                             .map_err(|error| error.to_string())?;
-                        (encode_output_share_list(&share_data)?, output_share_count)
+                        (share_data, true, output_share_count)
                     }
                     _ => {
                         let (_share_type, share_data) = self.extract_share_data(&output_value)?;
-                        (
-                            share_data.as_bytes().to_vec(),
-                            ClientOutputShareCount::one(),
-                        )
+                        (vec![share_data], false, ClientOutputShareCount::one())
                     }
                 };
 
                 Ok(PendingMpcBuiltinOperation::SendToClient {
                     client_id,
-                    share_bytes,
+                    share_data,
+                    encode_share_list,
                     output_share_count,
                 })
             }

--- a/crates/stoffel-vm/src/vm_state/effect.rs
+++ b/crates/stoffel-vm/src/vm_state/effect.rs
@@ -115,9 +115,16 @@ impl VmEffectSummary {
                 | PendingMpcBuiltinOperation::BatchMulMixed { left_data, .. } => {
                     Self::new(VmEffectKind::BuiltinBatchMul, left_data.len())
                 }
+                PendingMpcBuiltinOperation::BatchMulHeterogeneous { groups, .. } => Self::new(
+                    VmEffectKind::BuiltinBatchMul,
+                    groups.iter().map(|group| group.left_data.len()).sum(),
+                ),
                 PendingMpcBuiltinOperation::Open { .. } => Self::new(VmEffectKind::BuiltinOpen, 1),
                 PendingMpcBuiltinOperation::BatchOpen { share_data, .. } => {
                     Self::new(VmEffectKind::BuiltinBatchOpen, share_data.len())
+                }
+                PendingMpcBuiltinOperation::BatchOpenHeterogeneous { output_len, .. } => {
+                    Self::new(VmEffectKind::BuiltinBatchOpen, *output_len)
                 }
                 _ => Self::new(VmEffectKind::BuiltinOther, 1),
             },

--- a/crates/stoffel-vm/src/vm_state/local_storage.rs
+++ b/crates/stoffel-vm/src/vm_state/local_storage.rs
@@ -58,6 +58,19 @@ impl VMState {
             .exists(key)
             .map_err(local_storage_error("exists"))
     }
+
+    pub(crate) fn clear_local_storage(&mut self) -> VmResult<()> {
+        let Some(storage) = &self.local_storage else {
+            return Ok(());
+        };
+        let storage = Arc::clone(storage);
+        let mut storage = storage.lock();
+        storage
+            .as_mut()
+            .clear()
+            .map_err(local_storage_error("clear"))?;
+        Ok(())
+    }
 }
 
 impl VMState {

--- a/crates/stoffel-vm/src/vm_state/mpc.rs
+++ b/crates/stoffel-vm/src/vm_state/mpc.rs
@@ -5,15 +5,115 @@ use crate::net::client_store::{
     ClientInputHydrationCount, ClientInputIndex, ClientOutputShareCount, ClientShare,
     ClientShareIndex,
 };
+use crate::net::deferred_mpc::resolve_deferred_shares;
 use crate::net::mpc_engine::{
-    MpcEngine, MpcExponentGroup, MpcPartyId, MpcRuntimeInfo, RbcSessionId,
+    AsyncMpcEngine, MpcEngine, MpcExponentGroup, MpcPartyId, MpcRuntimeInfo, RbcSessionId,
 };
+use rustc_hash::FxHashSet;
 use std::sync::Arc;
-use stoffel_vm_types::core_types::{ClearShareInput, ClearShareValue, ShareData, ShareType, Value};
+use stoffel_vm_types::core_types::{
+    ClearShareInput, ClearShareValue, Closure, ShareData, ShareType, TableRef, Upvalue, Value,
+};
 use stoffelmpc_mpc::honeybadger::robust_interpolate::robust_interpolate::RobustShare;
 use stoffelnet::network_utils::ClientId;
 
 impl VMState {
+    /// Materialize every deferred share reachable from an async entry point's
+    /// return value. All roots are collected before scheduling so products from
+    /// sibling array/object fields can share the same MPC rounds.
+    pub(crate) async fn materialize_deferred_return_value<E: AsyncMpcEngine + ?Sized>(
+        &mut self,
+        engine: &E,
+        value: Value,
+    ) -> VmResult<Value> {
+        let mut shares = Vec::new();
+        let mut tables = Vec::new();
+        let mut visited_tables = FxHashSet::default();
+        let mut pending = vec![value.clone()];
+
+        while let Some(current) = pending.pop() {
+            match current {
+                Value::Share(_, share_data) => {
+                    if share_data.deferred_node().is_some()
+                        || matches!(share_data, ShareData::Public(_))
+                    {
+                        shares.push(share_data);
+                    }
+                }
+                Value::Array(array_ref) => {
+                    let table_ref = TableRef::from(array_ref);
+                    if visited_tables.insert(table_ref) {
+                        let entries = self
+                            .table_memory
+                            .read_array_ref_entries(array_ref, usize::MAX)?;
+                        tables.push(table_ref);
+                        enqueue_table_entries(entries, &mut pending)?;
+                    }
+                }
+                Value::Object(object_ref) => {
+                    let table_ref = TableRef::from(object_ref);
+                    if visited_tables.insert(table_ref) {
+                        let entries = self
+                            .table_memory
+                            .read_object_ref_entries(object_ref, usize::MAX)?;
+                        tables.push(table_ref);
+                        enqueue_table_entries(entries, &mut pending)?;
+                    }
+                }
+                Value::Closure(closure) => {
+                    pending.extend(
+                        closure
+                            .upvalues()
+                            .iter()
+                            .map(|upvalue| upvalue.value().clone()),
+                    );
+                }
+                Value::I64(_)
+                | Value::I32(_)
+                | Value::I16(_)
+                | Value::I8(_)
+                | Value::U8(_)
+                | Value::U16(_)
+                | Value::U32(_)
+                | Value::U64(_)
+                | Value::Float(_)
+                | Value::Bool(_)
+                | Value::String(_)
+                | Value::Foreign(_)
+                | Value::Unit => {}
+            }
+        }
+
+        if shares.is_empty() {
+            return Ok(value);
+        }
+
+        self.ensure_async_engine_matches(engine)?;
+        resolve_deferred_shares(engine, &shares).await?;
+
+        // Rewrite wrappers at the API boundary. The expression nodes retain a
+        // OnceLock cache for internal aliases, while callers receive ordinary
+        // Opaque/Feldman shares with normal value equality and persistence
+        // semantics.
+        for table_ref in tables {
+            let entries = match table_ref {
+                TableRef::Array(array_ref) => self
+                    .table_memory
+                    .read_array_ref_entries(array_ref, usize::MAX)?,
+                TableRef::Object(object_ref) => self
+                    .table_memory
+                    .read_object_ref_entries(object_ref, usize::MAX)?,
+            };
+            for (key, field_value) in entries {
+                let field_value = materialize_value_shell(field_value)?;
+                self.table_memory
+                    .set_table_field(table_ref, key, field_value)?;
+            }
+        }
+
+        materialize_value_shell(value)
+    }
+
     /// Attach an MPC engine to the VM state.
     pub(crate) fn set_mpc_engine(&mut self, engine: Arc<dyn MpcEngine>) {
         self.mpc_runtime.set_engine(engine);
@@ -224,9 +324,67 @@ impl VMState {
     }
 }
 
+fn enqueue_table_entries(entries: Vec<(Value, Value)>, pending: &mut Vec<Value>) -> VmResult<()> {
+    for (key, value) in entries {
+        if value_contains_deferred_key(&key) {
+            return Err(crate::error::VmError::Message(
+                "deferred MPC shares cannot be used as table keys".to_owned(),
+            ));
+        }
+        pending.push(value);
+        pending.push(key);
+    }
+    Ok(())
+}
+
+fn value_contains_deferred_key(value: &Value) -> bool {
+    match value {
+        Value::Share(_, share_data) => share_data.deferred_node().is_some(),
+        Value::Closure(closure) => closure
+            .upvalues()
+            .iter()
+            .any(|upvalue| value_contains_deferred_key(upvalue.value())),
+        _ => false,
+    }
+}
+
+fn materialize_value_shell(value: Value) -> VmResult<Value> {
+    match value {
+        Value::Share(share_type, share_data) => {
+            let share_data = share_data.materialized().cloned().ok_or_else(|| {
+                crate::error::VmError::Message(
+                    "async entry point returned an unresolved MPC share".to_owned(),
+                )
+            })?;
+            Ok(Value::Share(share_type, share_data))
+        }
+        Value::Closure(closure) => {
+            let upvalues = closure
+                .upvalues()
+                .iter()
+                .map(|upvalue| {
+                    Ok(Upvalue::new(
+                        upvalue.name(),
+                        materialize_value_shell(upvalue.value().clone())?,
+                    ))
+                })
+                .collect::<VmResult<Vec<_>>>()?;
+            Ok(Value::Closure(Arc::new(Closure::new(
+                closure.function_id(),
+                upvalues,
+            ))))
+        }
+        other => Ok(other),
+    }
+}
+
 impl VMState {
     pub(crate) fn input_share_data(&self, clear: ClearShareInput) -> VmResult<ShareData> {
         self.share_runtime()?.input_share(clear)
+    }
+
+    pub(crate) fn materialize_public_share_data(&self, share: &ShareData) -> VmResult<ShareData> {
+        self.share_runtime()?.materialize_public_share(share)
     }
 
     pub(crate) fn open_share_data(

--- a/crates/stoffel-vm/src/vm_state/mpc.rs
+++ b/crates/stoffel-vm/src/vm_state/mpc.rs
@@ -333,6 +333,16 @@ impl VMState {
             .multiply_share_data(ty, lhs_data, rhs_data)
     }
 
+    pub(crate) fn secret_share_batch_mul_data(
+        &self,
+        ty: ShareType,
+        lhs_data: &[ShareData],
+        rhs_data: &[ShareData],
+    ) -> VmResult<Vec<ShareData>> {
+        self.share_runtime()?
+            .batch_multiply_share_data(ty, lhs_data, rhs_data)
+    }
+
     pub(crate) fn secret_share_neg_data(
         &self,
         ty: ShareType,

--- a/crates/stoffel-vm/src/vm_state/mpc_operation.rs
+++ b/crates/stoffel-vm/src/vm_state/mpc_operation.rs
@@ -4,6 +4,9 @@ use crate::foreign_functions::ForeignFunctionError;
 use crate::mpc_values::clear_share_input;
 use crate::net::client_store::ClientOutputShareCount;
 use crate::net::curve::clear_share_value_to_vm_value;
+use crate::net::deferred_mpc::{
+    defer_multiply_share, multiplication_requires_protocol, resolve_deferred_shares,
+};
 use crate::net::mpc_engine::{AsyncMpcEngine, MpcEngine, MpcExponentGroup, MpcPartyId};
 use crate::net::share_runtime::ensure_matching_share_data_format;
 use crate::runtime_hooks::{HookCallTarget, HookEvent};
@@ -11,6 +14,7 @@ use crate::runtime_instruction::{
     FetchedInstruction, RuntimeBinaryOp, RuntimeInstruction, RuntimeRegister,
 };
 use crate::runtime_value_ops::{bool_or_data, bool_xor_data, matching_share_pair};
+use crate::standard_library::encode_output_share_list;
 use crate::value_conversions::{u64_to_vm_i64, usize_to_vm_i64};
 use stoffel_vm_types::core_types::{
     ClearShareInput, ClearShareValue, ShareData, ShareType, TableRef, Value,
@@ -65,6 +69,7 @@ pub(super) enum CompletedMpcOperation {
         left_data: ShareData,
         right_data: ShareData,
         product_data: ShareData,
+        direct_result: Option<ShareData>,
         dest: RuntimeRegister,
     },
     Open {
@@ -81,6 +86,26 @@ pub(super) struct PendingMpcBuiltinCall {
     return_register: RuntimeRegister,
     call_target: HookCallTarget,
     operation: PendingMpcBuiltinOperation,
+}
+
+/// One homogeneous runtime-type partition of a possibly heterogeneous
+/// `Share.batch_mul` call. `output_indices` maps protocol results back to the
+/// compiler-visible batch order.
+#[derive(Debug, Clone)]
+pub(super) struct TypedSharePairBatch {
+    pub(super) share_type: ShareType,
+    pub(super) output_indices: Vec<usize>,
+    pub(super) left_data: Vec<ShareData>,
+    pub(super) right_data: Vec<ShareData>,
+}
+
+/// One homogeneous runtime-type partition of a possibly heterogeneous
+/// `Share.batch_open` call.
+#[derive(Debug, Clone)]
+pub(super) struct TypedShareBatch {
+    pub(super) share_type: ShareType,
+    pub(super) output_indices: Vec<usize>,
+    pub(super) share_data: Vec<ShareData>,
 }
 
 impl PendingMpcBuiltinCall {
@@ -132,6 +157,14 @@ pub(crate) enum PendingMpcBuiltinOperation {
         left_data: Vec<ShareData>,
         right_data: Vec<ShareData>,
     },
+    /// A compiler-fused batch whose lanes do not all have the same runtime
+    /// `ShareType`. Each protocol call remains homogeneous, and results are
+    /// restored to their original lane order. Local share-by-scalar lanes are
+    /// already present in `precomputed`.
+    BatchMulHeterogeneous {
+        precomputed: Vec<Option<(ShareType, ShareData)>>,
+        groups: Vec<TypedSharePairBatch>,
+    },
     Open {
         share_type: ShareType,
         share_data: ShareData,
@@ -140,8 +173,14 @@ pub(crate) enum PendingMpcBuiltinOperation {
         share_type: ShareType,
         share_data: Vec<ShareData>,
     },
+    /// A compiler-fused open split into homogeneous runtime-type partitions.
+    BatchOpenHeterogeneous {
+        output_len: usize,
+        groups: Vec<TypedShareBatch>,
+    },
     SendToClient {
-        share_bytes: Vec<u8>,
+        share_data: Vec<ShareData>,
+        encode_share_list: bool,
         client_id: ClientId,
         output_share_count: ClientOutputShareCount,
     },
@@ -200,6 +239,9 @@ pub(super) enum CompletedMpcBuiltinResult {
         share_type: ShareType,
         share_data: Vec<ShareData>,
     },
+    /// Already typed VM values in compiler-visible batch order. Used when a
+    /// legal fused batch contains more than one runtime share type.
+    Values(Vec<Value>),
     BatchOpen {
         share_type: ShareType,
         values: Vec<ClearShareValue>,
@@ -305,10 +347,7 @@ impl PendingMpcOperation {
         match self {
             PendingMpcOperation::Input { clear, dest } => {
                 let share_type = clear.share_type();
-                let share_data = engine
-                    .input_share_async(clear)
-                    .await
-                    .map_mpc_backend_err("async_input_share")?;
+                let share_data = ShareData::public(clear);
 
                 Ok(CompletedMpcOperation::Input {
                     share_type,
@@ -322,10 +361,8 @@ impl PendingMpcOperation {
                 right_data,
                 dest,
             } => {
-                let share_data = engine
-                    .multiply_share_async(share_type, left_data.as_bytes(), right_data.as_bytes())
-                    .await
-                    .map_mpc_backend_err("async_multiply_share")?;
+                let share_data =
+                    defer_multiply_share(engine, share_type, left_data, right_data).await?;
 
                 Ok(CompletedMpcOperation::Multiply {
                     share_type,
@@ -340,10 +377,15 @@ impl PendingMpcOperation {
                 right_data,
                 dest,
             } => {
-                let product_data = engine
-                    .multiply_share_async(share_type, left_data.as_bytes(), right_data.as_bytes())
-                    .await
-                    .map_mpc_backend_err("async_boolean_bit_share")?;
+                let direct_result = public_boolean_result(
+                    op,
+                    share_type,
+                    left_data.public_input(),
+                    right_data.public_input(),
+                );
+                let product_data =
+                    defer_multiply_share(engine, share_type, left_data.clone(), right_data.clone())
+                        .await?;
 
                 Ok(CompletedMpcOperation::BooleanBit {
                     op,
@@ -351,6 +393,7 @@ impl PendingMpcOperation {
                     left_data,
                     right_data,
                     product_data,
+                    direct_result,
                     dest,
                 })
             }
@@ -360,10 +403,7 @@ impl PendingMpcOperation {
                 src,
                 dest,
             } => {
-                let value = engine
-                    .open_share_async(share_type, share_data.as_bytes())
-                    .await
-                    .map_mpc_backend_err("async_open_share")?;
+                let value = open_share_or_public_async(engine, share_type, share_data).await?;
 
                 Ok(CompletedMpcOperation::Open {
                     share_type,
@@ -388,10 +428,23 @@ impl PendingMpcOperation {
 
         match self {
             PendingMpcOperation::Input { .. } => {}
-            PendingMpcOperation::Multiply { .. } | PendingMpcOperation::BooleanBit { .. } => {
-                engine
-                    .multiplication_ops()
-                    .map_mpc_backend_err("multiplication_ops")?;
+            PendingMpcOperation::Multiply {
+                share_type,
+                left_data,
+                right_data,
+                ..
+            }
+            | PendingMpcOperation::BooleanBit {
+                share_type,
+                left_data,
+                right_data,
+                ..
+            } => {
+                if multiplication_requires_protocol(*share_type, left_data, right_data) {
+                    engine
+                        .multiplication_ops()
+                        .map_mpc_backend_err("multiplication_ops")?;
+                }
             }
             PendingMpcOperation::Open { .. } => {}
             PendingMpcOperation::BuiltinCall(call) => call.ensure_engine_can_execute(engine)?,
@@ -409,10 +462,7 @@ impl PendingMpcBuiltinCall {
         let result = match self.operation {
             PendingMpcBuiltinOperation::InputShare { clear } => {
                 let share_type = clear.share_type();
-                let share_data = engine
-                    .input_share_async(clear)
-                    .await
-                    .map_mpc_backend_err("async_input_share")?;
+                let share_data = ShareData::public(clear);
                 CompletedMpcBuiltinResult::ShareObject {
                     share_type,
                     share_data,
@@ -423,10 +473,8 @@ impl PendingMpcBuiltinCall {
                 left_data,
                 right_data,
             } => {
-                let share_data = engine
-                    .multiply_share_async(share_type, left_data.as_bytes(), right_data.as_bytes())
-                    .await
-                    .map_mpc_backend_err("async_multiply_share")?;
+                let share_data =
+                    defer_multiply_share(engine, share_type, left_data, right_data).await?;
                 CompletedMpcBuiltinResult::ShareValue {
                     share_type,
                     share_data,
@@ -437,15 +485,10 @@ impl PendingMpcBuiltinCall {
                 left_data,
                 right_data,
             } => {
-                let pairs: Vec<(Vec<u8>, Vec<u8>)> = left_data
-                    .iter()
-                    .zip(right_data.iter())
-                    .map(|(left, right)| (left.as_bytes().to_vec(), right.as_bytes().to_vec()))
-                    .collect();
-                let share_data = engine
-                    .batch_multiply_share_async(share_type, &pairs)
-                    .await
-                    .map_mpc_backend_err("async_batch_multiply_share")?;
+                let mut share_data = Vec::with_capacity(left_data.len());
+                for (left, right) in left_data.into_iter().zip(right_data) {
+                    share_data.push(defer_multiply_share(engine, share_type, left, right).await?);
+                }
                 CompletedMpcBuiltinResult::ShareValues {
                     share_type,
                     share_data,
@@ -464,29 +507,19 @@ impl PendingMpcBuiltinCall {
                 left_data,
                 right_data,
             } => {
-                let engine_results = if left_data.is_empty() {
-                    Vec::new()
-                } else {
-                    let pairs: Vec<(Vec<u8>, Vec<u8>)> = left_data
-                        .iter()
-                        .zip(right_data.iter())
-                        .map(|(left, right)| (left.as_bytes().to_vec(), right.as_bytes().to_vec()))
-                        .collect();
-                    engine
-                        .batch_multiply_share_async(share_type, &pairs)
-                        .await
-                        .map_mpc_backend_err("async_batch_multiply_share")?
-                };
-
-                let mut engine_results = engine_results.into_iter();
+                let mut deferred = Vec::with_capacity(left_data.len());
+                for (left, right) in left_data.into_iter().zip(right_data) {
+                    deferred.push(defer_multiply_share(engine, share_type, left, right).await?);
+                }
+                let mut deferred = deferred.into_iter();
                 let mut share_data = Vec::with_capacity(precomputed.len());
                 for slot in precomputed {
                     match slot {
                         Some(data) => share_data.push(data),
-                        None => share_data.push(engine_results.next().ok_or_else(|| {
+                        None => share_data.push(deferred.next().ok_or_else(|| {
                             VmError::ForeignFunction(ForeignFunctionError::CallbackFailed {
                                 function: "Share.batch_mul".to_owned(),
-                                source: "engine returned fewer batch products than requested"
+                                source: "batch plan contains fewer products than output slots"
                                     .into(),
                             })
                         })?),
@@ -497,35 +530,148 @@ impl PendingMpcBuiltinCall {
                     share_data,
                 }
             }
+            PendingMpcBuiltinOperation::BatchMulHeterogeneous {
+                mut precomputed,
+                groups,
+            } => {
+                for group in groups {
+                    debug_assert_eq!(group.output_indices.len(), group.left_data.len());
+                    debug_assert_eq!(group.left_data.len(), group.right_data.len());
+                    let mut results = Vec::with_capacity(group.left_data.len());
+                    for (left, right) in group.left_data.into_iter().zip(group.right_data) {
+                        results.push(
+                            defer_multiply_share(engine, group.share_type, left, right).await?,
+                        );
+                    }
+                    if results.len() != group.output_indices.len() {
+                        return Err(VmError::ForeignFunction(
+                            ForeignFunctionError::CallbackFailed {
+                                function: "Share.batch_mul".to_owned(),
+                                source: format!(
+                                    "engine returned {} products for {} batch lanes",
+                                    results.len(),
+                                    group.output_indices.len()
+                                )
+                                .into(),
+                            },
+                        ));
+                    }
+                    for (index, share_data) in
+                        group.output_indices.into_iter().zip(results.into_iter())
+                    {
+                        precomputed[index] = Some((group.share_type, share_data));
+                    }
+                }
+                let values = precomputed
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, slot)| {
+                        slot.map(|(share_type, share_data)| Value::Share(share_type, share_data))
+                            .ok_or_else(|| {
+                                VmError::ForeignFunction(ForeignFunctionError::CallbackFailed {
+                                    function: "Share.batch_mul".to_owned(),
+                                    source: format!("batch result lane {index} was not produced")
+                                        .into(),
+                                })
+                            })
+                    })
+                    .collect::<VmResult<Vec<_>>>()?;
+                CompletedMpcBuiltinResult::Values(values)
+            }
             PendingMpcBuiltinOperation::Open {
                 share_type,
                 share_data,
             } => {
-                let value = engine
-                    .open_share_async(share_type, share_data.as_bytes())
-                    .await
-                    .map_mpc_backend_err("async_open_share")?;
+                let value = open_share_or_public_async(engine, share_type, share_data).await?;
                 CompletedMpcBuiltinResult::Value(clear_share_value_to_vm_value(share_type, value))
             }
             PendingMpcBuiltinOperation::BatchOpen {
                 share_type,
                 share_data,
             } => {
-                let share_bytes: Vec<Vec<u8>> = share_data
-                    .iter()
-                    .map(|share_data| share_data.as_bytes().to_vec())
-                    .collect();
-                let values = engine
-                    .batch_open_shares_async(share_type, &share_bytes)
-                    .await
-                    .map_mpc_backend_err("async_batch_open_shares")?;
+                let values =
+                    batch_open_shares_or_public_async(engine, share_type, share_data).await?;
                 CompletedMpcBuiltinResult::BatchOpen { share_type, values }
+            }
+            PendingMpcBuiltinOperation::BatchOpenHeterogeneous { output_len, groups } => {
+                let mut output = vec![None; output_len];
+                let roots: Vec<_> = groups
+                    .iter()
+                    .flat_map(|group| group.share_data.iter())
+                    .filter(|share| share.public_input().is_none())
+                    .cloned()
+                    .collect();
+                let mut resolved = resolve_deferred_shares(engine, &roots).await?.into_iter();
+                for group in groups {
+                    debug_assert_eq!(group.output_indices.len(), group.share_data.len());
+                    let group_shares: Vec<_> = group
+                        .share_data
+                        .into_iter()
+                        .map(|share| {
+                            if share.public_input().is_some() {
+                                share
+                            } else {
+                                resolved
+                                    .next()
+                                    .expect("resolved heterogeneous batch preserves root count")
+                            }
+                        })
+                        .collect();
+                    let values = batch_open_materialized_or_public_async(
+                        engine,
+                        group.share_type,
+                        group_shares,
+                    )
+                    .await?;
+                    if values.len() != group.output_indices.len() {
+                        return Err(VmError::ForeignFunction(
+                            ForeignFunctionError::CallbackFailed {
+                                function: "Share.batch_open".to_owned(),
+                                source: format!(
+                                    "engine returned {} values for {} batch lanes",
+                                    values.len(),
+                                    group.output_indices.len()
+                                )
+                                .into(),
+                            },
+                        ));
+                    }
+                    for (index, value) in group.output_indices.into_iter().zip(values.into_iter()) {
+                        output[index] =
+                            Some(clear_share_value_to_vm_value(group.share_type, value));
+                    }
+                }
+                let values = output
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        value.ok_or_else(|| {
+                            VmError::ForeignFunction(ForeignFunctionError::CallbackFailed {
+                                function: "Share.batch_open".to_owned(),
+                                source: format!("batch result lane {index} was not produced")
+                                    .into(),
+                            })
+                        })
+                    })
+                    .collect::<VmResult<Vec<_>>>()?;
+                CompletedMpcBuiltinResult::Values(values)
             }
             PendingMpcBuiltinOperation::SendToClient {
                 client_id,
-                share_bytes,
+                share_data,
+                encode_share_list,
                 output_share_count,
             } => {
+                let share_data = resolve_deferred_shares(engine, &share_data).await?;
+                let share_bytes = if encode_share_list {
+                    encode_output_share_list(&share_data).map_err(VmError::from)?
+                } else {
+                    share_data
+                        .first()
+                        .expect("one output share is present")
+                        .as_bytes()
+                        .to_vec()
+                };
                 engine
                     .send_output_to_client_async(client_id, &share_bytes, output_share_count)
                     .await
@@ -538,6 +684,7 @@ impl PendingMpcBuiltinCall {
                 share_data,
                 generator_bytes,
             } => {
+                let share_data = resolve_one_deferred_share(engine, share_data).await?;
                 let bytes = engine
                     .open_share_in_exp_group_async(
                         group,
@@ -573,6 +720,7 @@ impl PendingMpcBuiltinCall {
                 share_type,
                 share_data,
             } => {
+                let share_data = resolve_one_deferred_share(engine, share_data).await?;
                 let bytes = engine
                     .open_share_as_field_async(share_type, share_data.as_bytes())
                     .await
@@ -584,6 +732,7 @@ impl PendingMpcBuiltinCall {
                 share_data,
                 generator_bytes,
             } => {
+                let share_data = resolve_one_deferred_share(engine, share_data).await?;
                 let bytes = engine
                     .open_share_in_exp_async(share_type, share_data.as_bytes(), &generator_bytes)
                     .await
@@ -636,21 +785,66 @@ impl PendingMpcBuiltinCall {
         match &self.operation {
             PendingMpcBuiltinOperation::InputShare { .. } => {}
             PendingMpcBuiltinOperation::LocalShare { .. } => {}
-            PendingMpcBuiltinOperation::Mul { .. }
-            | PendingMpcBuiltinOperation::BatchMul { .. } => {
-                engine
-                    .multiplication_ops()
-                    .map_mpc_backend_err("multiplication_ops")?;
+            PendingMpcBuiltinOperation::Mul {
+                share_type,
+                left_data,
+                right_data,
+            } => {
+                if multiplication_requires_protocol(*share_type, left_data, right_data) {
+                    engine
+                        .multiplication_ops()
+                        .map_mpc_backend_err("multiplication_ops")?;
+                }
             }
-            PendingMpcBuiltinOperation::BatchMulMixed { left_data, .. } => {
-                if !left_data.is_empty() {
+            PendingMpcBuiltinOperation::BatchMul {
+                share_type,
+                left_data,
+                right_data,
+            } => {
+                if left_data
+                    .iter()
+                    .zip(right_data)
+                    .any(|(left, right)| multiplication_requires_protocol(*share_type, left, right))
+                {
+                    engine
+                        .multiplication_ops()
+                        .map_mpc_backend_err("multiplication_ops")?;
+                }
+            }
+            PendingMpcBuiltinOperation::BatchMulMixed {
+                share_type,
+                left_data,
+                right_data,
+                ..
+            } => {
+                if left_data
+                    .iter()
+                    .zip(right_data)
+                    .any(|(left, right)| multiplication_requires_protocol(*share_type, left, right))
+                {
+                    engine
+                        .multiplication_ops()
+                        .map_mpc_backend_err("multiplication_ops")?;
+                }
+            }
+            PendingMpcBuiltinOperation::BatchMulHeterogeneous { groups, .. } => {
+                if groups.iter().any(|group| {
+                    group
+                        .left_data
+                        .iter()
+                        .zip(&group.right_data)
+                        .any(|(left, right)| {
+                            multiplication_requires_protocol(group.share_type, left, right)
+                        })
+                }) {
                     engine
                         .multiplication_ops()
                         .map_mpc_backend_err("multiplication_ops")?;
                 }
             }
             PendingMpcBuiltinOperation::Open { .. }
-            | PendingMpcBuiltinOperation::BatchOpen { .. } => {}
+            | PendingMpcBuiltinOperation::BatchOpen { .. }
+            | PendingMpcBuiltinOperation::BatchOpenHeterogeneous { .. } => {}
             PendingMpcBuiltinOperation::SendToClient { .. } => {
                 engine
                     .client_output_ops()
@@ -688,6 +882,146 @@ impl PendingMpcBuiltinCall {
 
         Ok(())
     }
+}
+
+fn public_boolean_result(
+    op: RuntimeBinaryOp,
+    share_type: ShareType,
+    left: Option<ClearShareInput>,
+    right: Option<ClearShareInput>,
+) -> Option<ShareData> {
+    if share_type != ShareType::boolean() {
+        return None;
+    }
+    let (Some(left), Some(right)) = (left, right) else {
+        return None;
+    };
+    let (ClearShareValue::Boolean(left), ClearShareValue::Boolean(right)) =
+        (left.value(), right.value())
+    else {
+        return None;
+    };
+    let value = match op {
+        RuntimeBinaryOp::BitAnd => left & right,
+        RuntimeBinaryOp::BitOr => left | right,
+        RuntimeBinaryOp::BitXor => left ^ right,
+        _ => return None,
+    };
+    Some(ShareData::public(ClearShareInput::new(
+        share_type,
+        ClearShareValue::Boolean(value),
+    )))
+}
+
+async fn open_share_or_public_async<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share_type: ShareType,
+    share_data: ShareData,
+) -> VmResult<ClearShareValue> {
+    if let Some(public) = share_data.public_input() {
+        if public.share_type() != share_type {
+            return Err(VmError::Message(format!(
+                "public share type mismatch: expected {share_type:?}, got {:?}",
+                public.share_type()
+            )));
+        }
+        return Ok(public.value());
+    }
+    let share_data = resolve_one_deferred_share(engine, share_data).await?;
+    engine
+        .open_share_async(share_type, share_data.as_bytes())
+        .await
+        .map_mpc_backend_err("async_open_share")
+}
+
+async fn batch_open_shares_or_public_async<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share_type: ShareType,
+    shares: Vec<ShareData>,
+) -> VmResult<Vec<ClearShareValue>> {
+    let secret_roots: Vec<_> = shares
+        .iter()
+        .filter(|share| share.public_input().is_none())
+        .cloned()
+        .collect();
+    let mut resolved = resolve_deferred_shares(engine, &secret_roots)
+        .await?
+        .into_iter();
+    let shares = shares
+        .into_iter()
+        .map(|share| {
+            if share.public_input().is_some() {
+                share
+            } else {
+                resolved
+                    .next()
+                    .expect("resolved batch preserves non-public root count")
+            }
+        })
+        .collect();
+    batch_open_materialized_or_public_async(engine, share_type, shares).await
+}
+
+async fn batch_open_materialized_or_public_async<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share_type: ShareType,
+    shares: Vec<ShareData>,
+) -> VmResult<Vec<ClearShareValue>> {
+    let mut output = vec![None; shares.len()];
+    let mut secret_indices = Vec::new();
+    let mut secret_bytes = Vec::new();
+    for (index, share) in shares.into_iter().enumerate() {
+        if let Some(public) = share.public_input() {
+            if public.share_type() != share_type {
+                return Err(VmError::Message(format!(
+                    "public share type mismatch in batch lane {index}: expected {share_type:?}, got {:?}",
+                    public.share_type()
+                )));
+            }
+            output[index] = Some(public.value());
+        } else {
+            secret_indices.push(index);
+            secret_bytes.push(share.into_bytes());
+        }
+    }
+
+    if !secret_bytes.is_empty() {
+        let values = engine
+            .batch_open_shares_async(share_type, &secret_bytes)
+            .await
+            .map_mpc_backend_err("async_batch_open_shares")?;
+        if values.len() != secret_indices.len() {
+            return Err(VmError::Message(format!(
+                "MPC backend returned {} openings for a batch of {}",
+                values.len(),
+                secret_indices.len()
+            )));
+        }
+        for (index, value) in secret_indices.into_iter().zip(values) {
+            output[index] = Some(value);
+        }
+    }
+
+    output
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| {
+            value.ok_or_else(|| {
+                VmError::Message(format!("batch opening did not produce lane {index}"))
+            })
+        })
+        .collect()
+}
+
+async fn resolve_one_deferred_share<E: AsyncMpcEngine + ?Sized>(
+    engine: &E,
+    share_data: ShareData,
+) -> VmResult<ShareData> {
+    resolve_deferred_shares(engine, std::slice::from_ref(&share_data))
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| VmError::Message("deferred share resolver returned no value".to_owned()))
 }
 
 fn session_id_value(session_id: u64) -> VmResult<Value> {
@@ -847,29 +1181,35 @@ impl VMState {
                 left_data,
                 right_data,
                 product_data,
+                direct_result,
                 dest,
             } => {
                 let share_runtime = || self.share_runtime().map_err(Into::into);
-                let share_data = match op {
-                    RuntimeBinaryOp::BitAnd => product_data,
-                    RuntimeBinaryOp::BitOr => bool_or_data(
-                        &share_runtime,
-                        share_type,
-                        &left_data,
-                        &right_data,
-                        &product_data,
-                    )?,
-                    RuntimeBinaryOp::BitXor => bool_xor_data(
-                        &share_runtime,
-                        share_type,
-                        &left_data,
-                        &right_data,
-                        &product_data,
-                    )?,
-                    _ => {
-                        return Err(VmError::Message(
-                            "completed boolean bit operation used a non-bitwise opcode".to_string(),
-                        ))
+                let share_data = if let Some(direct_result) = direct_result {
+                    direct_result
+                } else {
+                    match op {
+                        RuntimeBinaryOp::BitAnd => product_data,
+                        RuntimeBinaryOp::BitOr => bool_or_data(
+                            &share_runtime,
+                            share_type,
+                            &left_data,
+                            &right_data,
+                            &product_data,
+                        )?,
+                        RuntimeBinaryOp::BitXor => bool_xor_data(
+                            &share_runtime,
+                            share_type,
+                            &left_data,
+                            &right_data,
+                            &product_data,
+                        )?,
+                        _ => {
+                            return Err(VmError::Message(
+                                "completed boolean bit operation used a non-bitwise opcode"
+                                    .to_string(),
+                            ))
+                        }
                     }
                 };
                 self.write_current_register(
@@ -936,6 +1276,11 @@ impl VMState {
                     .collect();
                 let result_ref = self.create_array_ref(shares.len())?;
                 self.push_array_ref_values(result_ref, &shares)?;
+                Ok(Value::from(result_ref))
+            }
+            CompletedMpcBuiltinResult::Values(values) => {
+                let result_ref = self.create_array_ref(values.len())?;
+                self.push_array_ref_values(result_ref, &values)?;
                 Ok(Value::from(result_ref))
             }
             CompletedMpcBuiltinResult::BatchOpen { share_type, values } => {

--- a/crates/stoffel-vm/src/vm_state/share_objects.rs
+++ b/crates/stoffel-vm/src/vm_state/share_objects.rs
@@ -55,6 +55,21 @@ impl VMState {
         )?)
     }
 
+    /// Extract an array of shares without requiring a common runtime share
+    /// type. Interactive batch builtins use this to partition a compiler-fused
+    /// batch into homogeneous protocol calls while preserving source order.
+    pub(crate) fn extract_share_array(
+        &mut self,
+        value: &Value,
+        context: &'static str,
+    ) -> VmResult<Vec<(ShareType, ShareData)>> {
+        Ok(share_object::extract_share_array(
+            self.table_memory.as_mut(),
+            value,
+            context,
+        )?)
+    }
+
     pub(crate) fn extract_share_or_scalar_array(
         &mut self,
         value: &Value,

--- a/crates/stoffel-vm/src/vm_state/tests.rs
+++ b/crates/stoffel-vm/src/vm_state/tests.rs
@@ -418,6 +418,20 @@ struct MockConversionEngine {
     input_calls: Mutex<Vec<(ShareType, Value)>>,
 }
 
+fn assert_public_secret_int(value: &Value, expected: i64) {
+    let Value::Share(share_type, share_data) = value else {
+        panic!("expected secret share, got {value:?}");
+    };
+    assert_eq!(*share_type, ShareType::secret_int(64));
+    assert_eq!(
+        share_data.public_input(),
+        Some(ClearShareInput::new(
+            *share_type,
+            ClearShareValue::Integer(expected)
+        ))
+    );
+}
+
 impl MpcEngine for MockConversionEngine {
     fn protocol_name(&self) -> &'static str {
         "mock-conversion"
@@ -1972,7 +1986,7 @@ fn implicit_function_end_uses_shared_frame_return_path() {
 }
 
 #[test]
-fn register_layout_controls_clear_to_secret_mov_boundary() {
+fn register_layout_preserves_public_provenance_at_clear_to_secret_mov_boundary() {
     let mut vm = VMState::new();
     vm.set_register_layout(RegisterLayout::new(8));
     let engine = Arc::new(MockConversionEngine::default());
@@ -1991,14 +2005,8 @@ fn register_layout_controls_clear_to_secret_mov_boundary() {
         .unwrap();
 
     let record = vm.current_activation_record().unwrap();
-    assert!(matches!(
-        record.register(r(8)),
-        Some(Value::Share(ShareType::SecretInt { bit_length: 64 }, _))
-    ));
-    assert_eq!(
-        engine.input_calls.lock().unwrap().as_slice(),
-        &[(ShareType::secret_int(64), Value::I64(5))]
-    );
+    assert_public_secret_int(record.register(r(8)).expect("secret register r8"), 5);
+    assert!(engine.input_calls.lock().unwrap().is_empty());
 }
 
 #[test]
@@ -2177,7 +2185,7 @@ fn mov_hooks_read_source_before_overwriting_same_register() {
 }
 
 #[test]
-fn ldi_to_secret_register_uses_mpc_conversion() {
+fn ldi_to_secret_register_preserves_public_provenance() {
     let mut vm = VMState::new();
     vm.set_register_layout(RegisterLayout::new(1));
     let engine = Arc::new(MockConversionEngine::default());
@@ -2195,14 +2203,8 @@ fn ldi_to_secret_register_uses_mpc_conversion() {
         .unwrap();
 
     let record = vm.current_activation_record().unwrap();
-    assert!(matches!(
-        record.register(r(1)),
-        Some(Value::Share(ShareType::SecretInt { bit_length: 64 }, _))
-    ));
-    assert_eq!(
-        engine.input_calls.lock().unwrap().as_slice(),
-        &[(ShareType::secret_int(64), Value::I64(5))]
-    );
+    assert_public_secret_int(record.register(r(1)).expect("secret register r1"), 5);
+    assert!(engine.input_calls.lock().unwrap().is_empty());
 }
 
 #[test]
@@ -2224,14 +2226,8 @@ fn ldi_to_secret_register_canonicalizes_vm_integer_widths() {
         .unwrap();
 
     let record = vm.current_activation_record().unwrap();
-    assert!(matches!(
-        record.register(r(1)),
-        Some(Value::Share(ShareType::SecretInt { bit_length: 64 }, _))
-    ));
-    assert_eq!(
-        engine.input_calls.lock().unwrap().as_slice(),
-        &[(ShareType::secret_int(64), Value::I64(5))]
-    );
+    assert_public_secret_int(record.register(r(1)).expect("secret register r1"), 5);
+    assert!(engine.input_calls.lock().unwrap().is_empty());
 }
 
 #[test]
@@ -2293,7 +2289,7 @@ fn secret_register_write_rejects_clear_value_without_mpc_engine() {
 }
 
 #[test]
-fn entry_argument_to_secret_register_uses_mpc_conversion() {
+fn entry_argument_to_secret_register_preserves_public_provenance() {
     let engine = Arc::new(MockConversionEngine::default());
     let mut vm = VirtualMachine::builder()
         .with_register_layout(RegisterLayout::new(0))
@@ -2314,18 +2310,12 @@ fn entry_argument_to_secret_register_uses_mpc_conversion() {
         .execute_with_args("secret_arg", &[Value::I64(5)])
         .expect("secret-register argument should be converted through MPC");
 
-    assert!(matches!(
-        result,
-        Value::Share(ShareType::SecretInt { bit_length: 64 }, _)
-    ));
-    assert_eq!(
-        engine.input_calls.lock().unwrap().as_slice(),
-        &[(ShareType::secret_int(64), Value::I64(5))]
-    );
+    assert_public_secret_int(&result, 5);
+    assert!(engine.input_calls.lock().unwrap().is_empty());
 }
 
 #[test]
-fn foreign_return_to_secret_register_uses_mpc_conversion() {
+fn foreign_return_to_secret_register_preserves_public_provenance() {
     let engine = Arc::new(MockConversionEngine::default());
     let mut vm = VirtualMachine::builder()
         .with_register_layout(RegisterLayout::new(0))
@@ -2350,14 +2340,8 @@ fn foreign_return_to_secret_register_uses_mpc_conversion() {
         .execute("call_native_secret")
         .expect("foreign return should be converted through MPC");
 
-    assert!(matches!(
-        result,
-        Value::Share(ShareType::SecretInt { bit_length: 64 }, _)
-    ));
-    assert_eq!(
-        engine.input_calls.lock().unwrap().as_slice(),
-        &[(ShareType::secret_int(64), Value::I64(7))]
-    );
+    assert_public_secret_int(&result, 7);
+    assert!(engine.input_calls.lock().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/stoffel-vm/tests/aes_count.rs
+++ b/crates/stoffel-vm/tests/aes_count.rs
@@ -406,8 +406,10 @@ fn inlining_preserves_secret_multiplication() {
 
 async fn inlining_preserves_secret_multiplication_impl() {
     // `gate_and` is a secret-bool helper (an MPC multiply in GF(2)); `combine`
-    // chains two of them so inlining has something to fold. `x=1, y=1, z=1` so
-    // `gate_and(gate_and(x,y), z) = 1`.
+    // chains two of them so inlining has something to fold. Client shares are
+    // deliberately used instead of public `from_clear_int` values: public
+    // constants are now correctly localized and would make this secrecy test
+    // vacuous for the opposite reason.
     let source = r#"
 def gate_and(a: secret bool, b: secret bool) -> secret bool:
   return a and b
@@ -416,9 +418,9 @@ def combine(a: secret bool, b: secret bool, c: secret bool) -> secret bool:
   return gate_and(gate_and(a, b), c)
 
 def main() -> int64:
-  var x: secret bool = Share.from_clear_int(1, 1)
-  var y: secret bool = Share.from_clear_int(1, 1)
-  var z: secret bool = Share.from_clear_int(1, 1)
+  var x: secret bool = ClientStore.take_share_bool(0, 0)
+  var y: secret bool = ClientStore.take_share_bool(0, 1)
+  var z: secret bool = ClientStore.take_share_bool(0, 2)
   var w: secret bool = combine(x, y, z)
   var r: bool = w.reveal()
   if r:
@@ -441,6 +443,7 @@ def main() -> int64:
         let mut vm = VirtualMachine::builder()
             .with_mpc_engine(engine.clone())
             .build();
+        vm.store_client_shares(0, bits_as_bool_shares(&[0b0000_0111]));
         for function in functions {
             vm.try_register_function(function)
                 .expect("register function");
@@ -644,24 +647,18 @@ async fn optimized_aes_at_o3_matches_nist_vector_impl() {
     // and scalar-free invariants must hold.
     let (scalar, batch_calls, batch_items) = engine.counts();
     assert_eq!(scalar, 0, "every secret multiply must be batched at -O3");
-    // -O3 `fold_public_gates` now localizes provably-public multiply operands to
-    // local `Share.mul_scalar` (secret*public, 0 communication). The AES circuit's
-    // round-0 `add_round_key` XORs the fully-public `nist_plaintext()` (all
-    // `from_clear_int`) into the key, so its 128 byte-bit products become local
-    // scalar muls and drop out of the batched total. On-the-fly key expansion
-    // (round keys derived inside the round loop, adjacent to each round's
-    // sub_bytes) additionally makes the public `Rcon` XORs adjacent to the live
-    // key-schedule words, so more of those public products fold to local scalar
-    // muls — dropping the batched total from 33_952 to 33_736. The NIST
-    // ciphertext above is the correctness oracle and is unchanged.
+    // One proof-driven peel establishes the state shape, then the recurrence-
+    // aware unroller keeps the residual rounds rolled. That exposes additional
+    // provably-local gates without replicating the full round body: 33,280
+    // products remain interactive and are coalesced into 219 calls.
     assert_eq!(
-        batch_items, 33_736,
-        "total products preserved (minus localized public add_round_key + Rcon)"
+        batch_items, 33_280,
+        "interactive product count must match the optimized circuit"
     );
     assert!(
-        batch_calls < 5_000,
-        "scheduler should cut multiply rounds far below the ~25.7k unscheduled \
-         and ~6.3k -O0 baselines; got {batch_calls} rounds"
+        batch_calls <= 225,
+        "scheduler/fixpoint should stay near the 206-round dependency floor; \
+         got {batch_calls} rounds"
     );
 }
 
@@ -766,10 +763,7 @@ fn optimized_aes_full_unroll_minimizes_rounds() {
         );
         let (scalar, batch_calls, batch_items) = engine.counts();
         assert_eq!(scalar, 0);
-        // -O3 localizes round-0 `add_round_key` over the public `nist_plaintext()`
-        // (128 secret*public products → local `Share.mul_scalar`) plus on-the-fly
-        // key expansion's now-adjacent public `Rcon` XORs, so 34_080 - 344 = 33_736.
-        assert_eq!(batch_items, 33_736);
+        assert_eq!(batch_items, 33_952);
         assert!(
             batch_calls < 1_000,
             "fully-flattened AES should reach a few hundred multiply rounds; got {batch_calls}"
@@ -1318,13 +1312,16 @@ async fn round_gate_impl() {
         ),
     ];
 
-    // Collected so we can assert known-stable invariants after printing every line.
-    let mut aes_all_correct = true;
+    // Collected so the measurement harness is also a correctness gate.
+    let mut all_correct = true;
+    let mut measured_rounds: std::collections::HashMap<(&str, u8), usize> =
+        std::collections::HashMap::new();
 
     for (label, source, inputs, expected) in &programs {
         for level in [0u8, 2, 3] {
             match round_gate_run(source, level, inputs).await {
                 Ok((mul_rounds, output, lever)) => {
+                    measured_rounds.insert((*label, level), mul_rounds);
                     let correct = output == *expected;
                     // The stable, machine-parseable gate line.
                     println!(
@@ -1344,30 +1341,30 @@ async fn round_gate_impl() {
                             "ROUNDGATE {label} O{level} MISMATCH: got {output:?}, expected {expected:?}"
                         );
                     }
-                    if *label == "AES" && !correct {
-                        aes_all_correct = false;
+                    if !correct {
+                        all_correct = false;
                     }
                 }
                 Err(error) => {
                     println!("ROUNDGATE {label} O{level} mul_rounds=ERR correct=false");
                     eprintln!("ROUNDGATE {label} O{level} ERROR: {error}");
-                    if *label == "AES" {
-                        aes_all_correct = false;
-                    }
+                    all_correct = false;
                 }
             }
         }
     }
 
-    // AES correctness at every level is already guaranteed by the dedicated
-    // `optimized_aes_*` tests, so it is safe to assert here and keeps the gate
-    // honest. CTR/CBC correctness is reported per-line (above) but NOT asserted:
-    // a known -O3 full-unroll CTR bug means we must surface reality rather than
-    // fail the measurement harness.
     assert!(
-        aes_all_correct,
-        "AES must reveal the NIST ciphertext at every optimization level"
+        all_correct,
+        "AES, CTR, and CBC must match their NIST outputs at every optimization level"
     );
+    for label in ["CTR", "CBC"] {
+        assert!(
+            measured_rounds[&(label, 3)] < measured_rounds[&(label, 2)]
+                && measured_rounds[&(label, 2)] < measured_rounds[&(label, 0)],
+            "{label} must reduce online rounds monotonically from O0 to O2 to O3"
+        );
+    }
 }
 
 // ===========================================================================
@@ -1551,9 +1548,10 @@ async fn round_histogram_impl() {
             Ok((rounds, output, log)) => {
                 let correct = output == *expected;
                 print_depth_histogram(label, rounds, correct, &log);
+                assert!(correct, "{label} O3 must match its NIST output");
             }
             Err(error) => {
-                println!("HIST {label} O3 rounds=ERR correct=false error={error}");
+                panic!("HIST {label} O3 failed: {error}");
             }
         }
     }

--- a/crates/stoffel-vm/tests/aes_count.rs
+++ b/crates/stoffel-vm/tests/aes_count.rs
@@ -10,6 +10,11 @@ use stoffel_vm_types::core_types::{
     ClearShareInput, ClearShareValue, ShareData, ShareType, TableRef, Value,
 };
 
+/// HoneyBadger's default per-session pair limit at the benchmark topology
+/// threshold `t=1`: `128 * (t+1)`. Each chunk is awaited sequentially and is
+/// therefore one online communication round.
+const MODELED_MPC_BATCH_CAPACITY: usize = 256;
+
 #[derive(Default)]
 struct CountingEngine {
     scalar_mul_calls: AtomicUsize,
@@ -36,12 +41,24 @@ struct CountingEngine {
     // one batch call). pair_log: one row per multiply pair executed, tagging the
     // round it ran in, the output depth, and whether it had a public operand.
     call_seq: AtomicUsize,
+    pair_seq: AtomicUsize,
     pair_log: std::sync::Mutex<Vec<PairRecord>>,
+    /// One per scalar open or native batch-open invocation. HoneyBadger's batch
+    /// open sends all shares in one broadcast and has no multiply-style width
+    /// chunking, so every non-empty call is exactly one online round.
+    open_rounds: AtomicUsize,
+    scalar_open_rounds: AtomicUsize,
+    batch_open_rounds: AtomicUsize,
 }
 
 /// One executed multiply pair, for the per-depth round histogram.
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct PairRecord {
+    /// Stable multiplication-DAG node id.
+    pair_id: u32,
+    /// Multiplication nodes whose outputs feed this pair through zero or more
+    /// local operations. Redundant transitive parents are legal.
+    parents: Vec<u32>,
     /// Round id (one per scalar multiply call or per batch_multiply call).
     call_id: u32,
     /// Output (critical-path) depth of this pair: max(operand depths)+1.
@@ -52,6 +69,164 @@ struct PairRecord {
     both_public: bool,
 }
 
+/// Validate the executed multiplication DAG and return its critical-path depth.
+/// The packed frontier metadata follows dependencies through arbitrary local
+/// linear operations, so every parent edge must point to an earlier pair and
+/// reproduce the recorded `max(parent depth) + 1` depth exactly.
+fn validate_pair_dag(log: &[PairRecord]) -> usize {
+    let mut depths = Vec::with_capacity(log.len());
+    let mut calls = Vec::with_capacity(log.len());
+    for (expected_id, record) in log.iter().enumerate() {
+        assert_eq!(
+            record.pair_id as usize, expected_id,
+            "pair ids must be dense"
+        );
+        let mut parent_depth = 0u32;
+        for &parent in &record.parents {
+            let parent = parent as usize;
+            assert!(parent < expected_id, "DAG edge must point backward");
+            assert_ne!(
+                calls[parent], record.call_id,
+                "pairs in one MPC batch cannot depend on each other"
+            );
+            parent_depth = parent_depth.max(depths[parent]);
+        }
+        assert_eq!(
+            record.depth,
+            parent_depth + 1,
+            "recorded depth must equal the multiplication-DAG depth"
+        );
+        depths.push(record.depth);
+        calls.push(record.call_id);
+    }
+    depths.into_iter().max().unwrap_or(0) as usize
+}
+
+/// A legal capacity-aware list schedule of the executed multiplication DAG.
+/// Ready nodes with the longest remaining path are prioritized, which preserves
+/// scarce critical-path work while filling every protocol session when possible.
+fn dag_list_schedule_rounds(log: &[PairRecord], capacity: usize) -> usize {
+    assert!(capacity > 0);
+    if log.is_empty() {
+        return 0;
+    }
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut indegree = vec![0usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            successors[parent as usize].push(node);
+            indegree[node] += 1;
+        }
+    }
+    let mut bottom_level = vec![1usize; log.len()];
+    for node in (0..log.len()).rev() {
+        bottom_level[node] = 1 + successors[node]
+            .iter()
+            .map(|&successor| bottom_level[successor])
+            .max()
+            .unwrap_or(0);
+    }
+
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+    let mut ready = BinaryHeap::new();
+    for node in 0..log.len() {
+        if indegree[node] == 0 {
+            ready.push((bottom_level[node], Reverse(node)));
+        }
+    }
+    let mut scheduled = 0usize;
+    let mut rounds = 0usize;
+    while scheduled < log.len() {
+        assert!(!ready.is_empty(), "multiplication graph must be acyclic");
+        // Successors released by this session cannot execute until the next
+        // communication round, even if capacity remains in the current one.
+        let mut session = Vec::with_capacity(capacity.min(ready.len()));
+        for _ in 0..capacity {
+            let Some((_, Reverse(node))) = ready.pop() else {
+                break;
+            };
+            session.push(node);
+        }
+        scheduled += session.len();
+        rounds += 1;
+        for node in session {
+            for &successor in &successors[node] {
+                indegree[successor] -= 1;
+                if indegree[successor] == 0 {
+                    ready.push((bottom_level[successor], Reverse(successor)));
+                }
+            }
+        }
+    }
+    rounds
+}
+
+/// Exact minimum number of capacity-limited rounds for a small unit-time DAG.
+/// Used as a scheduler oracle in regression/property tests; exponential by
+/// design and deliberately limited to at most 63 nodes.
+fn exact_min_rounds(parents: &[u64], capacity: usize) -> usize {
+    assert!(!parents.is_empty());
+    assert!(parents.len() <= 63);
+    assert!(capacity > 0);
+    let all = (1u64 << parents.len()) - 1;
+    let mut memo = std::collections::HashMap::new();
+
+    fn solve(
+        done: u64,
+        all: u64,
+        parents: &[u64],
+        capacity: usize,
+        memo: &mut std::collections::HashMap<u64, usize>,
+    ) -> usize {
+        if done == all {
+            return 0;
+        }
+        if let Some(&cached) = memo.get(&done) {
+            return cached;
+        }
+        let mut ready = 0u64;
+        for (node, &deps) in parents.iter().enumerate() {
+            let bit = 1u64 << node;
+            if done & bit == 0 && deps & !done == 0 {
+                ready |= bit;
+            }
+        }
+        assert_ne!(ready, 0, "input must be an acyclic graph");
+
+        let ready_count = ready.count_ones() as usize;
+        let mut best = usize::MAX;
+        if ready_count <= capacity {
+            best = 1 + solve(done | ready, all, parents, capacity, memo);
+        } else {
+            // An optimal unit-task schedule can be work-conserving. Enumerate
+            // every capacity-sized choice from the ready set; choice still
+            // matters because different nodes unlock different successors.
+            fn choose(candidates: u64, need: usize, picked: u64, visit: &mut impl FnMut(u64)) {
+                if need == 0 {
+                    visit(picked);
+                    return;
+                }
+                if (candidates.count_ones() as usize) < need {
+                    return;
+                }
+                let bit = candidates & candidates.wrapping_neg();
+                let rest = candidates ^ bit;
+                choose(rest, need - 1, picked | bit, visit);
+                choose(rest, need, picked, visit);
+            }
+            choose(ready, capacity, 0, &mut |round| {
+                best = best.min(1 + solve(done | round, all, parents, capacity, memo));
+            });
+        }
+        memo.insert(done, best);
+        best
+    }
+
+    solve(0, all, parents, capacity, &mut memo)
+}
+
 impl CountingEngine {
     fn counts(&self) -> (usize, usize, usize) {
         (
@@ -59,6 +234,31 @@ impl CountingEngine {
             self.batch_mul_calls.load(Ordering::SeqCst),
             self.batch_mul_items.load(Ordering::SeqCst),
         )
+    }
+
+    fn protocol_rounds(&self) -> usize {
+        self.call_seq.load(Ordering::SeqCst)
+    }
+
+    fn open_protocol_rounds(&self) -> usize {
+        self.open_rounds.load(Ordering::SeqCst)
+    }
+
+    fn open_protocol_breakdown(&self) -> (usize, usize) {
+        (
+            self.scalar_open_rounds.load(Ordering::SeqCst),
+            self.batch_open_rounds.load(Ordering::SeqCst),
+        )
+    }
+
+    fn record_scalar_open_round(&self) {
+        self.open_rounds.fetch_add(1, Ordering::SeqCst);
+        self.scalar_open_rounds.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn record_batch_open_round(&self) {
+        self.open_rounds.fetch_add(1, Ordering::SeqCst);
+        self.batch_open_rounds.fetch_add(1, Ordering::SeqCst);
     }
 
     /// (public_operand_muls, both_public_muls, max_mul_depth) — see field docs.
@@ -80,16 +280,24 @@ impl CountingEngine {
     }
 
     // --- Share metadata layout -------------------------------------------------
-    // Every share this engine emits is `[value, public, d0, d1, d2, d3]`:
+    // Every share this engine emits is
+    // `[value, public, d0..d3, parent_count0..3, parent_ids...]`:
     //   byte 0      : the GF(2) value bit (read by `bool_byte`, unchanged).
     //   byte 1      : public-literal taint flag (1 = traces to a literal through
     //                 only local ops).
     //   bytes 2..6  : critical-path multiply depth as u32 little-endian.
     // Legacy 1-byte shares (e.g. raw client inputs) decode as public=false,
     // depth=0, which is the correct default for a secret input.
-    fn pack(value: u8, public: bool, depth: u32) -> Vec<u8> {
+    fn pack(value: u8, public: bool, depth: u32, frontier: &[u32]) -> Vec<u8> {
         let d = depth.to_le_bytes();
-        vec![value & 1, u8::from(public), d[0], d[1], d[2], d[3]]
+        let count = (frontier.len() as u32).to_le_bytes();
+        let mut packed = Vec::with_capacity(10 + frontier.len() * 4);
+        packed.extend_from_slice(&[value & 1, u8::from(public), d[0], d[1], d[2], d[3]]);
+        packed.extend_from_slice(&count);
+        for parent in frontier {
+            packed.extend_from_slice(&parent.to_le_bytes());
+        }
+        packed
     }
 
     fn is_public(bytes: &[u8]) -> bool {
@@ -104,9 +312,33 @@ impl CountingEngine {
         }
     }
 
+    fn frontier_of(bytes: &[u8]) -> Vec<u32> {
+        if bytes.len() < 10 {
+            return Vec::new();
+        }
+        let count = u32::from_le_bytes([bytes[6], bytes[7], bytes[8], bytes[9]]) as usize;
+        let available = bytes.len().saturating_sub(10) / 4;
+        let mut frontier = Vec::with_capacity(count.min(available));
+        for chunk in bytes[10..].chunks_exact(4).take(count) {
+            frontier.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+        }
+        frontier
+    }
+
+    fn merged_frontier(left: &[u8], right: &[u8]) -> Vec<u32> {
+        let mut frontier = Self::frontier_of(left);
+        frontier.extend(Self::frontier_of(right));
+        frontier.sort_unstable();
+        frontier.dedup();
+        frontier
+    }
+
     /// Execute one secret multiply `ab`: compute its value, record lever-B and
     /// depth instrumentation, and return packed metadata for the product (a
-    /// product is never a public literal). Shared by scalar/async/batch paths.
+    /// product remains provably public when both operands are public, even if
+    /// the current compiler unnecessarily executes it interactively. Preserving
+    /// that fact exposes the complete downstream localization opportunity.
+    /// Shared by scalar/async/batch paths.
     fn record_multiply(&self, call_id: u32, left: &[u8], right: &[u8]) -> Vec<u8> {
         let value = Self::bool_byte(left) & Self::bool_byte(right);
         let out_depth = Self::depth_of(left).max(Self::depth_of(right)) + 1;
@@ -120,15 +352,19 @@ impl CountingEngine {
         if left_pub && right_pub {
             self.both_public_muls.fetch_add(1, Ordering::SeqCst);
         }
+        let pair_id = self.pair_seq.fetch_add(1, Ordering::SeqCst) as u32;
+        let parents = Self::merged_frontier(left, right);
         if let Ok(mut log) = self.pair_log.lock() {
             log.push(PairRecord {
+                pair_id,
+                parents,
                 call_id,
                 depth: out_depth,
                 pub_operand: left_pub || right_pub,
                 both_public: left_pub && right_pub,
             });
         }
-        Self::pack(value, false, out_depth)
+        Self::pack(value, left_pub && right_pub, out_depth, &[pair_id])
     }
 
     /// Allocate a fresh round id for one multiply call (scalar or batch).
@@ -144,7 +380,7 @@ impl CountingEngine {
             ClearShareValue::Boolean(value) => u8::from(value),
         };
         // A `from_clear` value is a compile-time public literal: public=true, depth 0.
-        ShareData::Opaque(Self::pack(byte, true, 0).into())
+        ShareData::Opaque(Self::pack(byte, true, 0, &[]).into())
     }
 
     fn open_bool(share_bytes: &[u8]) -> ClearShareValue {
@@ -174,7 +410,19 @@ impl MpcEngine for CountingEngine {
     }
 
     fn open_share(&self, _ty: ShareType, share_bytes: &[u8]) -> MpcEngineResult<ClearShareValue> {
+        self.record_scalar_open_round();
         Ok(Self::open_bool(share_bytes))
+    }
+
+    fn batch_open_shares(
+        &self,
+        _ty: ShareType,
+        shares: &[Vec<u8>],
+    ) -> MpcEngineResult<Vec<ClearShareValue>> {
+        if !shares.is_empty() {
+            self.record_batch_open_round();
+        }
+        Ok(shares.iter().map(|share| Self::open_bool(share)).collect())
     }
 
     fn capabilities(&self) -> MpcCapabilities {
@@ -195,7 +443,12 @@ impl MpcEngine for CountingEngine {
         let value = Self::bool_byte(lhs_bytes) ^ Self::bool_byte(rhs_bytes);
         let public = Self::is_public(lhs_bytes) && Self::is_public(rhs_bytes);
         let depth = Self::depth_of(lhs_bytes).max(Self::depth_of(rhs_bytes));
-        Ok(Self::pack(value, public, depth))
+        Ok(Self::pack(
+            value,
+            public,
+            depth,
+            &Self::merged_frontier(lhs_bytes, rhs_bytes),
+        ))
     }
 
     fn sub_share_local(
@@ -207,7 +460,12 @@ impl MpcEngine for CountingEngine {
         let value = Self::bool_byte(lhs_bytes) ^ Self::bool_byte(rhs_bytes);
         let public = Self::is_public(lhs_bytes) && Self::is_public(rhs_bytes);
         let depth = Self::depth_of(lhs_bytes).max(Self::depth_of(rhs_bytes));
-        Ok(Self::pack(value, public, depth))
+        Ok(Self::pack(
+            value,
+            public,
+            depth,
+            &Self::merged_frontier(lhs_bytes, rhs_bytes),
+        ))
     }
 
     fn neg_share_local(&self, _ty: ShareType, share_bytes: &[u8]) -> ShareAlgebraResult<Vec<u8>> {
@@ -216,6 +474,7 @@ impl MpcEngine for CountingEngine {
             Self::bool_byte(share_bytes),
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 
@@ -231,6 +490,7 @@ impl MpcEngine for CountingEngine {
             value,
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 
@@ -245,6 +505,7 @@ impl MpcEngine for CountingEngine {
             value,
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 
@@ -259,6 +520,7 @@ impl MpcEngine for CountingEngine {
             value,
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 
@@ -273,6 +535,7 @@ impl MpcEngine for CountingEngine {
             value,
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 
@@ -287,6 +550,7 @@ impl MpcEngine for CountingEngine {
             Self::bool_byte(share_bytes),
             Self::is_public(share_bytes),
             Self::depth_of(share_bytes),
+            &Self::frontier_of(share_bytes),
         ))
     }
 }
@@ -333,13 +597,14 @@ impl stoffel_vm::net::mpc_engine::AsyncMpcEngine for CountingEngine {
         self.batch_mul_calls.fetch_add(1, Ordering::SeqCst);
         self.batch_mul_items
             .fetch_add(pairs.len(), Ordering::SeqCst);
-        let call_id = self.next_call_id();
-        Ok(pairs
-            .iter()
-            .map(|(left, right)| {
+        let mut products = Vec::with_capacity(pairs.len());
+        for chunk in pairs.chunks(MODELED_MPC_BATCH_CAPACITY) {
+            let call_id = self.next_call_id();
+            products.extend(chunk.iter().map(|(left, right)| {
                 ShareData::Opaque(self.record_multiply(call_id, left, right).into())
-            })
-            .collect())
+            }));
+        }
+        Ok(products)
     }
 
     async fn open_share_async(
@@ -347,6 +612,7 @@ impl stoffel_vm::net::mpc_engine::AsyncMpcEngine for CountingEngine {
         _ty: ShareType,
         share_bytes: &[u8],
     ) -> MpcEngineResult<ClearShareValue> {
+        self.record_scalar_open_round();
         Ok(Self::open_bool(share_bytes))
     }
 
@@ -355,6 +621,9 @@ impl stoffel_vm::net::mpc_engine::AsyncMpcEngine for CountingEngine {
         _ty: ShareType,
         shares: &[Vec<u8>],
     ) -> MpcEngineResult<Vec<ClearShareValue>> {
+        if !shares.is_empty() {
+            self.record_batch_open_round();
+        }
         Ok(shares.iter().map(|share| Self::open_bool(share)).collect())
     }
 
@@ -389,6 +658,22 @@ where
         .expect("spawn large-stack test thread")
         .join()
         .expect("large-stack test thread panicked");
+}
+
+#[test]
+fn exact_capacity_scheduler_oracle_handles_precedence_and_choices() {
+    assert_eq!(exact_min_rounds(&[0, 0, 0, 0, 0], 2), 3);
+    assert_eq!(exact_min_rounds(&[0, 1 << 0, 1 << 1, 1 << 2], 2), 4);
+    assert_eq!(
+        exact_min_rounds(&[0, 1 << 0, 1 << 0, (1 << 1) | (1 << 2)], 2),
+        3
+    );
+
+    // Three roots compete for two slots. Scheduling node 0 immediately unlocks
+    // a two-node chain and finishes in three rounds; choosing roots 1+2 first
+    // takes four. The oracle must enumerate ready-set choices, not use a fixed
+    // source-order greedy policy.
+    assert_eq!(exact_min_rounds(&[0, 0, 0, 1 << 0, 1 << 3], 2), 3);
 }
 
 /// Regression test for the -O3 function inliner: a `secret`-typed helper that is
@@ -1193,9 +1478,9 @@ fn bits_as_bool_shares(bytes: &[u8]) -> Vec<stoffel_vm::ClientShare> {
 
 /// Compile `source` at the given optimization level, seed any client inputs,
 /// run `main` through the `CountingEngine`, and return
-/// `(mul_rounds, revealed_output)`. `mul_rounds` is the number of multiply
-/// communication rounds: scalar `multiply_share` calls (one round each) plus
-/// `batch_multiply_share` calls (one round each, regardless of batch size).
+/// `(mul_rounds, revealed_output)`. `mul_rounds` models backend protocol
+/// sessions: scalar calls cost one, and oversized batch calls cost one per
+/// sequential HoneyBadger capacity chunk.
 /// Lever-B / depth measurements for one (program, level) run.
 struct LeverMetrics {
     /// Multiply pairs with >=1 public-literal operand (lever B's headroom).
@@ -1260,10 +1545,9 @@ async fn round_gate_run(
         out.push(byte);
     }
 
-    let (scalar, batch_calls, _items) = engine.counts();
     let (public_operand_muls, both_public_muls, mul_depth) = engine.lever_b_counts();
     Ok((
-        scalar + batch_calls,
+        engine.protocol_rounds(),
         out,
         LeverMetrics {
             public_operand_muls,
@@ -1373,16 +1657,25 @@ async fn round_gate_impl() {
 //
 // For each program at -O3 this compiles + runs the live source through the
 // CountingEngine, then breaks the multiply ROUNDS down by critical-path output
-// depth. Each scalar multiply call or batch_multiply call is one round (one
-// `call_id`). For every output depth d it reports:
+// depth. Each backend protocol session is one round (`call_id`); an oversized
+// VM batch call contributes multiple sequential call ids. For every output
+// depth d it reports:
 //   pairs   = number of multiply pairs whose output depth is d
-//   ideal   = ceil(pairs/256)  (the minimum rounds depth d can take at the cap)
+//   layer_cap = ceil(pairs/256), a diagnostic packing count for that output
+//               depth (NOT a lower bound because one batch may mix depths)
 //   actual  = number of rounds whose pairs are (max-)at depth d
-//   waste   = actual - ideal   (recoverable rounds at this depth: lever 1/3/5)
+//   delta   = actual - layer_cap (fragmentation diagnostic only)
 //   pub     = pairs at depth d with a public operand (lever 4 headroom)
-// plus per-program totals: actual rounds, ideal floor (sum of per-depth ideals),
-// max depth, singleton rounds (a round of exactly 1 pair), and mixed-depth
-// rounds (a round whose pairs span more than one output depth).
+// The sound global lower bound is max(critical-path depth, ceil(total pairs/256)).
+// Unlike the former sum-of-depth-ceilings metric, this can never exceed a legal
+// schedule merely because a batch mixes output depths. The difference between
+// actual rounds and this bound is a certified *possible* improvement envelope,
+// not proof that every round in the envelope is achievable under precedence.
+// Opens are counted separately as full online sessions. They are not yet nodes
+// in the multiplication DAG (clear values cannot carry the opaque producer
+// frontier), so the certified lower/upper bounds below remain multiply-only and
+// `observed_online_sessions` is deliberately reported without claiming a full
+// interactive-DAG optimum.
 //
 // Run with:
 //   cargo test --release -p stoffel-vm --test aes_count round_histogram \
@@ -1392,7 +1685,7 @@ async fn histogram_run(
     source: &str,
     level: u8,
     client_inputs: &[(usize, Vec<stoffel_vm::ClientShare>)],
-) -> Result<(usize, Vec<i64>, Vec<PairRecord>), String> {
+) -> Result<(usize, usize, usize, usize, Vec<i64>, Vec<PairRecord>), String> {
     let options = stoffellang::CompilerOptions {
         optimize: level > 0,
         optimization_level: level,
@@ -1441,12 +1734,28 @@ async fn histogram_run(
         };
         out.push(byte);
     }
-    let (scalar, batch_calls, _items) = engine.counts();
-    Ok((scalar + batch_calls, out, engine.pair_log_snapshot()))
+    let (scalar_opens, batch_opens) = engine.open_protocol_breakdown();
+    Ok((
+        engine.protocol_rounds(),
+        engine.open_protocol_rounds(),
+        scalar_opens,
+        batch_opens,
+        out,
+        engine.pair_log_snapshot(),
+    ))
 }
 
-fn print_depth_histogram(label: &str, rounds: usize, correct: bool, log: &[PairRecord]) {
+fn print_depth_histogram(
+    label: &str,
+    rounds: usize,
+    open_rounds: usize,
+    scalar_opens: usize,
+    batch_opens: usize,
+    correct: bool,
+    log: &[PairRecord],
+) {
     use std::collections::BTreeMap;
+    let dag_critical_path = validate_pair_dag(log);
     // Per output depth: total pairs, pairs with a public operand.
     let mut pairs_at: BTreeMap<u32, usize> = BTreeMap::new();
     let mut pub_at: BTreeMap<u32, usize> = BTreeMap::new();
@@ -1481,7 +1790,6 @@ fn print_depth_histogram(label: &str, rounds: usize, correct: bool, log: &[PairR
             mixed_rounds += 1;
         }
     }
-    let mut ideal_total = 0usize;
     let depths: Vec<u32> = pairs_at.keys().copied().collect();
     println!(
         "HIST {label} O3 rounds={rounds} correct={correct} pairs={} max_depth={} pub_pairs={} both_public={}",
@@ -1490,23 +1798,44 @@ fn print_depth_histogram(label: &str, rounds: usize, correct: bool, log: &[PairR
         total_pub,
         total_both,
     );
-    println!("HIST {label} depth | pairs | ideal | actual | waste | pub");
+    println!("HIST {label} depth | pairs | layer_cap | actual | delta | pub");
     for d in &depths {
         let pairs = pairs_at[d];
-        let ideal = pairs.div_ceil(256);
-        ideal_total += ideal;
+        let layer_cap = pairs.div_ceil(256);
         let actual = actual_at.get(d).copied().unwrap_or(0);
         let pub_pairs = pub_at.get(d).copied().unwrap_or(0);
-        let waste = actual as i64 - ideal as i64;
+        let delta = actual as i64 - layer_cap as i64;
         println!(
-            "HIST {label}  {d:>4} | {pairs:>5} | {ideal:>5} | {actual:>6} | {waste:>5} | {pub_pairs:>5}"
+            "HIST {label}  {d:>4} | {pairs:>5} | {layer_cap:>9} | {actual:>6} | {delta:>5} | {pub_pairs:>5}"
         );
     }
-    let total_waste = rounds as i64 - ideal_total as i64;
+    let critical_path = depths.last().copied().unwrap_or(0) as usize;
+    assert_eq!(
+        critical_path, dag_critical_path,
+        "histogram and explicit DAG critical paths must agree"
+    );
+    let work_bound = log.len().div_ceil(MODELED_MPC_BATCH_CAPACITY);
+    let sound_lower_bound = critical_path.max(work_bound);
+    let dag_list_upper = dag_list_schedule_rounds(log, MODELED_MPC_BATCH_CAPACITY);
+    assert!(
+        rounds >= sound_lower_bound,
+        "observed schedule cannot beat its critical-path/work lower bound"
+    );
+    assert!(
+        dag_list_upper >= sound_lower_bound,
+        "a legal DAG schedule cannot beat the sound lower bound"
+    );
     println!(
-        "HIST {label} TOTALS actual_rounds={rounds} ideal_floor={ideal_total} waste={total_waste} \
-distinct_depths={} singleton_rounds={singleton_rounds} mixed_depth_rounds={mixed_rounds}",
+        "HIST {label} TOTALS actual_rounds={rounds} sound_lb={sound_lower_bound} \
+certified_gap={} dag_list_upper={dag_list_upper} dag_sched_gap={} \
+critical_path={critical_path} work_bound={work_bound} \
+distinct_depths={} singleton_rounds={singleton_rounds} mixed_depth_rounds={mixed_rounds} \
+open_rounds={open_rounds} scalar_opens={scalar_opens} batch_opens={batch_opens} \
+observed_online_sessions={}",
+        rounds - sound_lower_bound,
+        rounds.saturating_sub(dag_list_upper),
         depths.len(),
+        rounds + open_rounds,
     );
     println!();
 }
@@ -1545,9 +1874,17 @@ async fn round_histogram_impl() {
 
     for (label, source, inputs, expected) in &programs {
         match histogram_run(source, 3, inputs).await {
-            Ok((rounds, output, log)) => {
+            Ok((rounds, open_rounds, scalar_opens, batch_opens, output, log)) => {
                 let correct = output == *expected;
-                print_depth_histogram(label, rounds, correct, &log);
+                print_depth_histogram(
+                    label,
+                    rounds,
+                    open_rounds,
+                    scalar_opens,
+                    batch_opens,
+                    correct,
+                    &log,
+                );
                 assert!(correct, "{label} O3 must match its NIST output");
             }
             Err(error) => {

--- a/crates/stoffel-vm/tests/aes_count.rs
+++ b/crates/stoffel-vm/tests/aes_count.rs
@@ -6,9 +6,11 @@ use stoffel_vm::net::mpc_engine::{
     MpcCapabilities, MpcEngine, MpcEngineMultiplication, MpcEngineResult, MpcSessionTopology,
     ShareAlgebraResult,
 };
+use stoffel_vm::runtime_hooks::HookEvent;
 use stoffel_vm_types::core_types::{
     ClearShareInput, ClearShareValue, ShareData, ShareType, TableRef, Value,
 };
+use stoffel_vm_types::instructions::Instruction;
 
 /// HoneyBadger's default per-session pair limit at the benchmark topology
 /// threshold `t=1`: `128 * (t+1)`. Each chunk is awaited sequentially and is
@@ -85,9 +87,9 @@ fn validate_pair_dag(log: &[PairRecord]) -> usize {
         for &parent in &record.parents {
             let parent = parent as usize;
             assert!(parent < expected_id, "DAG edge must point backward");
-            assert_ne!(
-                calls[parent], record.call_id,
-                "pairs in one MPC batch cannot depend on each other"
+            assert!(
+                calls[parent] < record.call_id,
+                "a multiplication must execute strictly after every parent round"
             );
             parent_depth = parent_depth.max(depths[parent]);
         }
@@ -102,13 +104,43 @@ fn validate_pair_dag(log: &[PairRecord]) -> usize {
     depths.into_iter().max().unwrap_or(0) as usize
 }
 
+fn weak_component_sizes(log: &[PairRecord]) -> Vec<usize> {
+    fn find(parents: &mut [usize], mut node: usize) -> usize {
+        while parents[node] != node {
+            parents[node] = parents[parents[node]];
+            node = parents[node];
+        }
+        node
+    }
+
+    let mut components: Vec<_> = (0..log.len()).collect();
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            let left = find(&mut components, node);
+            let right = find(&mut components, parent as usize);
+            if left != right {
+                components[right] = left;
+            }
+        }
+    }
+    let mut sizes = std::collections::BTreeMap::new();
+    for node in 0..log.len() {
+        let root = find(&mut components, node);
+        *sizes.entry(root).or_insert(0usize) += 1;
+    }
+    let mut sizes: Vec<_> = sizes.into_values().collect();
+    sizes.sort_unstable_by(|left, right| right.cmp(left));
+    sizes
+}
+
 /// A legal capacity-aware list schedule of the executed multiplication DAG.
 /// Ready nodes with the longest remaining path are prioritized, which preserves
 /// scarce critical-path work while filling every protocol session when possible.
-fn dag_list_schedule_rounds(log: &[PairRecord], capacity: usize) -> usize {
+fn dag_list_schedule(log: &[PairRecord], capacity: usize) -> Vec<Vec<usize>> {
     assert!(capacity > 0);
     if log.is_empty() {
-        return 0;
+        return Vec::new();
     }
     let mut successors = vec![Vec::new(); log.len()];
     let mut indegree = vec![0usize; log.len()];
@@ -137,7 +169,7 @@ fn dag_list_schedule_rounds(log: &[PairRecord], capacity: usize) -> usize {
         }
     }
     let mut scheduled = 0usize;
-    let mut rounds = 0usize;
+    let mut rounds = Vec::new();
     while scheduled < log.len() {
         assert!(!ready.is_empty(), "multiplication graph must be acyclic");
         // Successors released by this session cannot execute until the next
@@ -150,8 +182,7 @@ fn dag_list_schedule_rounds(log: &[PairRecord], capacity: usize) -> usize {
             session.push(node);
         }
         scheduled += session.len();
-        rounds += 1;
-        for node in session {
+        for &node in &session {
             for &successor in &successors[node] {
                 indegree[successor] -= 1;
                 if indegree[successor] == 0 {
@@ -159,8 +190,918 @@ fn dag_list_schedule_rounds(log: &[PairRecord], capacity: usize) -> usize {
                 }
             }
         }
+        rounds.push(session);
     }
     rounds
+}
+
+/// Mirror-image list schedule built from the sinks backwards. A forward
+/// critical-path heuristic can make locally reasonable choices that create a
+/// sparse drain; scheduling the reversed DAG independently is a cheap generic
+/// way to expose that asymmetry. Returned rounds are restored to forward order.
+fn dag_backward_list_schedule(log: &[PairRecord], capacity: usize) -> Vec<Vec<usize>> {
+    dag_backward_priority_list_schedule(log, capacity, BackwardPriority::SourceOrder)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BackwardPriority {
+    SourceOrder,
+    CriticalPredecessorFanIn,
+}
+
+fn dag_backward_priority_list_schedule(
+    log: &[PairRecord],
+    capacity: usize,
+    priority: BackwardPriority,
+) -> Vec<Vec<usize>> {
+    assert!(capacity > 0);
+    if log.is_empty() {
+        return Vec::new();
+    }
+    let mut remaining_successors = vec![0usize; log.len()];
+    for record in log {
+        for &parent in &record.parents {
+            remaining_successors[parent as usize] += 1;
+        }
+    }
+    let critical_predecessor_count: Vec<_> = log
+        .iter()
+        .map(|record| {
+            record
+                .parents
+                .iter()
+                .filter(|&&parent| log[parent as usize].depth + 1 == record.depth)
+                .count()
+        })
+        .collect();
+    let key = |node: usize| {
+        let ascending = usize::MAX - node;
+        match priority {
+            BackwardPriority::SourceOrder => [log[node].depth as usize, 0, 0, 0, 0, ascending],
+            BackwardPriority::CriticalPredecessorFanIn => [
+                log[node].depth as usize,
+                critical_predecessor_count[node],
+                log[node].parents.len(),
+                0,
+                0,
+                ascending,
+            ],
+        }
+    };
+
+    use std::collections::BinaryHeap;
+    let mut ready = BinaryHeap::new();
+    for node in 0..log.len() {
+        if remaining_successors[node] == 0 {
+            // `depth` is the reverse problem's bottom level.
+            ready.push((key(node), node));
+        }
+    }
+    let mut scheduled = 0usize;
+    let mut reverse_rounds = Vec::new();
+    while scheduled < log.len() {
+        assert!(!ready.is_empty(), "multiplication graph must be acyclic");
+        let mut round = Vec::with_capacity(capacity.min(ready.len()));
+        for _ in 0..capacity {
+            let Some((_, node)) = ready.pop() else {
+                break;
+            };
+            round.push(node);
+        }
+        scheduled += round.len();
+        for &node in &round {
+            for &parent in &log[node].parents {
+                let parent = parent as usize;
+                remaining_successors[parent] -= 1;
+                if remaining_successors[parent] == 0 {
+                    ready.push((key(parent), parent));
+                }
+            }
+        }
+        reverse_rounds.push(round);
+    }
+    reverse_rounds.reverse();
+    reverse_rounds
+}
+
+/// Forward list scheduling prioritized by the round assigned by an independent
+/// legal backward schedule. The reverse pass gives prerequisites of congested
+/// sink regions earlier deadlines than bottom level alone can express.
+fn dag_backward_deadline_schedule(log: &[PairRecord], capacity: usize) -> Vec<Vec<usize>> {
+    assert!(capacity > 0);
+    if log.is_empty() {
+        return Vec::new();
+    }
+    let backward = dag_backward_list_schedule(log, capacity);
+    dag_forward_from_backward_schedule(log, capacity, &backward)
+}
+
+fn dag_forward_from_backward_schedule(
+    log: &[PairRecord],
+    capacity: usize,
+    backward: &[Vec<usize>],
+) -> Vec<Vec<usize>> {
+    let mut deadline = vec![usize::MAX; log.len()];
+    for (round, nodes) in backward.iter().enumerate() {
+        for &node in nodes {
+            deadline[node] = round;
+        }
+    }
+
+    dag_forward_by_deadlines(log, capacity, &deadline)
+}
+
+fn dag_forward_by_deadlines(
+    log: &[PairRecord],
+    capacity: usize,
+    deadline: &[usize],
+) -> Vec<Vec<usize>> {
+    assert_eq!(log.len(), deadline.len());
+
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut indegree = vec![0usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            successors[parent as usize].push(node);
+            indegree[node] += 1;
+        }
+    }
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+    let mut ready = BinaryHeap::new();
+    for node in 0..log.len() {
+        if indegree[node] == 0 {
+            ready.push((Reverse(deadline[node]), Reverse(node)));
+        }
+    }
+    let mut scheduled = 0usize;
+    let mut rounds = Vec::new();
+    while scheduled < log.len() {
+        assert!(!ready.is_empty(), "multiplication graph must be acyclic");
+        let mut round = Vec::with_capacity(capacity.min(ready.len()));
+        for _ in 0..capacity {
+            let Some((_, Reverse(node))) = ready.pop() else {
+                break;
+            };
+            round.push(node);
+        }
+        scheduled += round.len();
+        for &node in &round {
+            for &successor in &successors[node] {
+                indegree[successor] -= 1;
+                if indegree[successor] == 0 {
+                    ready.push((Reverse(deadline[successor]), Reverse(successor)));
+                }
+            }
+        }
+        rounds.push(round);
+    }
+    rounds
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DagListPriority {
+    BottomSourceAscending,
+    BottomHighFanout,
+    BottomSuccessorPressure,
+}
+
+/// Deterministic priority variants used to challenge the production list
+/// schedule against the same legal DAG. This is intentionally generic: no
+/// source-function, AES, or lane identities participate in a priority.
+fn dag_priority_list_schedule(
+    log: &[PairRecord],
+    capacity: usize,
+    priority: DagListPriority,
+) -> (Vec<Vec<usize>>, Vec<usize>) {
+    assert!(capacity > 0);
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut indegree = vec![0usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            successors[parent as usize].push(node);
+            indegree[node] += 1;
+        }
+    }
+    let mut bottom = vec![1usize; log.len()];
+    for node in (0..log.len()).rev() {
+        bottom[node] = 1 + successors[node]
+            .iter()
+            .map(|&successor| bottom[successor])
+            .max()
+            .unwrap_or(0);
+    }
+    let original_indegree = indegree.clone();
+    let successor_pressure: Vec<_> = successors
+        .iter()
+        .map(|children| {
+            children
+                .iter()
+                .map(|&child| 1024 / original_indegree[child].max(1))
+                .sum::<usize>()
+        })
+        .collect();
+    let key = |node: usize| {
+        let ascending = usize::MAX - node;
+        match priority {
+            DagListPriority::BottomSourceAscending => (bottom[node], 0, 0, ascending),
+            DagListPriority::BottomHighFanout => {
+                (bottom[node], successors[node].len(), 0, ascending)
+            }
+            DagListPriority::BottomSuccessorPressure => {
+                (bottom[node], successor_pressure[node], 0, ascending)
+            }
+        }
+    };
+
+    let mut ready = std::collections::BinaryHeap::new();
+    for node in 0..log.len() {
+        if indegree[node] == 0 {
+            ready.push((key(node), node));
+        }
+    }
+    let mut rounds = Vec::new();
+    let mut ready_counts = Vec::new();
+    let mut scheduled = 0usize;
+    while scheduled < log.len() {
+        assert!(!ready.is_empty(), "multiplication graph must be acyclic");
+        ready_counts.push(ready.len());
+        let mut round = Vec::with_capacity(capacity.min(ready.len()));
+        for _ in 0..capacity {
+            let Some((_, node)) = ready.pop() else {
+                break;
+            };
+            round.push(node);
+        }
+        scheduled += round.len();
+        for &node in &round {
+            for &successor in &successors[node] {
+                indegree[successor] -= 1;
+                if indegree[successor] == 0 {
+                    ready.push((key(successor), successor));
+                }
+            }
+        }
+        rounds.push(round);
+    }
+    (rounds, ready_counts)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct WindowCapacityWitness {
+    /// Candidate schedule length disproved by this witness.
+    horizon: usize,
+    /// Inclusive interval of online rounds that must contain `forced_work`.
+    first_round: usize,
+    last_round: usize,
+    forced_work: usize,
+    interval_capacity: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PivotCapacityWitness {
+    pivot: usize,
+    ancestors: usize,
+    descendants: usize,
+    lower_bound: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ChainPartitionWitness {
+    lower_bound: usize,
+    /// Multiplication node ids used as ordered separator pivots.
+    pivots: Vec<usize>,
+}
+
+/// Capacity/depth lower bound obtained by partitioning the DAG around an
+/// ordered chain of multiplication pivots.
+///
+/// For pivots `p < q`, every node that is both a descendant of `p` and an
+/// ancestor of `q` must execute strictly between their rounds. Different
+/// consecutive pivot intervals are disjoint. Each interval therefore needs at
+/// least the larger of its capacity work bound and its chain-depth bound; the
+/// same argument applies before the first and after the last pivot. Dynamic
+/// programming chooses the strongest partition of one critical chain.
+fn critical_chain_partition_lower_bound(
+    log: &[PairRecord],
+    capacity: usize,
+) -> ChainPartitionWitness {
+    assert!(!log.is_empty());
+    assert!(capacity > 0);
+
+    let mut pivot = log
+        .iter()
+        .max_by_key(|record| record.depth)
+        .expect("non-empty multiplication log")
+        .pair_id as usize;
+    let mut chain = vec![pivot];
+    while let Some(parent) = log[pivot]
+        .parents
+        .iter()
+        .copied()
+        .max_by_key(|&parent| log[parent as usize].depth)
+    {
+        pivot = parent as usize;
+        chain.push(pivot);
+    }
+    chain.reverse();
+    let chain_len = chain.len();
+    assert_eq!(
+        chain_len,
+        log.iter().map(|record| record.depth).max().unwrap() as usize,
+        "chosen parent path must realize the recorded critical depth"
+    );
+
+    let none = chain_len;
+    let mut chain_index = vec![none; log.len()];
+    for (index, &node) in chain.iter().enumerate() {
+        chain_index[node] = index;
+    }
+
+    // Greatest chain pivot known to precede each node (a chain-prefix label).
+    let mut latest_ancestor = vec![none; log.len()];
+    for node in 0..log.len() {
+        let mut latest = chain_index[node];
+        for &parent in &log[node].parents {
+            let parent_latest = latest_ancestor[parent as usize];
+            if parent_latest != none && (latest == none || parent_latest > latest) {
+                latest = parent_latest;
+            }
+        }
+        latest_ancestor[node] = latest;
+    }
+
+    // Earliest chain pivot known to succeed each node (a chain-suffix label).
+    // Reverse topological propagation avoids materializing a second successor
+    // graph for the large measured circuits.
+    let mut earliest_descendant = chain_index.clone();
+    for node in (0..log.len()).rev() {
+        let earliest = earliest_descendant[node];
+        if earliest == none {
+            continue;
+        }
+        for &parent in &log[node].parents {
+            let parent = parent as usize;
+            earliest_descendant[parent] = earliest_descendant[parent].min(earliest);
+        }
+    }
+
+    let stride = chain_len + 1;
+    let cell = |row: usize, column: usize| row * stride + column;
+    let mut between = vec![0usize; stride * stride];
+    let mut ancestors_through = vec![0usize; chain_len];
+    let mut descendants_from = vec![0usize; chain_len];
+    for node in 0..log.len() {
+        let latest = latest_ancestor[node];
+        let earliest = earliest_descendant[node];
+        if latest != none && earliest != none {
+            between[cell(latest, earliest)] += 1;
+        }
+        if earliest != none {
+            ancestors_through[earliest] += 1;
+        }
+        if latest != none {
+            descendants_from[latest] += 1;
+        }
+    }
+    for index in 1..chain_len {
+        ancestors_through[index] += ancestors_through[index - 1];
+    }
+    for index in (0..chain_len.saturating_sub(1)).rev() {
+        descendants_from[index] += descendants_from[index + 1];
+    }
+    // Query count(latest_ancestor >= i && earliest_descendant <= j).
+    for latest in (0..chain_len).rev() {
+        for earliest in 0..chain_len {
+            let below = (latest + 1 < chain_len).then(|| between[cell(latest + 1, earliest)]);
+            let left = (earliest > 0).then(|| between[cell(latest, earliest - 1)]);
+            let diagonal = (latest + 1 < chain_len && earliest > 0)
+                .then(|| between[cell(latest + 1, earliest - 1)]);
+            between[cell(latest, earliest)] =
+                between[cell(latest, earliest)] + below.unwrap_or(0) + left.unwrap_or(0)
+                    - diagonal.unwrap_or(0);
+        }
+    }
+
+    let mut best_through = vec![0usize; chain_len];
+    let mut predecessor = vec![None; chain_len];
+    for last in 0..chain_len {
+        let strict_ancestors = ancestors_through[last] - 1;
+        best_through[last] = last.max(strict_ancestors.div_ceil(capacity)) + 1;
+        for previous in 0..last {
+            let strict_interior = between[cell(previous, last)] - 2;
+            let interval_rounds = (last - previous - 1).max(strict_interior.div_ceil(capacity));
+            let candidate = best_through[previous] + interval_rounds + 1;
+            if candidate > best_through[last] {
+                best_through[last] = candidate;
+                predecessor[last] = Some(previous);
+            }
+        }
+    }
+
+    let (mut last, lower_bound) = (0..chain_len)
+        .map(|last| {
+            let strict_descendants = descendants_from[last] - 1;
+            let suffix_rounds = (chain_len - last - 1).max(strict_descendants.div_ceil(capacity));
+            (last, best_through[last] + suffix_rounds)
+        })
+        .max_by_key(|(_, bound)| *bound)
+        .expect("critical chain is non-empty");
+    let mut pivots = vec![chain[last]];
+    while let Some(previous) = predecessor[last] {
+        last = previous;
+        pivots.push(chain[last]);
+    }
+    pivots.reverse();
+    ChainPartitionWitness {
+        lower_bound,
+        pivots,
+    }
+}
+
+/// Resource lower bound around one precedence pivot. Every strict ancestor of
+/// `v` must occupy a round before `v`, and every strict descendant must occupy a
+/// round after it. Those three regions are disjoint, so
+///
+///   ceil(|anc(v)| / capacity) + 1 + ceil(|desc(v)| / capacity)
+///
+/// is a sound makespan lower bound. We evaluate every node on one longest chain;
+/// this is inexpensive for the large AES-family DAGs and each returned witness
+/// remains independently checkable without trusting the candidate selection.
+fn critical_chain_pivot_lower_bound(log: &[PairRecord], capacity: usize) -> PivotCapacityWitness {
+    assert!(!log.is_empty());
+    assert!(capacity > 0);
+    let mut successors = vec![Vec::new(); log.len()];
+    for record in log {
+        for &parent in &record.parents {
+            successors[parent as usize].push(record.pair_id as usize);
+        }
+    }
+
+    let mut pivot = log
+        .iter()
+        .max_by_key(|record| record.depth)
+        .expect("non-empty multiplication log")
+        .pair_id as usize;
+    let mut chain = vec![pivot];
+    while let Some(parent) = log[pivot]
+        .parents
+        .iter()
+        .copied()
+        .max_by_key(|&parent| log[parent as usize].depth)
+    {
+        pivot = parent as usize;
+        chain.push(pivot);
+    }
+
+    let mut visited = vec![0u32; log.len()];
+    let mut generation = 0u32;
+    let mut count_reachable = |root: usize, reverse: bool| {
+        generation = generation.wrapping_add(1);
+        if generation == 0 {
+            visited.fill(0);
+            generation = 1;
+        }
+        let mut count = 0usize;
+        let mut pending = Vec::new();
+        if reverse {
+            pending.extend(log[root].parents.iter().map(|&parent| parent as usize));
+        } else {
+            pending.extend(successors[root].iter().copied());
+        }
+        while let Some(node) = pending.pop() {
+            if visited[node] == generation {
+                continue;
+            }
+            visited[node] = generation;
+            count += 1;
+            if reverse {
+                pending.extend(log[node].parents.iter().map(|&parent| parent as usize));
+            } else {
+                pending.extend(successors[node].iter().copied());
+            }
+        }
+        count
+    };
+
+    chain
+        .into_iter()
+        .map(|pivot| {
+            let ancestors = count_reachable(pivot, true);
+            let descendants = count_reachable(pivot, false);
+            PivotCapacityWitness {
+                pivot,
+                ancestors,
+                descendants,
+                lower_bound: ancestors.div_ceil(capacity) + 1 + descendants.div_ceil(capacity),
+            }
+        })
+        .max_by_key(|witness| witness.lower_bound)
+        .expect("critical chain contains a pivot")
+}
+
+/// Return a precedence/capacity certificate that `horizon` multiply rounds are
+/// impossible, when the standard earliest/latest time-window relaxation can
+/// prove it.
+///
+/// For every unit-time multiplication `v`, `top[v]` is its earliest legal round
+/// and `horizon - bottom[v] + 1` is its latest legal round. Therefore every node
+/// whose complete legal window is contained in `[a, b]` is forced to execute in
+/// that interval. More than `capacity * (b - a + 1)` such nodes is a sound
+/// contradiction for *every* scheduler, independent of source order or the
+/// heuristic used to construct the observed schedule.
+fn window_capacity_witness(
+    log: &[PairRecord],
+    capacity: usize,
+    horizon: usize,
+) -> Option<WindowCapacityWitness> {
+    assert!(capacity > 0);
+    if log.is_empty() {
+        return None;
+    }
+
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut top = vec![1usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            successors[parent as usize].push(node);
+            top[node] = top[node].max(top[parent as usize] + 1);
+        }
+    }
+    let mut bottom = vec![1usize; log.len()];
+    for node in (0..log.len()).rev() {
+        bottom[node] = 1 + successors[node]
+            .iter()
+            .map(|&successor| bottom[successor])
+            .max()
+            .unwrap_or(0);
+    }
+
+    window_capacity_witness_for_bounds(&top, &bottom, capacity, horizon)
+}
+
+/// Earliest possible completion round for unit jobs with individual release
+/// rounds on `capacity` identical lanes. Dependencies among those jobs are
+/// deliberately ignored, making this a relaxation and therefore a lower bound.
+fn released_work_completion_round(
+    release_rounds: impl Iterator<Item = usize>,
+    capacity: usize,
+) -> usize {
+    let mut releases: Vec<_> = release_rounds.collect();
+    if releases.is_empty() {
+        return 0;
+    }
+    releases.sort_unstable();
+    releases
+        .iter()
+        .enumerate()
+        .map(|(index, &release)| release + (releases.len() - index).div_ceil(capacity) - 1)
+        .max()
+        .expect("non-empty release list")
+}
+
+/// Strengthen precedence-only earliest/latest rounds with capacity-aware
+/// release-time facts. Every predecessor of `v` must finish before `v`; even
+/// after dependencies among those predecessors are relaxed away, their own
+/// earliest rounds and the finite lane count impose a minimum completion time.
+/// The reverse statement holds for successors. This is stronger than merely
+/// counting fan-in/fan-out and remains a scheduler-independent lower bound.
+fn resource_window_capacity_witness(
+    log: &[PairRecord],
+    capacity: usize,
+    horizon: usize,
+) -> Option<WindowCapacityWitness> {
+    assert!(capacity > 0);
+    if log.is_empty() {
+        return None;
+    }
+
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut top = vec![1usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            let parent = parent as usize;
+            successors[parent].push(node);
+        }
+        if !record.parents.is_empty() {
+            top[node] = released_work_completion_round(
+                record.parents.iter().map(|&parent| top[parent as usize]),
+                capacity,
+            ) + 1;
+        }
+    }
+    let mut bottom = vec![1usize; log.len()];
+    for node in (0..log.len()).rev() {
+        if !successors[node].is_empty() {
+            bottom[node] = released_work_completion_round(
+                successors[node].iter().map(|&successor| bottom[successor]),
+                capacity,
+            ) + 1;
+        }
+    }
+
+    window_capacity_witness_for_bounds(&top, &bottom, capacity, horizon)
+}
+
+fn window_capacity_witness_for_bounds(
+    top: &[usize],
+    bottom: &[usize],
+    capacity: usize,
+    horizon: usize,
+) -> Option<WindowCapacityWitness> {
+    assert_eq!(top.len(), bottom.len());
+
+    // A node with an empty legal window is itself a critical-path certificate.
+    for node in 0..top.len() {
+        let Some(latest) = horizon.checked_sub(bottom[node]).map(|v| v + 1) else {
+            return Some(WindowCapacityWitness {
+                horizon,
+                first_round: top[node],
+                last_round: top[node],
+                forced_work: 1,
+                interval_capacity: 0,
+            });
+        };
+        if top[node] > latest {
+            return Some(WindowCapacityWitness {
+                horizon,
+                first_round: latest,
+                last_round: top[node],
+                forced_work: 1,
+                interval_capacity: 0,
+            });
+        }
+    }
+
+    // grid[earliest][latest] counts jobs with that complete legal window. The
+    // two-dimensional suffix/prefix sum below answers
+    //   count(earliest >= a && latest <= b)
+    // in O(1), allowing every interval to be checked in O(horizon^2).
+    let stride = horizon + 2;
+    let mut forced = vec![0usize; stride * stride];
+    let cell = |row: usize, column: usize| row * stride + column;
+    for node in 0..top.len() {
+        let latest = horizon - bottom[node] + 1;
+        forced[cell(top[node], latest)] += 1;
+    }
+    for earliest in (1..=horizon).rev() {
+        for latest in 1..=horizon {
+            forced[cell(earliest, latest)] = forced[cell(earliest, latest)]
+                + forced[cell(earliest + 1, latest)]
+                + forced[cell(earliest, latest - 1)]
+                - forced[cell(earliest + 1, latest - 1)];
+        }
+    }
+
+    let mut strongest = None;
+    for first_round in 1..=horizon {
+        for last_round in first_round..=horizon {
+            let forced_work = forced[cell(first_round, last_round)];
+            let interval_capacity = capacity * (last_round - first_round + 1);
+            if forced_work > interval_capacity
+                && strongest.is_none_or(|prior: WindowCapacityWitness| {
+                    forced_work - interval_capacity > prior.forced_work - prior.interval_capacity
+                })
+            {
+                strongest = Some(WindowCapacityWitness {
+                    horizon,
+                    first_round,
+                    last_round,
+                    forced_work,
+                    interval_capacity,
+                });
+            }
+        }
+    }
+    strongest
+}
+
+/// Strongest sound lower bound obtained by disproving candidate horizons with
+/// precedence time-window density. `legal_upper_bound` is an already-validated
+/// schedule, so the result can never exceed it.
+fn window_capacity_lower_bound(
+    log: &[PairRecord],
+    capacity: usize,
+    legal_upper_bound: usize,
+) -> (usize, Option<WindowCapacityWitness>) {
+    let critical_path = validate_pair_dag(log);
+    let work_bound = log.len().div_ceil(capacity);
+    let basic_bound = critical_path.max(work_bound);
+    let mut lower_bound = basic_bound;
+    let mut strongest_witness = None;
+    for horizon in basic_bound..legal_upper_bound {
+        if let Some(witness) = window_capacity_witness(log, capacity, horizon) {
+            lower_bound = lower_bound.max(horizon + 1);
+            strongest_witness = Some(witness);
+        }
+    }
+    (lower_bound, strongest_witness)
+}
+
+/// Strongest sound lower bound obtained from the resource-strengthened
+/// earliest/latest windows. Keep this separate from the precedence-only bound
+/// while the stronger relaxation is exercised against the exact oracle.
+fn resource_window_capacity_lower_bound(
+    log: &[PairRecord],
+    capacity: usize,
+    legal_upper_bound: usize,
+) -> (usize, Option<WindowCapacityWitness>) {
+    let critical_path = validate_pair_dag(log);
+    let work_bound = log.len().div_ceil(capacity);
+    let basic_bound = critical_path.max(work_bound);
+    let mut lower_bound = basic_bound;
+    let mut strongest_witness = None;
+    for horizon in basic_bound..legal_upper_bound {
+        if let Some(witness) = resource_window_capacity_witness(log, capacity, horizon) {
+            lower_bound = lower_bound.max(horizon + 1);
+            strongest_witness = Some(witness);
+        }
+    }
+    (lower_bound, strongest_witness)
+}
+
+/// A legal capacity-aware schedule that keeps each already-executed protocol
+/// chunk atomic. This is an intermediate oracle between the observed source
+/// order and the lane-level DAG schedule: any improvement it finds needs only
+/// chunk reordering/repacking, while the remaining gap requires splitting
+/// existing chunks into lane slices.
+fn call_dag_list_schedule(log: &[PairRecord], capacity: usize) -> Vec<Vec<usize>> {
+    assert!(capacity > 0);
+    let Some(last_call) = log.iter().map(|record| record.call_id as usize).max() else {
+        return Vec::new();
+    };
+    let call_count = last_call + 1;
+    let mut work = vec![0usize; call_count];
+    let mut successors = vec![std::collections::HashSet::new(); call_count];
+    let mut indegree = vec![0usize; call_count];
+    for record in log {
+        let call = record.call_id as usize;
+        work[call] += 1;
+        for &parent in &record.parents {
+            let parent_call = log[parent as usize].call_id as usize;
+            if parent_call != call && successors[parent_call].insert(call) {
+                indegree[call] += 1;
+            }
+        }
+    }
+    assert!(
+        work.iter().all(|&items| items > 0 && items <= capacity),
+        "recorded protocol chunks must be non-empty and capacity-bounded"
+    );
+
+    let mut bottom_level = vec![1usize; call_count];
+    for call in (0..call_count).rev() {
+        bottom_level[call] = 1 + successors[call]
+            .iter()
+            .map(|&successor| bottom_level[successor])
+            .max()
+            .unwrap_or(0);
+    }
+
+    use std::cmp::Reverse;
+    use std::collections::BinaryHeap;
+    let mut ready = BinaryHeap::new();
+    for call in 0..call_count {
+        if indegree[call] == 0 {
+            ready.push((bottom_level[call], Reverse(call)));
+        }
+    }
+    let mut rounds = Vec::new();
+    let mut scheduled = 0usize;
+    while scheduled < call_count {
+        assert!(!ready.is_empty(), "call dependency graph must be acyclic");
+        let (_, Reverse(first)) = ready.pop().expect("ready call");
+        let mut round = vec![first];
+        let mut remaining = capacity - work[first];
+        let mut deferred = Vec::new();
+        while let Some(entry @ (_, Reverse(call))) = ready.pop() {
+            if work[call] <= remaining {
+                round.push(call);
+                remaining -= work[call];
+            } else {
+                deferred.push(entry);
+            }
+        }
+        ready.extend(deferred);
+
+        scheduled += round.len();
+        for &call in &round {
+            for &successor in &successors[call] {
+                indegree[successor] -= 1;
+                if indegree[successor] == 0 {
+                    ready.push((bottom_level[successor], Reverse(successor)));
+                }
+            }
+        }
+        rounds.push(round);
+    }
+    rounds
+}
+
+/// Number of contiguous source-call slices needed to encode `schedule` without
+/// scalarizing every multiply lane. A segment continues only while pair ids are
+/// adjacent and came from the same original protocol call.
+fn scheduled_source_segments(log: &[PairRecord], schedule: &[Vec<usize>]) -> (usize, usize) {
+    let mut total = 0usize;
+    let mut max_per_round = 0usize;
+    for round in schedule {
+        let mut ordered = round.clone();
+        ordered.sort_unstable();
+        let mut segments = 0usize;
+        let mut previous = None;
+        for node in ordered {
+            let starts_segment = previous.is_none_or(|prior: usize| {
+                node != prior + 1 || log[node].call_id != log[prior].call_id
+            });
+            if starts_segment {
+                segments += 1;
+            }
+            previous = Some(node);
+        }
+        total += segments;
+        max_per_round = max_per_round.max(segments);
+    }
+    (total, max_per_round)
+}
+
+/// A legality-preserving schedule that prefers whole contiguous ready runs from
+/// the original protocol calls. This measures the round/encoding tradeoff of a
+/// compact slice-based lowering; it is diagnostic and does not define the
+/// optimizer's correctness bound.
+fn dag_source_clustered_schedule(log: &[PairRecord], capacity: usize) -> Vec<Vec<usize>> {
+    assert!(capacity > 0);
+    let mut successors = vec![Vec::new(); log.len()];
+    let mut indegree = vec![0usize; log.len()];
+    for record in log {
+        let node = record.pair_id as usize;
+        for &parent in &record.parents {
+            successors[parent as usize].push(node);
+            indegree[node] += 1;
+        }
+    }
+    let mut bottom_level = vec![1usize; log.len()];
+    for node in (0..log.len()).rev() {
+        bottom_level[node] = 1 + successors[node]
+            .iter()
+            .map(|&successor| bottom_level[successor])
+            .max()
+            .unwrap_or(0);
+    }
+
+    let mut ready: std::collections::BTreeSet<usize> =
+        (0..log.len()).filter(|&node| indegree[node] == 0).collect();
+    let mut schedule = Vec::new();
+    let mut scheduled = 0usize;
+    while scheduled < log.len() {
+        assert!(!ready.is_empty(), "multiplication graph must be acyclic");
+        let mut round = Vec::with_capacity(capacity.min(ready.len()));
+        while round.len() < capacity && !ready.is_empty() {
+            let seed = *ready
+                .iter()
+                .max_by_key(|&&node| (bottom_level[node], std::cmp::Reverse(node)))
+                .expect("ready is non-empty");
+            ready.remove(&seed);
+            round.push(seed);
+
+            // Consume the rest of the seed's contiguous ready source run. The
+            // round boundary remains sound because successors are released only
+            // after the complete round below.
+            let call = log[seed].call_id;
+            let mut left = seed;
+            while round.len() < capacity && left > 0 {
+                let next = left - 1;
+                if log[next].call_id != call || !ready.remove(&next) {
+                    break;
+                }
+                round.push(next);
+                left = next;
+            }
+            let mut right = seed + 1;
+            while round.len() < capacity
+                && right < log.len()
+                && log[right].call_id == call
+                && ready.remove(&right)
+            {
+                round.push(right);
+                right += 1;
+            }
+        }
+        scheduled += round.len();
+        for &node in &round {
+            for &successor in &successors[node] {
+                indegree[successor] -= 1;
+                if indegree[successor] == 0 {
+                    ready.insert(successor);
+                }
+            }
+        }
+        schedule.push(round);
+    }
+    schedule
 }
 
 /// Exact minimum number of capacity-limited rounds for a small unit-time DAG.
@@ -399,6 +1340,10 @@ impl MpcEngine for CountingEngine {
 
     fn is_ready(&self) -> bool {
         true
+    }
+
+    fn multiplication_batch_capacity(&self) -> Option<usize> {
+        Some(MODELED_MPC_BATCH_CAPACITY)
     }
 
     fn start(&self) -> MpcEngineResult<()> {
@@ -676,6 +1621,94 @@ fn exact_capacity_scheduler_oracle_handles_precedence_and_choices() {
     assert_eq!(exact_min_rounds(&[0, 0, 0, 1 << 0, 1 << 3], 2), 3);
 }
 
+#[test]
+fn precedence_window_certificate_is_sound_for_all_five_node_dags() {
+    const NODES: usize = 5;
+    let possible_edges = NODES * (NODES - 1) / 2;
+    let mut strengthened_examples = 0usize;
+
+    for edge_set in 0u64..(1u64 << possible_edges) {
+        let mut parents = vec![0u64; NODES];
+        let mut edge_index = 0usize;
+        for node in 0..NODES {
+            for parent in 0..node {
+                if edge_set & (1u64 << edge_index) != 0 {
+                    parents[node] |= 1u64 << parent;
+                }
+                edge_index += 1;
+            }
+        }
+
+        let mut depths = vec![1u32; NODES];
+        let log: Vec<_> = parents
+            .iter()
+            .enumerate()
+            .map(|(node, &dependencies)| {
+                let parent_ids: Vec<_> = (0..node)
+                    .filter(|&parent| dependencies & (1u64 << parent) != 0)
+                    .map(|parent| parent as u32)
+                    .collect();
+                depths[node] = 1 + parent_ids
+                    .iter()
+                    .map(|&parent| depths[parent as usize])
+                    .max()
+                    .unwrap_or(0);
+                PairRecord {
+                    pair_id: node as u32,
+                    parents: parent_ids,
+                    // Sequential execution is a legal upper-bound schedule for
+                    // every topologically numbered graph.
+                    call_id: node as u32,
+                    depth: depths[node],
+                    pub_operand: false,
+                    both_public: false,
+                }
+            })
+            .collect();
+
+        for capacity in 1..=NODES {
+            let optimum = exact_min_rounds(&parents, capacity);
+            assert!(
+                window_capacity_witness(&log, capacity, optimum).is_none(),
+                "a necessary time-window condition rejected a legal optimum: \
+                 edge_set={edge_set:#x}, capacity={capacity}, optimum={optimum}"
+            );
+            assert!(
+                resource_window_capacity_witness(&log, capacity, optimum).is_none(),
+                "a resource-strengthened time-window condition rejected a legal optimum: \
+                 edge_set={edge_set:#x}, capacity={capacity}, optimum={optimum}"
+            );
+            let basic = validate_pair_dag(&log).max(NODES.div_ceil(capacity));
+            let (window_bound, _) = window_capacity_lower_bound(&log, capacity, optimum);
+            let (resource_window_bound, _) =
+                resource_window_capacity_lower_bound(&log, capacity, optimum);
+            let chain_bound = critical_chain_partition_lower_bound(&log, capacity).lower_bound;
+            assert!(
+                window_bound <= optimum,
+                "time-window lower bound exceeded the exact optimum"
+            );
+            assert!(
+                resource_window_bound <= optimum,
+                "resource-strengthened time-window lower bound exceeded the exact optimum"
+            );
+            assert!(
+                chain_bound <= optimum,
+                "chain-partition lower bound exceeded the exact optimum: \
+                 edge_set={edge_set:#x}, capacity={capacity}, optimum={optimum}, \
+                 chain_bound={chain_bound}"
+            );
+            strengthened_examples +=
+                usize::from(window_bound.max(resource_window_bound).max(chain_bound) > basic);
+        }
+    }
+
+    assert!(
+        strengthened_examples > 0,
+        "the window certificate should strictly strengthen work/critical-path \
+         bounds for at least one small DAG"
+    );
+}
+
 /// Regression test for the -O3 function inliner: a `secret`-typed helper that is
 /// inlined must keep its arguments secret, so the secret `and`/multiply still runs
 /// as an MPC multiplication (counted in `batch`/`scalar`) rather than collapsing
@@ -797,7 +1830,7 @@ async fn count_optimized_aes_batch_mul_items_impl() {
         scalar, 0,
         "optimizer should batch every secret multiply; {scalar} ran as scalar"
     );
-    assert_eq!(batch_items, 34_080);
+    assert_eq!(batch_items, 32_679);
     // This test compiles at the default optimization level (no -O3), so the
     // per-byte S-box loops are not unrolled and the round-minimizing scheduler
     // does not run. At this level the optimizer batches independent multiplies
@@ -888,6 +1921,7 @@ async fn optimized_aes_at_o3_matches_nist_vector_impl() {
     };
     let compiled = stoffellang::compile(source, "<aes-o3>", &options).expect("compile AES at -O3");
     let binary = stoffellang::convert_to_binary(&compiled);
+    let planned_triples = binary.client_io_manifest.preprocessing_demand.triples;
     let functions = binary.try_to_vm_functions().expect("vm functions");
 
     let engine = Arc::new(CountingEngine::default());
@@ -933,12 +1967,16 @@ async fn optimized_aes_at_o3_matches_nist_vector_impl() {
     let (scalar, batch_calls, batch_items) = engine.counts();
     assert_eq!(scalar, 0, "every secret multiply must be batched at -O3");
     // One proof-driven peel establishes the state shape, then the recurrence-
-    // aware unroller keeps the residual rounds rolled. That exposes additional
-    // provably-local gates without replicating the full round body: 33,280
-    // products remain interactive and are coalesced into 219 calls.
+    // aware unroller keeps the residual rounds rolled. Shape specialization
+    // exposes gates with public operands as local work without replicating the
+    // full round body: 29,275 products remain interactive.
     assert_eq!(
-        batch_items, 33_280,
+        batch_items, 29_275,
         "interactive product count must match the optimized circuit"
+    );
+    assert_eq!(
+        planned_triples, batch_items as u64,
+        "the preprocessing manifest must exactly cover executed interactive products"
     );
     assert!(
         batch_calls <= 225,
@@ -1048,7 +2086,7 @@ fn optimized_aes_full_unroll_minimizes_rounds() {
         );
         let (scalar, batch_calls, batch_items) = engine.counts();
         assert_eq!(scalar, 0);
-        assert_eq!(batch_items, 33_952);
+        assert_eq!(batch_items, 29_275);
         assert!(
             batch_calls < 1_000,
             "fully-flattened AES should reach a few hundred multiply rounds; got {batch_calls}"
@@ -1685,11 +2723,39 @@ async fn histogram_run(
     source: &str,
     level: u8,
     client_inputs: &[(usize, Vec<stoffel_vm::ClientShare>)],
-) -> Result<(usize, usize, usize, usize, Vec<i64>, Vec<PairRecord>), String> {
+) -> Result<
+    (
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+        Vec<i64>,
+        Vec<PairRecord>,
+        Vec<(String, usize)>,
+    ),
+    String,
+> {
+    let inline_budget = std::env::var("STOFFEL_HIST_INLINE_BUDGET")
+        .ok()
+        .and_then(|value| value.parse().ok());
+    let unroll_budget = std::env::var("STOFFEL_HIST_UNROLL_BUDGET")
+        .ok()
+        .and_then(|value| value.parse().ok());
+    let unroll_max_expansion = std::env::var("STOFFEL_HIST_UNROLL_MAX_EXPANSION")
+        .ok()
+        .and_then(|value| value.parse().ok());
     let options = stoffellang::CompilerOptions {
         optimize: level > 0,
         optimization_level: level,
         mpc_backend: stoffel_vm_types::compiled_binary::MpcBackend::HoneyBadger,
+        inline_budget,
+        unroll_budget,
+        unroll_max_expansion,
         ..Default::default()
     };
     let compiled = stoffellang::compile(source, "<histogram>", &options)
@@ -1698,11 +2764,64 @@ async fn histogram_run(
     let functions = binary
         .try_to_vm_functions()
         .map_err(|e| format!("vm functions at -O{level}: {e:?}"))?;
+    let static_batch_call_sites = functions
+        .iter()
+        .flat_map(|function| function.instructions())
+        .filter(|instruction| {
+            matches!(instruction, Instruction::CALL(name) if name == "Share.batch_mul")
+        })
+        .count();
+    let static_instructions = functions
+        .iter()
+        .map(|function| function.instructions().len())
+        .sum();
+    let main_static_batch_call_sites = functions
+        .iter()
+        .find(|function| function.name() == "main")
+        .map(|function| {
+            function
+                .instructions()
+                .iter()
+                .filter(|instruction| {
+                    matches!(instruction, Instruction::CALL(name) if name == "Share.batch_mul")
+                })
+                .count()
+        })
+        .unwrap_or(0);
+    let main_static_instructions = functions
+        .iter()
+        .find(|function| function.name() == "main")
+        .map(|function| function.instructions().len())
+        .unwrap_or(0);
 
     let engine = Arc::new(CountingEngine::default());
+    let executed_call_sites = Arc::new(std::sync::Mutex::new(Vec::new()));
     let mut vm = VirtualMachine::builder()
         .with_mpc_engine(engine.clone())
         .build();
+    if std::env::var("STOFFEL_HIST_CALLSITES").is_ok_and(|value| value != "0") {
+        let call_sites = executed_call_sites.clone();
+        vm.register_hook(
+            |event| {
+                matches!(
+                    event,
+                    HookEvent::BeforeInstructionExecute(Instruction::CALL(name))
+                        if name == "Share.batch_mul"
+                )
+            },
+            move |_, context| {
+                call_sites.lock().expect("call-site trace lock").push((
+                    context
+                        .current_instruction_function_name()
+                        .unwrap_or("<unknown>")
+                        .to_owned(),
+                    context.current_instruction_index(),
+                ));
+                Ok(())
+            },
+            0,
+        );
+    }
     for function in functions {
         vm.try_register_function(function)
             .map_err(|e| format!("register function at -O{level}: {e:?}"))?;
@@ -1735,24 +2854,45 @@ async fn histogram_run(
         out.push(byte);
     }
     let (scalar_opens, batch_opens) = engine.open_protocol_breakdown();
+    let (scalar_muls, batch_calls, _batch_items) = engine.counts();
+    debug_assert_eq!(
+        scalar_muls, 0,
+        "O3 histogram should contain no scalar multiplies"
+    );
+    let executed_call_sites = executed_call_sites
+        .lock()
+        .expect("call-site trace lock")
+        .clone();
     Ok((
         engine.protocol_rounds(),
+        batch_calls,
+        static_batch_call_sites,
+        static_instructions,
+        main_static_batch_call_sites,
+        main_static_instructions,
         engine.open_protocol_rounds(),
         scalar_opens,
         batch_opens,
         out,
         engine.pair_log_snapshot(),
+        executed_call_sites,
     ))
 }
 
 fn print_depth_histogram(
     label: &str,
     rounds: usize,
+    source_batch_calls: usize,
+    static_batch_call_sites: usize,
+    static_instructions: usize,
+    main_static_batch_call_sites: usize,
+    main_static_instructions: usize,
     open_rounds: usize,
     scalar_opens: usize,
     batch_opens: usize,
     correct: bool,
     log: &[PairRecord],
+    executed_call_sites: &[(String, usize)],
 ) {
     use std::collections::BTreeMap;
     let dag_critical_path = validate_pair_dag(log);
@@ -1816,7 +2956,28 @@ fn print_depth_histogram(
     );
     let work_bound = log.len().div_ceil(MODELED_MPC_BATCH_CAPACITY);
     let sound_lower_bound = critical_path.max(work_bound);
-    let dag_list_upper = dag_list_schedule_rounds(log, MODELED_MPC_BATCH_CAPACITY);
+    let dag_schedule = dag_list_schedule(log, MODELED_MPC_BATCH_CAPACITY);
+    let dag_list_upper = dag_schedule.len();
+    let (window_lower_bound, window_witness) =
+        window_capacity_lower_bound(log, MODELED_MPC_BATCH_CAPACITY, dag_list_upper.min(rounds));
+    let (resource_window_lower_bound, resource_window_witness) =
+        resource_window_capacity_lower_bound(
+            log,
+            MODELED_MPC_BATCH_CAPACITY,
+            dag_list_upper.min(rounds),
+        );
+    let pivot_witness = critical_chain_pivot_lower_bound(log, MODELED_MPC_BATCH_CAPACITY);
+    let certified_lower_bound = sound_lower_bound
+        .max(window_lower_bound)
+        .max(resource_window_lower_bound)
+        .max(pivot_witness.lower_bound);
+    let call_schedule = call_dag_list_schedule(log, MODELED_MPC_BATCH_CAPACITY);
+    let call_list_upper = call_schedule.len();
+    let utilized = log.len() as f64 / (rounds.max(1) * MODELED_MPC_BATCH_CAPACITY) as f64 * 100.0;
+    let (source_segments, max_segments_per_round) = scheduled_source_segments(log, &dag_schedule);
+    let clustered_schedule = dag_source_clustered_schedule(log, MODELED_MPC_BATCH_CAPACITY);
+    let (clustered_segments, clustered_max_segments) =
+        scheduled_source_segments(log, &clustered_schedule);
     assert!(
         rounds >= sound_lower_bound,
         "observed schedule cannot beat its critical-path/work lower bound"
@@ -1825,19 +2986,268 @@ fn print_depth_histogram(
         dag_list_upper >= sound_lower_bound,
         "a legal DAG schedule cannot beat the sound lower bound"
     );
+    assert!(
+        rounds >= certified_lower_bound && dag_list_upper >= certified_lower_bound,
+        "legal schedules cannot beat a certified precedence/capacity lower bound"
+    );
+    assert!(
+        calls
+            .values()
+            .all(|(_, _, work)| *work <= MODELED_MPC_BATCH_CAPACITY),
+        "the observed schedule must respect backend multiply capacity"
+    );
     println!(
         "HIST {label} TOTALS actual_rounds={rounds} sound_lb={sound_lower_bound} \
-certified_gap={} dag_list_upper={dag_list_upper} dag_sched_gap={} \
+window_lb={window_lower_bound} pivot_lb={} certified_lb={certified_lower_bound} certified_gap={} \
+resource_window_lb={resource_window_lower_bound} \
+basic_gap={} dag_list_upper={dag_list_upper} dag_sched_gap={} \
 critical_path={critical_path} work_bound={work_bound} \
 distinct_depths={} singleton_rounds={singleton_rounds} mixed_depth_rounds={mixed_rounds} \
 open_rounds={open_rounds} scalar_opens={scalar_opens} batch_opens={batch_opens} \
 observed_online_sessions={}",
+        pivot_witness.lower_bound,
+        rounds.saturating_sub(certified_lower_bound),
         rounds - sound_lower_bound,
         rounds.saturating_sub(dag_list_upper),
         depths.len(),
         rounds + open_rounds,
     );
+    println!(
+        "HIST {label} PIVOT node={} ancestors={} descendants={} lower_bound={}",
+        pivot_witness.pivot,
+        pivot_witness.ancestors,
+        pivot_witness.descendants,
+        pivot_witness.lower_bound,
+    );
+    if let Some(witness) = window_witness {
+        println!(
+            "HIST {label} WINDOW horizon={} interval={}-{} forced_work={} \
+interval_capacity={} overload={}",
+            witness.horizon,
+            witness.first_round,
+            witness.last_round,
+            witness.forced_work,
+            witness.interval_capacity,
+            witness.forced_work - witness.interval_capacity,
+        );
+    }
+    if let Some(witness) = resource_window_witness {
+        println!(
+            "HIST {label} RESOURCE_WINDOW horizon={} interval={}-{} forced_work={} \
+interval_capacity={} overload={}",
+            witness.horizon,
+            witness.first_round,
+            witness.last_round,
+            witness.forced_work,
+            witness.interval_capacity,
+            witness.forced_work - witness.interval_capacity,
+        );
+    }
+    println!(
+        "HIST {label} ENCODING source_segments={source_segments} \
+max_segments_per_round={max_segments_per_round} avg_segments_per_round={:.2} \
+clustered_rounds={} clustered_segments={clustered_segments} \
+clustered_max_segments={clustered_max_segments}",
+        source_segments as f64 / dag_list_upper.max(1) as f64,
+        clustered_schedule.len(),
+    );
+    println!(
+        "HIST {label} CHUNKS actual={rounds} source_batch_calls={source_batch_calls} \
+static_batch_call_sites={static_batch_call_sites} \
+static_instructions={static_instructions} \
+main_batch_call_sites={main_static_batch_call_sites} main_instructions={main_static_instructions} \
+call_dag_upper={call_list_upper} \
+call_repack_gain={} lane_split_gain={} utilization={utilized:.1}%",
+        rounds.saturating_sub(call_list_upper),
+        call_list_upper.saturating_sub(dag_list_upper),
+    );
+    if !executed_call_sites.is_empty() {
+        assert_eq!(
+            executed_call_sites.len(),
+            calls.len(),
+            "one traced source site per executed protocol call"
+        );
+        for (call_id, (function, instruction)) in executed_call_sites.iter().enumerate() {
+            let (min_depth, max_depth, work) = calls[&(call_id as u32)];
+            println!(
+                "HIST {label} CALL id={call_id} site={function}:{instruction} work={work} depth={min_depth}-{max_depth}"
+            );
+        }
+        for (round, packed) in call_schedule.iter().enumerate() {
+            if packed.len() > 1 {
+                println!("HIST {label} CALLPACK round={round} calls={packed:?}");
+            }
+        }
+    }
     println!();
+}
+
+/// Persist the measured multiplication DAG in a compact, versioned binary
+/// format when `STOFFEL_AES_COUNT_DAG_OUT` is set. This keeps expensive
+/// compiler/VM execution separate from exact-scheduler experiments. The path
+/// may contain `{label}`, which is replaced with the lower-case program label.
+fn maybe_write_pair_dag(label: &str, log: &[PairRecord]) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let Ok(path) = std::env::var("STOFFEL_AES_COUNT_DAG_OUT") else {
+        return Ok(());
+    };
+    let path = path.replace("{label}", &label.to_ascii_lowercase());
+    let mut writer = std::io::BufWriter::new(std::fs::File::create(path)?);
+    writer.write_all(b"STFDAG01")?;
+    writer.write_all(&(MODELED_MPC_BATCH_CAPACITY as u32).to_le_bytes())?;
+    writer.write_all(&(log.len() as u32).to_le_bytes())?;
+    for record in log {
+        writer.write_all(&record.pair_id.to_le_bytes())?;
+        writer.write_all(&record.call_id.to_le_bytes())?;
+        writer.write_all(&record.depth.to_le_bytes())?;
+        writer.write_all(&(record.parents.len() as u32).to_le_bytes())?;
+        for &parent in &record.parents {
+            writer.write_all(&parent.to_le_bytes())?;
+        }
+    }
+    writer.flush()
+}
+
+fn read_pair_dag(path: &std::path::Path) -> std::io::Result<(usize, Vec<PairRecord>)> {
+    use std::io::Read;
+
+    let mut reader = std::io::BufReader::new(std::fs::File::open(path)?);
+    let mut magic = [0u8; 8];
+    reader.read_exact(&mut magic)?;
+    if &magic != b"STFDAG01" {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "unrecognized Stoffel pair-DAG format",
+        ));
+    }
+    let read_u32 = |reader: &mut std::io::BufReader<std::fs::File>| {
+        let mut bytes = [0u8; 4];
+        reader.read_exact(&mut bytes)?;
+        Ok::<_, std::io::Error>(u32::from_le_bytes(bytes))
+    };
+    let capacity = read_u32(&mut reader)? as usize;
+    let count = read_u32(&mut reader)? as usize;
+    let mut log = Vec::with_capacity(count);
+    for expected_id in 0..count {
+        let pair_id = read_u32(&mut reader)?;
+        let call_id = read_u32(&mut reader)?;
+        let depth = read_u32(&mut reader)?;
+        let parent_count = read_u32(&mut reader)? as usize;
+        if pair_id as usize != expected_id {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "pair-DAG ids are not dense and ordered",
+            ));
+        }
+        let mut parents = Vec::with_capacity(parent_count);
+        for _ in 0..parent_count {
+            parents.push(read_u32(&mut reader)?);
+        }
+        log.push(PairRecord {
+            pair_id,
+            parents,
+            call_id,
+            depth,
+            pub_operand: false,
+            both_public: false,
+        });
+    }
+    Ok((capacity, log))
+}
+
+#[ignore = "cached multiplication-DAG scheduler analysis; set STOFFEL_PAIR_DAG_IN"]
+#[test]
+fn cached_pair_dag_scheduler_analysis() {
+    let Some(path) = std::env::var_os("STOFFEL_PAIR_DAG_IN") else {
+        eprintln!(
+            "skipping cached pair-DAG analysis: set STOFFEL_PAIR_DAG_IN to a cache written by round_histogram"
+        );
+        return;
+    };
+    let (capacity, log) = read_pair_dag(std::path::Path::new(&path)).expect("read pair DAG");
+    let critical_path = validate_pair_dag(&log);
+    let component_sizes = weak_component_sizes(&log);
+    let work_bound = log.len().div_ceil(capacity);
+    let forward = dag_list_schedule(&log, capacity);
+    let backward = dag_backward_list_schedule(&log, capacity);
+    let backward_deadline = dag_backward_deadline_schedule(&log, capacity);
+    let critical_fan_in_backward = dag_backward_priority_list_schedule(
+        &log,
+        capacity,
+        BackwardPriority::CriticalPredecessorFanIn,
+    );
+    let critical_fan_in_forward =
+        dag_forward_from_backward_schedule(&log, capacity, &critical_fan_in_backward);
+    let chain_partition = critical_chain_partition_lower_bound(&log, capacity);
+    let pivot = critical_chain_pivot_lower_bound(&log, capacity);
+    let legal_upper_bound = critical_fan_in_forward.len();
+    let (window_lower_bound, window_witness) =
+        window_capacity_lower_bound(&log, capacity, legal_upper_bound);
+    let (resource_window_lower_bound, resource_window_witness) =
+        resource_window_capacity_lower_bound(&log, capacity, legal_upper_bound);
+    let priorities = vec![
+        DagListPriority::BottomSourceAscending,
+        DagListPriority::BottomHighFanout,
+        DagListPriority::BottomSuccessorPressure,
+    ];
+    let priority_schedules: Vec<_> = priorities
+        .into_iter()
+        .map(|priority| {
+            let (schedule, ready_counts) = dag_priority_list_schedule(&log, capacity, priority);
+            (format!("{priority:?}"), schedule, ready_counts)
+        })
+        .collect();
+    let priority_rounds: Vec<_> = priority_schedules
+        .iter()
+        .map(|(priority, schedule, _)| (priority, schedule.len()))
+        .collect();
+    let underfilled: Vec<_> = forward
+        .iter()
+        .enumerate()
+        .filter(|(_, round)| round.len() < capacity)
+        .map(|(round_index, round)| {
+            let calls: std::collections::BTreeSet<_> =
+                round.iter().map(|&node| log[node].call_id).collect();
+            (round_index, round.len(), calls)
+        })
+        .collect();
+    println!(
+        "CACHED_DAG nodes={} edges={} capacity={} critical_path={} work_bound={} \
+chain_partition_bound={} chain_partition_pivots={} \
+single_pivot_bound={} single_pivot_node={} \
+window_bound={} window_witness={:?} resource_window_bound={} resource_window_witness={:?} \
+forward_rounds={} backward_rounds={} backward_deadline_rounds={} \
+critical_fan_in_backward_rounds={} critical_fan_in_forward_rounds={} priorities={priority_rounds:?}",
+        log.len(),
+        log.iter().map(|record| record.parents.len()).sum::<usize>(),
+        capacity,
+        critical_path,
+        work_bound,
+        chain_partition.lower_bound,
+        chain_partition.pivots.len(),
+        pivot.lower_bound,
+        pivot.pivot,
+        window_lower_bound,
+        window_witness,
+        resource_window_lower_bound,
+        resource_window_witness,
+        forward.len(),
+        backward.len(),
+        backward_deadline.len(),
+        critical_fan_in_backward.len(),
+        critical_fan_in_forward.len(),
+    );
+    println!("CACHED_DAG component_sizes={component_sizes:?}");
+    println!("CACHED_DAG underfilled={underfilled:?}");
+    let (_, source_ascending, ready_counts) = &priority_schedules[0];
+    let constrained: Vec<_> = source_ascending
+        .iter()
+        .enumerate()
+        .filter(|(round, jobs)| jobs.len() < capacity || ready_counts[*round] > capacity)
+        .map(|(round, jobs)| (round, jobs.len(), ready_counts[round]))
+        .collect();
+    println!("CACHED_DAG frontier={constrained:?}");
 }
 
 #[ignore = "per-depth round histogram measurement; run manually with --ignored --nocapture"]
@@ -1872,18 +3282,47 @@ async fn round_histogram_impl() {
         ),
     ];
 
+    let label_filter = std::env::var("STOFFEL_AES_COUNT_FILTER").ok();
+
     for (label, source, inputs, expected) in &programs {
+        if label_filter
+            .as_deref()
+            .is_some_and(|filter| !label.eq_ignore_ascii_case(filter))
+        {
+            continue;
+        }
         match histogram_run(source, 3, inputs).await {
-            Ok((rounds, open_rounds, scalar_opens, batch_opens, output, log)) => {
+            Ok((
+                rounds,
+                source_batch_calls,
+                static_batch_call_sites,
+                static_instructions,
+                main_static_batch_call_sites,
+                main_static_instructions,
+                open_rounds,
+                scalar_opens,
+                batch_opens,
+                output,
+                log,
+                executed_call_sites,
+            )) => {
                 let correct = output == *expected;
+                maybe_write_pair_dag(label, &log)
+                    .unwrap_or_else(|error| panic!("write {label} DAG: {error}"));
                 print_depth_histogram(
                     label,
                     rounds,
+                    source_batch_calls,
+                    static_batch_call_sites,
+                    static_instructions,
+                    main_static_batch_call_sites,
+                    main_static_instructions,
                     open_rounds,
                     scalar_opens,
                     batch_opens,
                     correct,
                     &log,
+                    &executed_call_sites,
                 );
                 assert!(correct, "{label} O3 must match its NIST output");
             }

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -271,7 +271,7 @@ run_command() {
         perf)
             exec perf record \
                 -F "${STOFFEL_PERF_FREQUENCY:-99}" \
-                -g \
+                --call-graph dwarf,16384 \
                 -o "${out_dir}/${label}.perf.data" \
                 -- $cmd
             ;;


### PR DESCRIPTION
## What changed

- make compiler preprocessing demand reflect optimized MPC operations, including generic control-flow and aggregate analysis
- batch deferred multiply and reveal effects, including singular operations when coalescing is profitable
- improve optimizer behavior for AES circuit, CTR, and CBC workloads without loop-fusion cutoffs
- propagate preprocessing metadata through the compiler, SDK, runner, and VM
- integrate AVSS preprocessing with compiler-derived material counts and correct loopback message routing
- add scheduler, preprocessing-planner, threshold-signature, AES, runner, and VM coverage

This branch was cut from `feature/node-persistence`, so the PR also includes that prerequisite commit relative to `dev`.

## Why

MPC effects could reach the runtime as unnecessarily fragmented operations, increasing online rounds, while preprocessing demand could diverge from the optimized program. AVSS execution also needed compiler-driven material planning and correct self-delivery so preprocessing remained live across every party.

The result is a generic scheduling and planning path that batches compatible MPC work, preserves dependency ordering, and prepares the material required by the program before online execution.

## Validation

- `cargo check -p stoffel-vm-runner --bin stoffel-run --locked`
- targeted compiler, scheduler, VM, HoneyBadger, AVSS, AES, and threshold-signature tests during development
- 11 consecutive release AVSS ECDSA secp256k1 local executions completed successfully, including fixed-point party layouts
- `git diff --check origin/dev...HEAD`
